### PR TITLE
Fix things to be compatible with both python 2 and 3

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -267,10 +267,14 @@ def process_terms(app, what_, name, obj, options, lines):
     """
     Prepend term call signature(s) into term docstrings.
     """
-    from types import TypeType
+    if sys.version_info > (3,):
+        type_type = type
+    else:
+        from types import TypeType as type_type
+
     from sfepy.terms import Term
 
-    if isinstance(obj, TypeType):
+    if isinstance(obj, type_type):
         if issubclass(obj, Term) and len(obj.name):
             arg_types = obj.arg_types
             if ((len(arg_types) > 1) and not isinstance(arg_types[0], str)):


### PR DESCRIPTION
Could not regenerate the documentation using `python3` due to changes in the `types` module.
Changed things according to [Dive into Python 3](http://www.diveintopython3.net/porting-code-to-python-3-with-2to3.html#types)