### PR TITLE
Debug on error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
   - python run_tests.py; export SFEPY_TEST_RESULTS=$?; (exit $SFEPY_TEST_RESULTS)
   - |
     if [ $SFEPY_TEST_RESULTS -ne 0 ]; then
-      python run_tests.py --debug
+      python run_tests.py --raise
     fi
 
 notifications:

--- a/INSTALL
+++ b/INSTALL
@@ -93,8 +93,8 @@ installed. Also be sure to have a recent version of Numpy and SciPy installed
 (latest releases or Git versions are the best bet). Verify also your pytables
 (hdf5) installation (possible test_io.py failures).
 
-To debug a failure, run './run_tests.py --debug'.
-See also './run_tests.py --help' for further options.
+See also './run_tests.py --help' for further options, especially --raise and
+--debug are helpful.
 
 Documentation:
 --------------

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -147,11 +147,15 @@ In the source directory type::
 
     python run_tests.py
 
-If a particular test fails, please run it in debug mode::
+If a particular test fails, please run it in the raise mode::
+
+    python run_tests.py --raise tests/failing_test_name.py
+
+and report the output to the `SfePy mailing list`_. It is also possible to
+automatically start a debugger when/if an exception is raised by running a
+test in the debug mode::
 
     python run_tests.py --debug tests/failing_test_name.py
-
-and report the output to the `SfePy mailing list`_.
 
 On a Linux-based system, the script can be executed directly by::
 

--- a/doc/users_guide.rst
+++ b/doc/users_guide.rst
@@ -113,26 +113,11 @@ Stand-Alone Examples
 Running Tests
 ^^^^^^^^^^^^^
 
-The tests are run by the ``run_tests.py`` script::
+The tests are run by the ``run_tests.py`` script. Run
 
     $ ./run_tests.py -h
-    Usage: run_tests.py [options] [test_filename[ test_filename ...]]
 
-    Options:
-      --version             show program's version number and exit
-      -h, --help            show this help message and exit
-      --print-doc           print the docstring of this file (howto write new
-                            tests)
-      -d directory, --dir=directory
-                            directory with tests [default: tests]
-      -o directory, --output=directory
-                            directory for storing test results and temporary files
-                            [default: output-tests]
-      --debug               raise silenced exceptions to see what was wrong
-      --filter-none         do not filter any messages
-      --filter-less         filter output (suppress all except test messages)
-      --filter-more         filter output (suppress all except test result
-                            messages)
+to get help.
 
 Common Tasks
 """"""""""""
@@ -149,9 +134,14 @@ Common Tasks
     # Test if linear elasticity input file works.
     ./run_tests.py tests/test_input_le.py
 
-* Debug a failing test::
+* Debug a failing test by automatically starting a debugger when/if an
+  exception is raised ::
 
     ./run_tests.py tests/test_input_le.py --debug
+
+* Raise silenced exceptions that could have occurred in a failing test::
+
+    ./run_tests.py tests/test_input_le.py --raise
 
 Computations and Examples
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/extractor.py
+++ b/extractor.py
@@ -51,6 +51,8 @@ def parse_linearization(linearization):
     return dict_to_struct(out)
 
 help = {
+    'debug':
+    'automatically start debugger when an exception is raised',
     'filename' :
     'basename of output file(s) [default: <basename of input file>]',
     'dump' :
@@ -82,6 +84,9 @@ def main():
                             formatter_class=RawDescriptionHelpFormatter)
     parser.add_argument('--version', action='version',
                         version='%(prog)s ' + sfepy.__version__)
+    parser.add_argument('--debug',
+                        action='store_true', dest='debug',
+                        default=False, help=help['debug'])
     parser.add_argument('-o', metavar='filename',
                         action='store', dest='output_filename_trunk',
                         default=None, help=help['filename'])
@@ -111,6 +116,9 @@ def main():
     parser.add_argument('input_file', nargs='?', default=None)
     parser.add_argument('results_file')
     options = parser.parse_args()
+
+    if options.debug:
+        from sfepy.base.base import debug_on_error; debug_on_error()
 
     filename_in = options.input_file
     filename_results = options.results_file

--- a/homogen.py
+++ b/homogen.py
@@ -7,6 +7,8 @@ from sfepy.base.conf import ProblemConf, get_standard_keywords
 from sfepy.homogenization.homogen_app import HomogenizationApp
 
 help = {
+    'debug':
+    'automatically start debugger when an exception is raised',
     'filename' :
     'basename of output file(s) [default: <basename of input file>]',
 }
