### PR TITLE
python -> python2 in test_install.py

### DIFF
--- a/test_install.py
+++ b/test_install.py
@@ -156,8 +156,7 @@ def main():
     fd.close()
 
     if sys.version_info[0] < 3:
-        cmd = 'python'
-
+        cmd = 'python2'
     else:
         cmd = 'python3'
 


### PR DESCRIPTION
This made test_install.py run using python2 on Arch Linux, where `python` stands for `python3`.