### PR TITLE
Fix generators next

### DIFF
--- a/script/gen_gallery.py
+++ b/script/gen_gallery.py
@@ -477,7 +477,7 @@ def generate_rst_files(rst_dir, examples_dir, images_dir):
 
             ifd.write('    %s\n' % rst_filename_ns)
             fig_include = ''
-            fig_base = _get_fig_filenames(ebase, images_dir).next()
+            fig_base = next(_get_fig_filenames(ebase, images_dir))
             for fig_filename in _get_fig_filenames(ebase, images_dir):
                 rst_fig_filename = _make_sphinx_path(fig_filename)
 
@@ -568,7 +568,7 @@ def generate_gallery_html(examples_dir, output_filename, gallery_dir,
             link = os.path.join(link_prefix,
                                 os.path.splitext(link_base)[0] + '.html')
 
-            _get_fig_filenames(ebase, thumbnails_dir).next()
+            next(_get_fig_filenames(ebase, thumbnails_dir))
             for thumbnail_filename in _get_fig_filenames(ebase,
                                                          thumbnails_dir):
                 if not os.path.isfile(thumbnail_filename):

--- a/sfepy/applications/application.py
+++ b/sfepy/applications/application.py
@@ -52,7 +52,7 @@ class Application(Struct):
             if mode == 'coroutine':
                 # Pass application output to the generator.
                 container.append(out)
-                generator.next()
+                next(generator)
 
     def restore(self):
         """

--- a/sfepy/base/log.py
+++ b/sfepy/base/log.py
@@ -81,11 +81,11 @@ def read_log(filename):
             if ls[0] == '# groups':
                 n_gr = int(ls[1])
                 for ig in range(n_gr):
-                    fd.next()
-                    line_info = fd.next()
+                    next(fd)
+                    line_info = next(fd)
                     xlabel, ylabel, yscales = line_info.split(',')
 
-                    line_names = fd.next()
+                    line_names = next(fd)
                     names = line_names.split(':')[1]
 
                     info[ig] = (xlabel.split(':')[1].strip().strip('"'),


### PR DESCRIPTION
Generators do not have the `next` method in python 3.
All found occurences replaced by calls to the built-in function, which is available since python 2.6.