@@ -15,11 +17,17 @@ def main():
     parser = ArgumentParser()
     parser.add_argument("--version", action="version",
                         version="%(prog)s " + sfepy.__version__)
+    parser.add_argument('--debug',
+                        action='store_true', dest='debug',
+                        default=False, help=help['debug'])
     parser.add_argument("-o", metavar='filename', action="store",
                         dest="output_filename_trunk",
                         default=None, help=help['filename'])
     parser.add_argument('filename_in')
     options = parser.parse_args()
+
+    if options.debug:
+        from sfepy.base.base import debug_on_error; debug_on_error()
 
     filename_in = options.filename_in
 

--- a/phonon.py
+++ b/phonon.py
@@ -10,6 +10,8 @@ from sfepy.homogenization.band_gaps_app import AcousticBandGapsApp
 from sfepy.base.plotutils import plt
 
 help = {
+    'debug':
+    'automatically start debugger when an exception is raised',
     'filename' :
     'basename of output file(s) [default: <basename of input file>]',
     'detect_band_gaps' :
@@ -26,6 +28,9 @@ def main():
     parser = ArgumentParser()
     parser.add_argument("--version", action="version",
                         version="%(prog)s " + sfepy.__version__)
+    parser.add_argument('--debug',
+                        action='store_true', dest='debug',
+                        default=False, help=help['debug'])
     parser.add_argument("-o", metavar='filename',
                         action="store", dest="output_filename_trunk",
                         default=None, help=help['filename'])
@@ -42,8 +47,11 @@ def main():
                         action="store_true", dest="phase_velocity",
                         default=False, help=help['phase_velocity'])
     parser.add_argument("filename_in")
-    
     options = parser.parse_args()
+
+    if options.debug:
+        from sfepy.base.base import debug_on_error; debug_on_error()
+
     if options.plot:
         if plt is None:
             output('matplotlib.pyplot cannot be imported, ignoring option -p!')

--- a/postproc.py
+++ b/postproc.py
@@ -56,6 +56,8 @@ from sfepy.postprocess.domain_specific import DomainSpecificPlot
 import six
 
 help = {
+    'debug':
+    'automatically start debugger when an exception is raised',
     'filename' :
     'view image file name [default: "view.png"]',
     'output_dir' :
@@ -289,6 +291,9 @@ def main():
                             formatter_class=RawDescriptionHelpFormatter)
     parser.add_argument('--version', action='version',
                         version='%(prog)s ' + sfepy.__version__)
