### PR TITLE
Remove the unused method Problem.init_variables

### DIFF
--- a/sfepy/discrete/problem.py
+++ b/sfepy/discrete/problem.py
@@ -1409,10 +1409,6 @@ class Problem(Struct):
 
         return materials
 
-    def init_variables(self, state):
-        """Initialize variables with history."""
-        self.equations.variables.init_state(state)
-
     def get_variables(self, auto_create=False):
         if self.equations is not None:
             variables = self.equations.variables


### PR DESCRIPTION
The removed method does not work (probably since 2010, when `Variables.init_state` changed to `init_history`) and isn't used anywhere.