### PR TITLE
FIX BUG: "Python.h" Include Path Error under specified build of python

### DIFF
--- a/sfepy/config.py
+++ b/sfepy/config.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import shutil
+import sysconfig
 
 msg_unknown_os = """could not determine operating system!
 try setting it in site_cfg.py manually, see site_cfg_template.py"""
@@ -40,14 +41,7 @@ class Config(object):
             return site_cfg.python_include
 
         else:
-            system = self.system()
-
-            if system == 'posix':
-                version = self.python_version()
-                return os.path.join(sys.prefix, 'include', 'python' + version)
-
-            else:
-                return os.path.join(sys.prefix, 'include')
+            return sysconfig.get_config_var('INCLUDEPY')
 
 
     def system(self):


### PR DESCRIPTION
## Brief

use `sysconfig.get_config_var('INCLUDEPY')`, instead of `sys.prefix+'include'+'python'+version`, to obtain the correct include path of 'Python.h'

tested under (python 3.6m, mayavi 4.5)

---

## Problem

When running `python setup.py build`, I got an error while it came to
```
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -march=x86-64 -mtune=generic -O2
-pipe -fstack-protector-strong -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -march=x86-64 -mtune=generic -O2 -pipe -fstack-protecto
r-strong -fPIC -D__SDIR__="sfepy/discrete/common/extmods" -DSFEPY_PLATFORM=0 -Dinline=inline -Isfepy/discrete/common/extmods -I/usr/include/python3.6 
-I/usr/lib/python3.6/site-packages/numpy/core/include -c sfepy/discrete/common/extmods/fmfield.c -o build/temp.linux-x86_64-3.6/sfepy/discrete/common/e
xtmods/fmfield.o -g -O2 

In file included from sfepy/discrete/common/extmods/common.h:12:0,
                 from sfepy/discrete/common/extmods/fmfield.h:9,
                 from sfepy/discrete/common/extmods/fmfield.c:1:
sfepy/discrete/common/extmods/types.h:4:20: fatal error: Python.h: No such file or directory
 #include <Python.h>
                    ^
compilation terminated.
```

---

## Cause

This error occurred because of specifying a wrong include path **'-I/usr/include/python3.6'**.

In this case, I built python **'--with-pymalloc'**, so it installed the header files and static libraries into the directory **'/usr/include/python3.6m'**, with a suffix **'m'**.
(Besides, the suffix can be a combination of **'d'** for debug, **'m'** for pymalloc, **'u'** for wide-unicode)

While the fuction `python_include()` in **'sfepy/config.py:47'** gave the result of **'/usr/include/python3.6'**.

**'sfepy/config.py'**
```
37    def python_include(self):
38        if (has_attr(site_cfg, 'python_include')
39            and (site_cfg.python_include != 'auto')):
40            return site_cfg.python_include
41
42        else:
43            system = self.system()
44
45            if system == 'posix':
46                version = self.python_version()
47                return os.path.join(sys.prefix, 'include', 'python' + version)
48
49            else:
50                return os.path.join(sys.prefix, 'include')
```

---

## Solution

Using `return sysconfig.get_config_var('INCLUDEPY')` instead in **'sfepy/config.py:43-50:python_include(self)'** will fix this BUG.