+    parser.add_argument('--debug',
+                        action='store_true', dest='debug',
+                        default=False, help=help['debug'])
 
     group = parser.add_argument_group('Output Options')
     group.add_argument('-o', '--output', metavar='filename',
@@ -413,6 +418,9 @@ def main():
 
     parser.add_argument('filenames', nargs='+')
     options = parser.parse_args()
+
+    if options.debug:
+        from sfepy.base.base import debug_on_error; debug_on_error()
 
     filenames = options.filenames
 

--- a/probe.py
+++ b/probe.py
@@ -52,6 +52,8 @@ from sfepy.discrete.probes import write_results, read_results
 import six
 
 help = {
+    'debug':
+    'automatically start debugger when an exception is raised',
     'filename' :
     'basename of output file(s) [default: <basename of input file>]',
     'output_format' :
@@ -226,6 +228,9 @@ def main():
                             formatter_class=RawDescriptionHelpFormatter)
     parser.add_argument('--version', action='version',
                         version='%(prog)s ' + sfepy.__version__)
+    parser.add_argument('--debug',
+                        action='store_true', dest='debug',
+                        default=False, help=help['debug'])
     parser.add_argument('-o', metavar='filename',
                         action='store', dest='output_filename_trunk',
                         default=None, help=help['filename'])
@@ -256,6 +261,9 @@ def main():
     parser.add_argument('filename_in')
     parser.add_argument('filename_out')
     options = parser.parse_args()
+
+    if options.debug:
+        from sfepy.base.base import debug_on_error; debug_on_error()
 
     filename_input = options.filename_in
     filename_results = options.filename_out

--- a/run_tests.py
+++ b/run_tests.py
@@ -62,11 +62,9 @@ class OutputFilter(object):
         self.stdout = None
 
 def run_test(conf_name, options):
-    try:
-        os.makedirs(options.out_dir)
-    except OSError as e:
-        if e.errno != 17: # [Errno 17] File exists
-            raise
+    from sfepy.base.ioutils import ensure_path
+
+    ensure_path(op.join(options.out_dir, 'any'))
 
     if options.filter_none or options.raise_on_error:
         of = None
@@ -155,6 +153,8 @@ help = {
     'out_dir' : 'directory for storing test results and temporary files'
     ' [default: %(default)s]',
     'raise_on_error' : 'raise silenced exceptions to see what was wrong',
+    'debug':
+    'automatically start debugger when an exception is raised',
     'filter-none' : 'do not filter any messages',
     'filter-less' : 'filter output (suppress all except test messages)',
     'filter-more' : 'filter output (suppress all except test result messages)',
@@ -181,6 +181,9 @@ def main():
     parser.add_argument("--raise",
                         action="store_true", dest="raise_on_error",
                         default=False, help=help['raise_on_error'])
+    parser.add_argument("--debug",
+                        action="store_true", dest="debug",
+                        default=False, help=help['debug'])
     parser.add_argument("--filter-none",
                         action="store_true", dest="filter_none",
                         default=False, help=help['filter-none'])
@@ -197,6 +200,10 @@ def main():
     if options.print_doc:
         print(__doc__)
         return
+
+    if options.debug:
+        options.raise_on_error = True
+        from sfepy.base.base import debug_on_error; debug_on_error()
 
     run_tests = wrap_run_tests(options)
     stats = [0, 0, 0, 0.0]

--- a/run_tests.py
+++ b/run_tests.py
@@ -68,7 +68,7 @@ def run_test(conf_name, options):
         if e.errno != 17: # [Errno 17] File exists
             raise
 
-    if options.filter_none or options.debug:
+    if options.filter_none or options.raise_on_error:
         of = None
     elif options.filter_less:
         of = OutputFilter(['<<<', '>>>', '...', '!!!', '+++', '---'])
@@ -95,21 +95,21 @@ def run_test(conf_name, options):
         sys.exit(0)
     except:
         print('--- test instance creation failed')
-        if options.debug:
+        if options.raise_on_error:
             raise
         ok, n_fail, n_total = False, num, num
 
     if ok:
         try:
             tt = time.clock()
-            ok, n_fail, n_total = test.run(options.debug)
+            ok, n_fail, n_total = test.run(options.raise_on_error)
             test_time = time.clock() - tt
         except KeyboardInterrupt:
             print('>>> interrupted')
             sys.exit(0)
         except Exception as e:
             print('>>> %s' % e.__class__)
-            if options.debug:
+            if options.raise_on_error:
                 raise
             ok, n_fail, n_total = False, num, num
 
@@ -154,7 +154,7 @@ help = {
     'dir' : 'directory with tests [default: %(default)s]',
     'out_dir' : 'directory for storing test results and temporary files'
     ' [default: %(default)s]',
-    'debug' : 'raise silenced exceptions to see what was wrong',
+    'raise_on_error' : 'raise silenced exceptions to see what was wrong',
     'filter-none' : 'do not filter any messages',
     'filter-less' : 'filter output (suppress all except test messages)',
     'filter-more' : 'filter output (suppress all except test result messages)',
@@ -178,9 +178,9 @@ def main():
                         action="store", dest="out_dir",
                         default=get_dir('output-tests'),
                         help=help['out_dir'])
-    parser.add_argument("--debug",
-                        action="store_true", dest="debug",
-                        default=False, help=help['debug'])
+    parser.add_argument("--raise",
+                        action="store_true", dest="raise_on_error",
+                        default=False, help=help['raise_on_error'])
     parser.add_argument("--filter-none",
                         action="store_true", dest="filter_none",
                         default=False, help=help['filter-none'])

--- a/schroedinger.py
+++ b/schroedinger.py
@@ -27,6 +27,8 @@ def fix_path(filename):
     return os.path.join(sfepy.data_dir, filename)
 
 help = {
+    'debug':
+    'automatically start debugger when an exception is raised',
     'conf' :
     'override problem description file items, written as python'
     ' dictionary without surrounding braces',
@@ -55,6 +57,9 @@ def main():
                             formatter_class=RawDescriptionHelpFormatter)
     parser.add_argument('--version', action='version',
                         version='%(prog)s ' + sfepy.__version__)
+    parser.add_argument('--debug',
+                        action='store_true', dest='debug',
+                        default=False, help=help['debug'])
     parser.add_argument('-c', '--conf', metavar='"key : value, ..."',
                         action='store', dest='conf', type=str,
                         default=None, help= help['conf'])
@@ -85,6 +90,9 @@ def main():
                         default=None, help=help['tau'])
     parser.add_argument('filename_in', nargs='?')
     options = parser.parse_args()
+
+    if options.debug:
+        from sfepy.base.base import debug_on_error; debug_on_error()
 
     filename_in = options.filename_in
 

--- a/sfepy/base/base.py
+++ b/sfepy/base/base.py
@@ -96,6 +96,33 @@ def get_debug():
 
 debug = get_debug()
 
+def debug_on_error():
+    """
+    Start debugger at the line where an exception was raised.
+    """
+    try:
+        from IPython.core import ultratb
+
+        except_hook = ultratb.FormattedTB(mode='Verbose',
+                                          color_scheme='Linux', call_pdb=1)
+
+    except ImportError:
+        def except_hook(etype, value, tb):
+            if hasattr(sys, 'ps1') or not sys.stderr.isatty():
+                # We are in interactive mode or we don't have a tty-like
+                # device, so we call the default hook.
+                sys.__excepthook__(etype, value, tb)
+
+            else:
+                import traceback, pdb
+                # We are NOT in interactive mode, print the exception...
+                traceback.print_exception(etype, value, tb)
+                print()
+                # ...then start the debugger in post-mortem mode.
+                pdb.post_mortem(tb)
+
+    sys.excepthook = except_hook
+
 def mark_time(times, msg=None):
     """
     Time measurement utility.

--- a/shaper.py
+++ b/shaper.py
@@ -284,6 +284,8 @@ def solve_optimize( conf, options ):
     print(des)
 
 help = {
+    'debug':
+    'automatically start debugger when an exception is raised',
     'server_mode' :
     "run in server mode [default: %(default)s], N/A",
     'adjoint' :
@@ -308,6 +310,9 @@ def main():
     parser = ArgumentParser()
     parser.add_argument("--version", action="version",
                         version = "%(prog)s " + sfepy.__version__)
+    parser.add_argument('--debug',
+                        action='store_true', dest='debug',
+                        default=False, help=help['debug'])
     parser.add_argument("-s", "--server",
                         action = "store_true", dest = "server_mode",
                         default = False, help = help['server_mode'])
@@ -330,8 +335,10 @@ def main():
                         action = "store_true", dest = "optimize",
                         default = False, help = help['optimize'])
     parser.add_argument('filename_in')
-    
     options = parser.parse_args()
+
+    if options.debug:
+        from sfepy.base.base import debug_on_error; debug_on_error()
 
     if options.test is not None:
         options.adjoint = options.direct = True

--- a/simple.py
+++ b/simple.py
@@ -32,6 +32,8 @@ def print_solvers():
     print(sorted(solver_table.keys()))
 
 help = {
+    'debug':
+    'automatically start debugger when an exception is raised',
     'conf' :
     'override problem description file items, written as python'
     ' dictionary without surrounding braces',
@@ -77,6 +79,9 @@ def main():
                             formatter_class=RawDescriptionHelpFormatter)
     parser.add_argument('--version', action='version',
                         version='%(prog)s ' + sfepy.__version__)
+    parser.add_argument('--debug',
+                        action='store_true', dest='debug',
+                        default=False, help=help['debug'])
     parser.add_argument('-c', '--conf', metavar='"key : value, ..."',
                         action='store', dest='conf', type=str,
                         default=None, help= help['conf'])
@@ -137,6 +142,9 @@ def main():
             print_solvers()
 
         return
+
+    if options.debug:
+        from sfepy.base.base import debug_on_error; debug_on_error()
 
     filename_in = options.filename_in
     output.set_output(filename=options.log,


### PR DESCRIPTION
All top-level scripts got ``--debug`` option that runs a post-mortem debugger when an exception occurs.

The only change that might break things is that the original ``--debug`` of ``run_tests.py`` was renamed to ``--raise``.