### PR TITLE
lib.lapack bug fix

### DIFF
--- a/sfepy/solvers/eigen.py
+++ b/sfepy/solvers/eigen.py
@@ -121,7 +121,11 @@ class ScipySGEigenvalueSolver(EigenvalueSolver):
     def __init__(self, conf, **kwargs):
         EigenvalueSolver.__init__(self, conf, **kwargs)
 
-        import scipy.lib.lapack as llapack
+        try:
+            import scipy.linalg.lapack as llapack
+        except ImportError:
+            import scipy.lib.lapack as llapack
+
         self.llapack = llapack
 
     @standard_call


### PR DESCRIPTION
As per http://docs.scipy.org/doc/scipy/reference/release.0.12.0.html#scipy-lib-lapack lib.lapack is depreciated and so I updated to the new linalg.