### PR TITLE
Doc-tutorial

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -202,7 +202,7 @@ Depending on type of your build run following tests:
     ./sfepy-run run_tests
 
 
-- installed (localy or system-wide) build::
+- installed (local or system-wide) build::
 
     sfepy-run run_tests
 
@@ -280,7 +280,8 @@ create a *SfePy* specific new one as follows:
       c.TerminalIPythonApp.gui = 'wx'
       c.TerminalInteractiveShell.colors = 'Linux' # NoColor, Linux, or LightBG
 
-   Beware: generally it is NOT recommended to use `star (*)` imports here!
+   Please note, that generally it is not recommended to use `starred` (*)
+   imports here.
 
 #. Run the customized IPython shell::
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -281,9 +281,6 @@ customize it as follows:
 
 .. _sfepy-custom-imports:
 
-*SfePy* custom imports
-^^^^^^^^^^^^^^^^^^^^^^
-
 TBD: and load custom *SfePy* imports:
 
 .. sourcecode:: ipython

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -280,7 +280,7 @@ create a *SfePy* specific new one as follows:
       c.TerminalIPythonApp.gui = 'wx'
       c.TerminalInteractiveShell.colors = 'Linux' # NoColor, Linux, or LightBG
 
-   Please note, that generally it is not recommended to use `starred` (*)
+   Please note, that generally it is not recommended to use `star` (*)
    imports here.
 
 #. Run the customized IPython shell::

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -245,8 +245,8 @@ Then re-run your code and report the output to the `SfePy mailing list`_.
 
 .. _using-ipython:
 
-Using IPython
--------------
+Using IPython (TBD)
+-------------------
 
 It is preferable to use (a customized) `IPython`_ over the regular Python shell
 when following :doc:`tutorial` or :doc:`primer`. Install `IPython`_ and then
@@ -277,6 +277,30 @@ customize it as follows:
       c.TerminalIPythonApp.gui = 'wx'
 
       c.TerminalInteractiveShell.colors = 'Linux' # NoColor, Linux, or LightBG
+
+
+.. _sfepy-custom-imports:
+
+*SfePy* custom imports
+^^^^^^^^^^^^^^^^^^^^^^
+
+TBD: and load custom *SfePy* imports:
+
+.. sourcecode:: ipython
+
+    In [1]:  import numpy as nm
+    In [2]:  from sfepy.base.base import IndexedStruct
+    In [3]:  from sfepy.discrete import (FieldVariable, Material, Integral, Function,
+       ...:                              Equation, Equations, Problem)
+    In [4]:  from sfepy.discrete.fem import Mesh, FEDomain, Field
+    In [5]:  from sfepy.terms import Term
+    In [6]:  from sfepy.discrete.conditions import Conditions, EssentialBC
+    In [7]:  from sfepy.solvers.ls import ScipyDirect
+    In [8]:  from sfepy.solvers.nls import Newton
+    In [9]:  from sfepy.postprocess.viewer import Viewer
+    In [10]: from sfepy.mechanics.matcoefs import stiffness_from_lame
+
+
 
 #. Run the customized IPython shell::
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -39,7 +39,7 @@ Python packages required for using *SfePy*:
 - `PyTables`_ for storing results in HDF5 files,
 - `SymPy`_ for some tests and functions,
 - `Mayavi`_ for postproc.py,
-- `Pysparse`_ for schroedinger.py,
+- `Pysparse`_ for schroedinger.py (currently available for Python 2.7.x only),
 - `igakit`_ for script/gen_iga_patch.py - simple IGA domain generator,
 - `petsc4py`_ and `mpi4py`_ for running parallel examples and using parallel
   solvers from `PETSc`_,
@@ -68,7 +68,7 @@ Other dependencies/suggestions:
   some parts of primer/tutorial (see :ref:`using-ipython`).
 
 
-.. _Python_distribution
+.. _Python_distribution:
 
 Notes on selecting Python Distribution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -245,65 +245,49 @@ Then re-run your code and report the output to the `SfePy mailing list`_.
 
 .. _using-ipython:
 
-Using IPython (TBD)
--------------------
+Using IPython
+-------------
 
-It is preferable to use (a customized) `IPython`_ over the regular Python shell
-when following :doc:`tutorial` or :doc:`primer`. Install `IPython`_ and then
-customize it as follows:
+We generally recommend to use (a customized) `IPython`_ interactive shell over
+the regular Python interpreter when following :doc:`tutorial` or
+:doc:`primer` (or even for any regular interactive work with *SfePy*).
 
-#. Create a new profile::
+Install `IPython`_ (as a generic part of your selected distribution) and then
+customize it to your choice.
+
+Depending on your IPython usage, you can customize your `default` profile or
+create a *SfePy* specific new one as follows:
+
+#. Create a new *SfePy* profile::
 
      ipython profile create sfepy
 
 #. Open the ``~/.ipython/profile_sfepy/ipython_config.py`` file in a text
-   editor and add/edit after the ``c = get_config()`` line the following:
+   editor and add/edit after the ``c = get_config()`` line:
 
    .. sourcecode:: python
 
       exec_lines = [
-          'from sfepy.base.base import *',
-          'from sfepy.discrete import *',
-          'from sfepy.discrete.fem import *',
-          'from sfepy.applications import solve_pde',
+          'import numpy as nm',
           'import matplotlib as mpl',
           'mpl.use("WXAgg")',
-          'from matplotlib.pyplot import *',
-          'from sfepy.postprocess.viewer import Viewer',
+      #
+      # Add your preferred SfePy customization here...
+      #
       ]
 
       c.InteractiveShellApp.exec_lines = exec_lines
-
       c.TerminalIPythonApp.gui = 'wx'
-
       c.TerminalInteractiveShell.colors = 'Linux' # NoColor, Linux, or LightBG
 
-
-.. _sfepy-custom-imports:
-
-TBD: and load custom *SfePy* imports:
-
-.. sourcecode:: ipython
-
-    In [1]:  import numpy as nm
-
-    In [2]:  from sfepy.base.base import IndexedStruct
-    In [3]:  from sfepy.discrete import (FieldVariable, Material, Integral, Function,
-       ...:                              Equation, Equations, Problem)
-    In [4]:  from sfepy.discrete.fem import Mesh, FEDomain, Field
-    In [5]:  from sfepy.terms import Term
-    In [6]:  from sfepy.discrete.conditions import Conditions, EssentialBC
-    In [7]:  from sfepy.solvers.ls import ScipyDirect
-    In [8]:  from sfepy.solvers.nls import Newton
-    In [9]:  from sfepy.postprocess.viewer import Viewer
-    In [10]: from sfepy.mechanics.matcoefs import stiffness_from_lame
+   Beware: generally it is NOT recommended to use `star (*)` imports here!
 
 #. Run the customized IPython shell::
 
      ipython --profile=sfepy
 
-.. _multi_platform_distributions_notes:
 
+.. _multi_platform_distributions_notes:
 
 Notes on Multi-platform Python Distributions
 --------------------------------------------

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -286,6 +286,7 @@ TBD: and load custom *SfePy* imports:
 .. sourcecode:: ipython
 
     In [1]:  import numpy as nm
+
     In [2]:  from sfepy.base.base import IndexedStruct
     In [3]:  from sfepy.discrete import (FieldVariable, Material, Integral, Function,
        ...:                              Equation, Equations, Problem)
@@ -296,8 +297,6 @@ TBD: and load custom *SfePy* imports:
     In [8]:  from sfepy.solvers.nls import Newton
     In [9]:  from sfepy.postprocess.viewer import Viewer
     In [10]: from sfepy.mechanics.matcoefs import stiffness_from_lame
-
-
 
 #. Run the customized IPython shell::
 

--- a/doc/primer.rst
+++ b/doc/primer.rst
@@ -45,10 +45,10 @@ the schematic.
    :align: right
 
 The tensile and compressive stresses that develop in the specimen as a
-result of the point loads P are a function of the diameter (D) and
-thickness (t) of the cylindrical specimen. At the centre of the
+result of the point loads P are a function of the diameter :math:`D` and
+thickness :math:`t` of the cylindrical specimen. At the centre of the
 specimen, the compressive stress is 3 times the tensile stress and the
-analytical formulation for these are, respectively:
+analytical formulation for these are respectively:
 
 .. math::
    :label: eq_tensile_stress
@@ -77,11 +77,11 @@ model. Follow these steps to model the ITS:
 
 #. The ITS specimen has a diameter of 150 mm. Using *Gmsh* add three new
    points (geometry elementary entities) at the following coordinates:
-   (0.0 0.0), (75.0,0.0) and (0.0,75.0).
+   :math:`(0.0 0.0), (75.0,0.0) \,\textrm{and}\, (0.0,75.0)`.
 #. Next add two straight lines connecting the points.
 #. Next add a Circle arc connecting two of the points to form the
    quarter circle segment.
-#. Still under *Geometry* add a ruled surface.
+#. Still under `Geometry` add a ruled surface.
 #. With the geometry of the model defined, add a mesh by clicking on the
    2D button under the Mesh functions.
 
@@ -97,7 +97,7 @@ The figures that follow show the various stages in the model process.
    :width: 20 %
 
 That's the meshing done. Save the mesh in a format that *SfePy*
-recognizes. For now use the **medit** `.mesh` format e.g. `its2D.mesh`.
+recognizes. For now use the `medit` `.mesh` format e.g. `its2D.mesh`.
 
 **Hint:** Check the drop down in the *Save As* dialog for the different
 formats that *Gmsh* can save to.

--- a/doc/primer.rst
+++ b/doc/primer.rst
@@ -1,6 +1,3 @@
-.. highlight:: python
-   :linenothreshold: 3
-
 .. include:: links.inc
 
 .. _sec-primer:
@@ -145,7 +142,7 @@ The next step in the process is coding the *SfePy* problem definition file.
 Problem description
 -------------------
 
-The programming of the problem description file is well documented in
+The programming of the `problem description file` is well documented in
 the *SfePy* :doc:`users_guide`. The problem description file used in the
 tutorial follows:
 
@@ -166,9 +163,7 @@ we are using Newton (N), millimeters (mm) and megaPascal (MPa). The
 help you in determining which derived units correspond to given basic
 units.
 
-The following block of code defines regions on your mesh:
-
-::
+The following block of code defines regions on your mesh::
 
     regions = {
         'Omega' : 'all',
@@ -185,9 +180,7 @@ Four regions are defined:
     4. `'Top'`: the topmost node. This is where the load is applied.
 
 Having defined the regions these can be used in other parts of your
-code. For example, in the definition of the boundary conditions:
-
-::
+code. For example, in the definition of the boundary conditions::
 
     ebcs = {
         'XSym' : ('Bottom', {'u.1' : 0.0}),
@@ -258,7 +251,7 @@ editor. You'll notice that the output file includes separate sections:
     * CELLS (the model element connectivity),
     * VECTORS (the node displacements in the x-, y- and z- directions).
 
-*SfePy* pprovides a script (`postproc.py`) to quickly view the solution. To run
+*SfePy* provides a script (`postproc.py`) to quickly view the solution. To run
 this script you need to have `Mayavi`_ installed. From the command line issue
 the following (assuming the correct paths)::
 
@@ -320,12 +313,13 @@ In the *SfePy* top-level directory run ::
 
     $ ipython
 
-and import :ref:`*SfePy* custom imports <sfepy-custom-imports>`. Once the
-*SfePy* customized IPython shell is ready, issue the following command:
+issue the following commands:
 
 .. sourcecode:: ipython
 
-    In [1]: pb, state = solve_pde('its2D_2.py')
+    In [1]: from sfepy.applications import solve_pde
+
+    In [2]: pb, state = solve_pde('its2D_2.py')
 
 The problem is solved and the problem definition and solution are
 provided in the `pb` and `state` variables respectively. The solution,
@@ -334,20 +328,20 @@ y-displacements at the nodes in the 2D model:
 
 .. sourcecode:: ipython
 
-    In [2]: u = state()
+    In [3]: u = state()
 
-    In [3]: u
-    Out[3]:
+    In [4]: u
+    Out[4]:
     array([ 0.        ,  0.        ,  0.37376671, ..., -0.19923848,
             0.08820237, -0.11201528])
 
-    In [4]: u.shape
-    Out[4]: (110,)
+    In [5]: u.shape
+    Out[5]: (110,)
 
-    In [5]: u.shape = (55, 2)
+    In [6]: u.shape = (55, 2)
 
-    In [6]: u
-    Out[6]:
+    In [7]: u
+    Out[7]:
     array([[ 0.        ,  0.        ],
            [ 0.37376671,  0.        ],
            [ 0.        , -1.65318152],
@@ -361,10 +355,10 @@ variable (`u`). In general, the following can be used:
 
 .. sourcecode:: ipython
 
-    In [7]: u = state.get_parts()['u']
+    In [8]: u = state.get_parts()['u']
 
-    In [8]: u
-    Out[8]:
+    In [9]: u
+    Out[9]:
     array([[ 0.        ,  0.        ],
            [ 0.37376671,  0.        ],
            [ 0.        , -1.65318152],
@@ -383,14 +377,14 @@ matrix is saved in `pb` as a `sparse matrix`_:
 
 .. sourcecode:: ipython
 
-    In [9]: K = pb.mtx_a
+    In [10]: K = pb.mtx_a
 
-    In [10]: K
-    Out[10]:
+    In [11]: K
+    Out[11]:
     <94x94 sparse matrix of type '<type 'numpy.float64'>'
             with 1070 stored elements in Compressed Sparse Row format>
 
-    In [11]: print K
+    In [12]: print K
       (0, 0)        2443.95959851
       (0, 7)        -2110.99917491
       (0, 14)       -332.960423597
@@ -443,8 +437,8 @@ matrix is saved in `pb` as a `sparse matrix`_:
       (93, 92)      -2607.52659081
       (93, 93)      9821.16012014
 
-    In [12]: K.shape
-    Out[12]: (94, 94)
+    In [13]: K.shape
+    Out[13]: (94, 94)
 
 One would expect the shape of the global stiffness matrix :math:`K` to be
 :math:`(110,110)` i.e. to have the same number of rows and columns as `u`. This
@@ -454,38 +448,38 @@ matrix, temporarily remove the imposed boundary conditions:
 
 .. sourcecode:: ipython
 
-    In [13]: pb.remove_bcs()
+    In [14]: pb.remove_bcs()
 
 Now we can calculate the force vector :math:`f`:
 
 .. sourcecode:: ipython
 
-    In [14]: f = pb.evaluator.eval_residual(u)
+    In [15]: f = pb.evaluator.eval_residual(u)
 
-    In [15]: f.shape
-    Out[15]: (110,)
+    In [16]: f.shape
+    Out[16]: (110,)
 
-    In [16]: f
-    Out[16]:
+    In [17]: f
+    Out[17]:
     array([ -4.73618436e+01,   1.42752386e+02,   1.56921124e-13, ...,
             -2.06057393e-13,   2.13162821e-14,  -2.84217094e-14])
 
 Remember to restore the original boundary conditions previously removed
-in step [13]:
+in step [14]:
 
 .. sourcecode:: ipython
 
-    In [17]: pb.time_update()
+    In [18]: pb.time_update()
 
 To view the residual force vector, we can save it to a VTK file. This
 requires creating a state and set its DOF vector to `f` as follows:
 
 .. sourcecode:: ipython
 
-    In [18]: state = pb.create_state()
-    In [19]: state.set_full(f)
-    In [20]: out = state.create_output_dict()
-    In [21]: pb.save_state('file.vtk', out=out)
+    In [19]: state = pb.create_state()
+    In [20]: state.set_full(f)
+    In [21]: out = state.create_output_dict()
+    In [22]: pb.save_state('file.vtk', out=out)
 
 Running the `postproc.py` script on ``file.vtk`` displays the average nodal
 forces as shown below:
@@ -497,10 +491,8 @@ The forces in the x- and y-directions at node 2 are:
 
 .. sourcecode:: ipython
 
-    In [22]: f.shape = (55, 2)
-
-    In [23]: f[2]
-    Out[23]: array([  6.20373272e+02,  -1.13686838e-13])
+    In [23]: f.shape = (55, 2)
+    In [24]: array([  6.20373272e+02,  -1.13686838e-13])
 
 Great, we have an almost zero residual vertical load or force apparent
 at node 2 i.e. -1.13686838e-13 Newton. Let us now check the stress at
@@ -520,7 +512,9 @@ achieve this.
 
 .. literalinclude:: /../examples/linear_elasticity/its2D_3.py
 
-The output::
+The output:
+
+.. code-block:: none
 
     ==================================================================
     Given load = 2000.00 N
@@ -538,7 +532,9 @@ The output::
 
 Not bad for such a coarse mesh! Re-running the problem using a
 :download:`finer mesh <../meshes/2d/big.mesh>` provides a more accurate
-solution::
+solution:
+
+.. code-block:: none
 
     ==================================================================
     Given load = 2000.00 N
@@ -564,35 +560,35 @@ The above computation could also be done in the customized ipython shell:
 
 .. sourcecode:: ipython
 
-    In [23]: from sfepy.discrete.fem.geometry_element import geometry_data
+    In [25]: from sfepy.discrete.fem.geometry_element import geometry_data
 
-    In [24]: gdata = geometry_data['2_3']
-    In [25]: nc = len(gdata.coors)
-    In [26]: ivn = Integral('ivn', order=-1,
+    In [26]: gdata = geometry_data['2_3']
+    In [27]: nc = len(gdata.coors)
+    In [28]: ivn = Integral('ivn', order=-1,
        ....:                coors=gdata.coors, weights=[gdata.volume / nc] * nc)
 
-    In [27]: pb, state = solve_pde('examples/linear_elasticity/its2D_2.py')
+    In [29]: pb, state = solve_pde('examples/linear_elasticity/its2D_2.py')
 
-    In [28]: stress = pb.evaluate('ev_cauchy_stress.ivn.Omega(Asphalt.D,u)',
+    In [30]: stress = pb.evaluate('ev_cauchy_stress.ivn.Omega(Asphalt.D,u)',
        ....:                      mode='qp', integrals=Integrals([ivn]))
-    In [29]: sfield = Field('stress', nm.float64, (3,), pb.domain.regions['Omega'])
-    In [30]: svar = FieldVariable('sigma', 'parameter', sfield,
+    In [31]: sfield = Field('stress', nm.float64, (3,), pb.domain.regions['Omega'])
+    In [32]: svar = FieldVariable('sigma', 'parameter', sfield,
        ....:                      primary_var_name='(set-to-None)')
-    In [31]: svar.set_data_from_qp(stress, ivn)
+    In [33]: svar.set_data_from_qp(stress, ivn)
 
-    In [32]: print 'Horizontal tensile stress = %.5e MPa/mm' % (svar()[0][0])
+    In [34]: print 'Horizontal tensile stress = %.5e MPa/mm' % (svar()[0][0])
     Horizontal tensile stress = 7.57220e+00 MPa/mm
-    In [33]: print 'Vertical compressive stress = %.5e MPa/mm' % (-svar()[0][1])
+    In [35]: print 'Vertical compressive stress = %.5e MPa/mm' % (-svar()[0][1])
     Vertical compressive stress = 2.58660e+01 MPa/mm
 
-    In [34]: mat = pb.get_materials()['Load']
-    In [35]: P = 2.0 * mat.get_data('special', None, 'val')[1]
-    In [36]: P
-    Out[36]: -2000.0
+    In [36]: mat = pb.get_materials()['Load']
+    In [37]: P = 2.0 * mat.get_data('special', None, 'val')[1]
+    In [38]: P
+    Out[38]: -2000.0
 
-    In [37]: print 'Horizontal tensile stress = %.5e MPa/mm' % (-2.*P/(nm.pi*150.))
+    In [39]: print 'Horizontal tensile stress = %.5e MPa/mm' % (-2.*P/(nm.pi*150.))
     Horizontal tensile stress = 8.48826e+00 MPa/mm
-    In [38]: print 'Vertical compressive stress = %.5e MPa/mm' % (-6.*P/(nm.pi*150.))
+    In [40]: print 'Vertical compressive stress = %.5e MPa/mm' % (-6.*P/(nm.pi*150.))
     Vertical compressive stress = 2.54648e+01 MPa/mm
 
 To wrap this tutorial up let's explore *SfePy*'s probing functions.

--- a/doc/primer.rst
+++ b/doc/primer.rst
@@ -68,9 +68,9 @@ Meshing
 -------
 
 Assuming plane strain conditions, the indirect tensile test may be modelled
-using a 2-D finite element mesh. Furthermore, the geometry of the model is
+using a 2D finite element mesh. Furthermore, the geometry of the model is
 symmetrical about the x- and y-axes passing through the centre of the
-circle. To take advantage of this symmetry only one quarter of the 2-D model
+circle. To take advantage of this symmetry only one quarter of the 2D model
 will be meshed and boundary conditions will be established to indicate this
 symmetry. The meshing program `Gmsh`_ is used here to very quickly mesh the
 model. Follow these steps to model the ITS:
@@ -97,14 +97,14 @@ The figures that follow show the various stages in the model process.
    :width: 20 %
 
 That's the meshing done. Save the mesh in a format that *SfePy*
-recognizes. For now use the **medit** .mesh format e.g. its2D.mesh.
+recognizes. For now use the **medit** `.mesh` format e.g. `its2D.mesh`.
 
 **Hint:** Check the drop down in the *Save As* dialog for the different
-formats that Gmsh can save to.
+formats that *Gmsh* can save to.
 
-If you open the its2D.mesh file using a text editor you'll notice that
-*Gmsh* saves the mesh in a 3-D format and includes some extra geometry
-items that should be deleted. Reformatted the mesh file to a 2-D format
+If you open the `its2D.mesh` file using a text editor you'll notice that
+*Gmsh* saves the mesh in a 3D format and includes some extra geometry
+items that should be deleted. Reformatted the mesh file to a 2D format
 and delete the *Edges* block. Note that when you do this the file cannot
 be reopened by *Gmsh* so it is always a good idea to also save your
 meshes in *Gmsh's* native format as well (Shift-Ctrl-S). Click
@@ -121,21 +121,21 @@ element connectivity. It is important to note that node and element
 numbering in *SfePy* start at 0 and not 1 as is the case in *Gmsh* and
 some other meshing programs.
 
-To view *.mesh* files you can use a demo of `medit`_. After loading your
+To view `.mesh` files you can use a demo of `medit`_. After loading your
 mesh file with medit you can see the node and element numbering by
 pressing **P** and **F** respectively. The numbering in medit starts at
 1 as shown. Thus the node at the center of the model in *SfePy*
 numbering is 0, and elements 76 and 77 are connected to this node. Node
-and element numbers can also be viewed in *Gmsh* - under the mesh option
-under the Visibility tab enable the node and surface labels. Note that
+and element numbers can also be viewed in *Gmsh* -- under the `mesh` option
+under the `Visibility` tab enable the `node` and `surface` labels. Note that
 the surface labels as numbered in *Gmsh* follow on from the line
-numbering. So to get the corresponding element number in SfePy you'll
+numbering. So to get the corresponding element number in *SfePy* you'll
 need to subtract the number of lines in the *Gmsh* file + 1. Confused
 yet? Luckily, *SfePy* provides some useful mesh functions to indicate
 which elements are connected to which nodes. Nodes and elements can also
 be identified by defining regions, which is addressed later.
 
-Another open source python option to view *.mesh* files is the
+Another open source python option to view `.mesh` files is the
 appropriately named `Python Mesh Viewer`_.
 
 The next step in the process is coding the *SfePy* problem definition file.
@@ -196,9 +196,9 @@ code. For example, in the definition of the boundary conditions:
 
 Now the power of the regions entity becomes apparent. To ensure symmetry
 about the x-axis, the vertical or y-displacement of the nodes in the
-Bottom region are prevented or set to zero. Similarly, for symmetry
+`'Bottom'` region are prevented or set to zero. Similarly, for symmetry
 about the y-axis, any horizontal or displacement in the x-direction of
-the nodes in the Left region or y-axis is prevented.
+the nodes in the `'Left'` region or y-axis is prevented.
 
 The load is specified in terms of the `'Load'` material as
 follows::
@@ -214,7 +214,7 @@ follows::
 Note the dot in `'.val'` -- this denotes a special material value, i.e.,
 a value that is not to be evaluated in quadrature points. The load is
 then applied in equations using the `'dw_point_load.0.Top(Load.val, v)'`
-term in the topmost node (region Top).
+term in the topmost node (region `'Top'`).
 
 We provided the material constants in terms of Young's modulus and
 Poisson's ratio, but the linear elastic isotropic equation used requires
@@ -249,16 +249,16 @@ then make sure you include the path to this file as well.
 (`output_dir`) provided in the script. The output file will be in the VTK
 format by default if this is not explicitly specified and the name of
 the output file will be the same as that used for the mesh file except
-with the '.vtk' extension i.e. ``its2D.vtk``.
+with the `'.vtk'` extension i.e. ``its2D.vtk``.
 
 The VTK format is an ASCII format. Open the file using a text
 editor. You'll notice that the output file includes separate sections:
 
-    * POINTS (these are the model nodes)
-    * CELLS (the model element connectivity)
-    * VECTORS (the node displacements in the x-, y- and z- directions.
+    * POINTS (these are the model nodes),
+    * CELLS (the model element connectivity),
+    * VECTORS (the node displacements in the x-, y- and z- directions).
 
-*SfePy* includes a script (`postproc.py`) to quickly view the solution. To run
+*SfePy* pprovides a script (`postproc.py`) to quickly view the solution. To run
 this script you need to have `Mayavi`_ installed. From the command line issue
 the following (assuming the correct paths)::
 
@@ -302,7 +302,6 @@ also includes the stresses and strains averaged in the elements:
 .. image:: images/primer/its2D_2.png
    :width: 40 %
 
-TBD (wrong math):
 Remember the objective was to determine the stresses at the centre of
 the specimen under a load :math:`P`. The solution as currently derived is
 expressed in terms of a global displacement vector :math:`u`. The global
@@ -321,15 +320,19 @@ In the *SfePy* top-level directory run ::
 
     $ ipython
 
-and import :ref:`sfepy-custom-imports`. Once the *SfePy* customized IPython
-shell is ready, issue the following command::
+and import :ref:`*SfePy* custom imports <sfepy-custom-imports>`. Once the
+*SfePy* customized IPython shell is ready, issue the following command:
+
+.. sourcecode:: ipython
 
     In [1]: pb, state = solve_pde('its2D_2.py')
 
 The problem is solved and the problem definition and solution are
-provided in the *pb* and *state* variables, respectively. The solution,
-or in this case, the global displacement vector (u), contains the x- and
-y-displacements at the nodes in the 2D model::
+provided in the `pb` and `state` variables respectively. The solution,
+or in this case, the global displacement vector :math:`u`, contains the x- and
+y-displacements at the nodes in the 2D model:
+
+.. sourcecode:: ipython
 
     In [2]: u = state()
 
@@ -354,7 +357,9 @@ y-displacements at the nodes in the 2D model::
            [ 0.08820237, -0.11201528]])
 
 **Note:** We have used the fact, that the state vector contains only one
-variable (*u*). In general, the following can be used::
+variable (`u`). In general, the following can be used:
+
+.. sourcecode:: ipython
 
     In [7]: u = state.get_parts()['u']
 
@@ -373,8 +378,10 @@ that is why in Out[8] the vector is reshaped according to Out[6].
 
 From the above it can be seen that *u* holds the displacements at the 55
 nodes in the model and that the displacement at node 2 (on which the
-load is applied) is (0, -1.65318152). The global stiffness
-matrix is saved in pb as a `sparse matrix`_::
+load is applied) is :math:`(0, -1.65318152)`. The global stiffness
+matrix is saved in `pb` as a `sparse matrix`_:
+
+.. sourcecode:: ipython
 
     In [9]: K = pb.mtx_a
 
@@ -439,15 +446,19 @@ matrix is saved in pb as a `sparse matrix`_::
     In [12]: K.shape
     Out[12]: (94, 94)
 
-One would expect the shape of the global stiffness matrix (K) to be
-(110,110) i.e. to have the same number of rows and columns as *u*. This
+One would expect the shape of the global stiffness matrix :math:`K` to be
+:math:`(110,110)` i.e. to have the same number of rows and columns as `u`. This
 matrix has been reduced by the fixed degrees of freedom imposed by the
 boundary conditions set at the nodes on symmetry axes. To restore the
-matrix, temporarily remove the imposed boundary conditions::
+matrix, temporarily remove the imposed boundary conditions:
+
+.. sourcecode:: ipython
 
     In [13]: pb.remove_bcs()
 
-Now we can calculate the force vector (f)::
+Now we can calculate the force vector :math:`f`:
+
+.. sourcecode:: ipython
 
     In [14]: f = pb.evaluator.eval_residual(u)
 
@@ -460,28 +471,31 @@ Now we can calculate the force vector (f)::
             -2.06057393e-13,   2.13162821e-14,  -2.84217094e-14])
 
 Remember to restore the original boundary conditions previously removed
-in step [13]::
+in step [13]:
+
+.. sourcecode:: ipython
 
     In [17]: pb.time_update()
 
-To view the residual force vector, we can save it to a vtk file. This
-requires creating a state and set its DOF vector to *f* as follows::
+To view the residual force vector, we can save it to a VTK file. This
+requires creating a state and set its DOF vector to `f` as follows:
+
+.. sourcecode:: ipython
 
     In [18]: state = pb.create_state()
-
     In [19]: state.set_full(f)
-
     In [20]: out = state.create_output_dict()
-
     In [21]: pb.save_state('file.vtk', out=out)
 
-Running the *postproc.py* script on file.vtk displays the average nodal
-forces as shown below.
+Running the `postproc.py` script on ``file.vtk`` displays the average nodal
+forces as shown below:
 
 .. image:: images/primer/its2D_3.png
    :width: 40 %
 
-The forces in the x- and y-directions at node 2 are::
+The forces in the x- and y-directions at node 2 are:
+
+.. sourcecode:: ipython
 
     In [22]: f.shape = (55, 2)
 
@@ -546,7 +560,9 @@ file, namely lines 25, 26::
     refinement_level = 0
     filename_mesh = refine_mesh(filename_mesh, refinement_level)
 
-The above computation could also be done in the customized ipython shell::
+The above computation could also be done in the customized ipython shell:
+
+.. sourcecode:: ipython
 
     In [23]: from sfepy.discrete.fem.geometry_element import geometry_data
 
@@ -585,7 +601,7 @@ Probing
 -------
 
 As a bonus for sticking to the end of this tutorial see the following
-:download:`problem definition file
+:download:`Problem description file
 </../examples/linear_elasticity/its2D_5.py>` that provides *SfePy*
 functions to quickly and neatly probe the solution.
 
@@ -595,7 +611,7 @@ Probing applies interpolation to output the solution along specified
 paths. For the tutorial, line probing is done along the x- and y-axes of
 the model.
 
-Run SfePy to solve the problem and apply the probes::
+Run *SfePy* to solve the problem and apply the probes::
 
     $ ./simple.py its2D_5.py
 
@@ -623,15 +639,15 @@ The probing function also generates previews of the mesh with the probe paths.
 Interactive Example
 -------------------
 
-SfePy can be used also interactively by constructing directly the classes that
+*SfePy* can be used also interactively by constructing directly the classes that
 corresponds to the keywords in the problem description files. The following
 listing shows a script with the same (and more) functionality as the above
 examples:
 
 .. literalinclude:: /../examples/linear_elasticity/its2D_interactive.py
 
-The script can be run from the SfePy top-level directory, assuming the in-place
-build, as follows::
+The script can be run from the *SfePy* top-level directory, assuming the
+in-place build, as follows::
 
     python examples/linear_elasticity/its2D_interactive.py
 

--- a/doc/primer.rst
+++ b/doc/primer.rst
@@ -231,7 +231,7 @@ Running *SfePy*
 One option to solve the problem is to run the *SfePy* `simple.py` script
 from the command line::
 
-    $ ./simple.py its2D_1.py
+    ./simple.py its2D_1.py
 
 **Note:** For the purpose of this tutorial it is assumed that the
 `problem description file` (``its2D_1.py``) is in the same directory as
@@ -255,7 +255,7 @@ editor. You'll notice that the output file includes separate sections:
 this script you need to have `Mayavi`_ installed. From the command line issue
 the following (assuming the correct paths)::
 
-    $ ./postproc.py its2D.vtk
+    ./postproc.py its2D.vtk
 
 The `postproc.py` script generates the image shown below, which shows by
 default the displacements in the model as arrows and their magnitude as
@@ -286,8 +286,8 @@ accordingly. The problem options were also updated to call the
 Run *SfePy* to solve the updated problem and view the solution (assuming
 the correct paths)::
 
-    $ ./simple.py its2D_2.py
-    $ ./postproc.py its2D.vtk -b
+    ./simple.py its2D_2.py
+    ./postproc.py its2D.vtk -b
 
 In addition to the node displacements, the VTK output shown below now
 also includes the stresses and strains averaged in the elements:
@@ -311,7 +311,7 @@ examples).
 
 In the *SfePy* top-level directory run ::
 
-    $ ipython
+    ipython
 
 issue the following commands:
 
@@ -609,7 +609,7 @@ the model.
 
 Run *SfePy* to solve the problem and apply the probes::
 
-    $ ./simple.py its2D_5.py
+    ./simple.py its2D_5.py
 
 The probing function will generate the following figures that show the
 displacements, normal stresses and strains as well as shear stresses

--- a/doc/primer.rst
+++ b/doc/primer.rst
@@ -151,14 +151,14 @@ tutorial follows:
 
 .. literalinclude:: /../examples/linear_elasticity/its2D_1.py
 
-:download:`Download </../examples/linear_elasticity/its2D_1.py>` and open
-the file in your favourite python editor. Note that you may wish to
-change the location of the output directory to somewhere on your
-drive. You may also need to edit the mesh file name. For the analysis we
-will assume that the material of the test specimen is linear elastic and
-isotropic. We define two material constants i.e. Young's modulus and
-Poisson's ratio. The material is assumed to be asphalt concrete having a
-Young's modulus of 2,000 MPa and a Poisson's ration of 0.4.
+Download the :download:`Problem description file
+</../examples/linear_elasticity/its2D_1.py>` and open it in your favourite
+Python editor. Note that you may wish to change the location of the output
+directory to somewhere on your drive. You may also need to edit the mesh file
+name. For the analysis we will assume that the material of the test specimen is
+linear elastic and isotropic. We define two material constants i.e. Young's
+modulus and Poisson's ratio. The material is assumed to be asphalt concrete
+having a Young's modulus of 2,000 MPa and a Poisson's ration of 0.4.
 
 **Note:** Be consistent in your choice and use of units. In the tutorial
 we are using Newton (N), millimeters (mm) and megaPascal (MPa). The
@@ -179,10 +179,10 @@ The following block of code defines regions on your mesh:
 
 Four regions are defined:
 
-    1. Omega: all the elements in the mesh
-    2. Left: the y-axis
-    3. Bottom: the x-axis
-    4. Top: the topmost node. This is where the load is applied.
+    1. `'Omega'`: all the elements in the mesh,
+    2. `'Left'`: the y-axis,
+    3. `'Bottom'`: the x-axis,
+    4. `'Top'`: the topmost node. This is where the load is applied.
 
 Having defined the regions these can be used in other parts of your
 code. For example, in the definition of the boundary conditions:
@@ -200,7 +200,7 @@ Bottom region are prevented or set to zero. Similarly, for symmetry
 about the y-axis, any horizontal or displacement in the x-direction of
 the nodes in the Left region or y-axis is prevented.
 
-The load is specified in terms of the 'Load' material as
+The load is specified in terms of the `'Load'` material as
 follows::
 
     materials = {
@@ -211,14 +211,14 @@ follows::
         'Load' : ({'.val' : [0.0, -1000.0]},),
     }
 
-Note the dot in '.val' - this denotes a special material value, i.e.,
+Note the dot in `'.val'` -- this denotes a special material value, i.e.,
 a value that is not to be evaluated in quadrature points. The load is
 then applied in equations using the `'dw_point_load.0.Top(Load.val, v)'`
 term in the topmost node (region Top).
 
 We provided the material constants in terms of Young's modulus and
 Poisson's ratio, but the linear elastic isotropic equation used requires
-as input Lamé's parameters. The lame_from_youngpoisson() function is thus
+as input Lamé's parameters. The `lame_from_youngpoisson()` function is thus
 used for conversion. Note that to use this function it was necessary to
 import the function into the code, which was done up front:
 
@@ -230,41 +230,41 @@ import the function into the code, which was done up front:
 <src/sfepy/mechanics/matcoefs>` module for other useful material related
 functions.
 
-That's it - we are now ready to solve the problem.
+That's it -- we are now ready to solve the problem.
 
-Running SfePy
--------------
+Running *SfePy*
+---------------
 
-One option to solve the problem is to run the SfePy simple.py script
-from the command shell::
+One option to solve the problem is to run the *SfePy* `simple.py` script
+from the command line::
 
     $ ./simple.py its2D_1.py
 
 **Note:** For the purpose of this tutorial it is assumed that the
-problem definition file (its2D_1.py) is in the same directory as the
-*simple.py* script. If you have the its2D_1.py file in another directory
+`problem description file` (``its2D_1.py``) is in the same directory as
+the *simple.py* script. If you have the ``its2D_1.py`` file in another directory
 then make sure you include the path to this file as well.
 
-SfePy solves the problem and outputs the solution to the output path
-(output_dir) provided in the script. The output file will be in the vtk
+*SfePy* solves the problem and outputs the solution to the output path
+(`output_dir`) provided in the script. The output file will be in the VTK
 format by default if this is not explicitly specified and the name of
 the output file will be the same as that used for the mesh file except
-with the vtk extension i.e. its2D.vtk.
+with the '.vtk' extension i.e. ``its2D.vtk``.
 
-The vtk format is an ascii format. Open the file using a text
+The VTK format is an ASCII format. Open the file using a text
 editor. You'll notice that the output file includes separate sections:
 
     * POINTS (these are the model nodes)
     * CELLS (the model element connectivity)
     * VECTORS (the node displacements in the x-, y- and z- directions.
 
-SfePy includes a script (postproc.py) to quickly view the solution. To run this
-script you need to have `Mayavi`_ installed. From the command line issue the
-following (with the correct paths)::
+*SfePy* includes a script (`postproc.py`) to quickly view the solution. To run
+this script you need to have `Mayavi`_ installed. From the command line issue
+the following (assuming the correct paths)::
 
     $ ./postproc.py its2D.vtk
 
-The *postproc.py* script generates the image shown below, which shows by
+The `postproc.py` script generates the image shown below, which shows by
 default the displacements in the model as arrows and their magnitude as
 color scale. Cool, but we are more interested in the stresses. To get
 these we need to modify the problem description file and do some
@@ -279,46 +279,50 @@ Post-processing
 *SfePy* provides functions to calculate stresses and strains. We'll
 include a function to calculate these and update the problem material
 definition and options to call this function as a
-post_process_hook. Save this file as :download:`its2D_2.py
+`post_process_hook()`. Save this file as :download:`its2D_2.py
 </../examples/linear_elasticity/its2D_2.py>`.
 
 .. literalinclude:: /../examples/linear_elasticity/its2D_2.py
 
 The updated file imports all of the previous definitions in
-its2D_1.py. The stress function (de_cauchy_stress) requires as input the
-stiffness tensor - thus it was necessary to update the materials
+``its2D_1.py``. The stress function (`de_cauchy_stress()`) requires as input
+the stiffness tensor -- thus it was necessary to update the materials
 accordingly. The problem options were also updated to call the
-stress_strain function as a post_process_hook.
+`stress_strain()` function as a `post_process_hook()`.
 
-Run SfePy to solve the updated problem and view the solution (assuring
+Run *SfePy* to solve the updated problem and view the solution (assuming
 the correct paths)::
 
     $ ./simple.py its2D_2.py
     $ ./postproc.py its2D.vtk -b
 
-In addition to the node displacements, the vtk output shown below now
+In addition to the node displacements, the VTK output shown below now
 also includes the stresses and strains averaged in the elements:
 
 .. image:: images/primer/its2D_2.png
    :width: 40 %
 
+TBD (wrong math):
 Remember the objective was to determine the stresses at the centre of
-the specimen under a load P. The solution as currently derived is
-expressed in terms of a global displacement vector (u). The global
-(residual) force vector (f) is a function of the global displacement
-vector and the global stiffness matrix (K) as: **f = Ku**. Let's
-determine the force vector interactively.
+the specimen under a load :math:`P`. The solution as currently derived is
+expressed in terms of a global displacement vector :math:`u`. The global
+(residual) force vector :math:`f` is a function of the global displacement
+vector and the global stiffness matrix  :math:`K` as: :math:`f = Ku`.
+Let's determine the force vector interactively.
 
 Running SfePy in interactive mode
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In addition to solving problems using the simple.py script you can also run
-SfePy interactively. We will use `IPython`_ with custom imports, as described
-in :ref:`using-ipython`. In the SfePy top-level directory::
+In addition to solving problems using the `simple.py` script you can also run
+*SfePy* interactively (we will use `IPython`_ interactive shell in following
+examples).
 
-    $ ipython --profile=sfepy
+In the *SfePy* top-level directory run ::
 
-Once the customized ipython shell loads up, issue the following command::
+    $ ipython
+
+and import :ref:`sfepy-custom-imports`. Once the *SfePy* customized IPython
+shell is ready, issue the following command::
 
     In [1]: pb, state = solve_pde('its2D_2.py')
 

--- a/doc/primer.rst
+++ b/doc/primer.rst
@@ -45,10 +45,10 @@ the schematic.
    :align: right
 
 The tensile and compressive stresses that develop in the specimen as a
-result of the point loads P are a function of the diameter :math:`D` and
-thickness :math:`t` of the cylindrical specimen. At the centre of the
+result of the point loads P are a function of the diameter (D) and
+thickness (t) of the cylindrical specimen. At the centre of the
 specimen, the compressive stress is 3 times the tensile stress and the
-analytical formulation for these are respectively:
+analytical formulation for these are, respectively:
 
 .. math::
    :label: eq_tensile_stress
@@ -77,11 +77,11 @@ model. Follow these steps to model the ITS:
 
 #. The ITS specimen has a diameter of 150 mm. Using *Gmsh* add three new
    points (geometry elementary entities) at the following coordinates:
-   :math:`(0.0 0.0), (75.0,0.0) \,\textrm{and}\, (0.0,75.0)`.
+   (0.0 0.0), (75.0,0.0) and (0.0,75.0).
 #. Next add two straight lines connecting the points.
 #. Next add a Circle arc connecting two of the points to form the
    quarter circle segment.
-#. Still under `Geometry` add a ruled surface.
+#. Still under *Geometry* add a ruled surface.
 #. With the geometry of the model defined, add a mesh by clicking on the
    2D button under the Mesh functions.
 
@@ -97,7 +97,7 @@ The figures that follow show the various stages in the model process.
    :width: 20 %
 
 That's the meshing done. Save the mesh in a format that *SfePy*
-recognizes. For now use the `medit` `.mesh` format e.g. `its2D.mesh`.
+recognizes. For now use the **medit** `.mesh` format e.g. `its2D.mesh`.
 
 **Hint:** Check the drop down in the *Save As* dialog for the different
 formats that *Gmsh* can save to.

--- a/doc/primer.rst
+++ b/doc/primer.rst
@@ -45,7 +45,7 @@ The tensile and compressive stresses that develop in the specimen as a
 result of the point loads P are a function of the diameter :math:`D` and
 thickness :math:`t` of the cylindrical specimen. At the centre of the
 specimen, the compressive stress is 3 times the tensile stress and the
-analytical formulation for these are respectively:
+analytical formulation for these are, respectively:
 
 .. math::
    :label: eq_tensile_stress

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -9,10 +9,12 @@ Tutorial
    :local:
    :backlinks: top
 
-*SfePy* can be used in two basic ways:
-  #. a black-box partial differential equation (PDE) solver,
-  #. a Python package to build custom applications involving solving PDEs by
-     the finite element (FE) method.
+
+*SfePy* package can be used in two basic ways as a: (TBD)
+
+#. Black-box Partial Differential Equation (PDE) solver,
+#. Python package to build custom applications involving solving PDEs by the
+ Finite Element Method (FEM).
 
 This tutorial focuses on the first way and introduces the basic concepts
 and nomenclature used in the following parts of the documentation. Check
@@ -25,13 +27,13 @@ Basic notions
 -------------
 
 The simplest way of using *SfePy* is to solve a system of PDEs defined
-in a **problem description file**, also referred to as **input
-file**. In such a file, the problem is described using several keywords
+in a `problem description file`, also referred to as `input
+file`. In such a file, the problem is described using several keywords
 that allow one to define the equations, variables, finite element
-approximations, solvers, solution domain and subdomains etc., see
-:ref:`sec-problem-description-file` for a full list of those keywords.
+approximations, solvers and solution domain and subdomains (see
+:ref:`sec-problem-description-file` for a full list of those keywords).
 
-The syntax of the problem description file is very simple yet powerful,
+The syntax of the `problem description file` is very simple yet powerful,
 as the file itself is just a regular Python module that can be normally
 imported -- no special parsing is necessary. The keywords mentioned above
 are regular Python variables (usually of the `dict` type) with special

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -9,10 +9,11 @@ Tutorial
    :local:
    :backlinks: top
 
-*SfePy* can be used in two basic ways:
-  #. a black-box partial differential equation (PDE) solver,
-  #. a Python package to build custom applications involving solving PDEs by
-     the finite element (FE) method.
+
+*SfePy* package can be used in two basic ways as a: (TBD)
+
+#. Black-box Partial Differential Equation (PDE) solver,
+#. Python package to build custom applications involving solving PDEs by the Finite Element Method (FEM).
 
 This tutorial focuses on the first way and introduces the basic concepts
 and nomenclature used in the following parts of the documentation. Check
@@ -25,13 +26,13 @@ Basic notions
 -------------
 
 The simplest way of using *SfePy* is to solve a system of PDEs defined
-in a **problem description file**, also referred to as **input
-file**. In such a file, the problem is described using several keywords
+in a `problem description file`, also referred to as `input
+file`. In such a file, the problem is described using several keywords
 that allow one to define the equations, variables, finite element
-approximations, solvers, solution domain and subdomains etc., see
-:ref:`sec-problem-description-file` for a full list of those keywords.
+approximations, solvers and solution domain and subdomains (see
+:ref:`sec-problem-description-file` for a full list of those keywords).
 
-The syntax of the problem description file is very simple yet powerful,
+The syntax of the `problem description file` is very simple yet powerful,
 as the file itself is just a regular Python module that can be normally
 imported -- no special parsing is necessary. The keywords mentioned above
 are regular Python variables (usually of the `dict` type) with special
@@ -47,7 +48,7 @@ But let us begin with a slight detour...
 Sneak peek: what is going on under the hood
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-#. A top-level script (usually ``simple.py`` as in this tutorial) reads
+#. A top-level script (usually `simple.py` as in this tutorial) reads
    in an input file.
 
 #. Following the contents of the input file, a :class:`Problem
@@ -98,15 +99,16 @@ This section introduces the basics of running *SfePy* on the command line. The
 ``$`` indicates the command prompt of your terminal.
 
 * The script ``simple.py`` is the most basic starting point in *SfePy*. It is
-  invoked as follows::
+  invoked as follows (depending on type of your setup)::
 
     $ ./simple.py examples/diffusion/poisson_short_syntax.py
 
-  or ::
+  or use the main wrap-on *SfePy* startup script::
 
     $ ./sfepy-run simple examples/diffusion/poisson_short_syntax.py
 
-* ``examples/diffusion/poisson_short_syntax.py`` is the *SfePy*
+* :download:`examples/diffusion/poisson_short_syntax.py
+  <../examples/diffusion/poisson_short_syntax.py>` is the *SfePy*
   :ref:`sec-problem-description-file`, which defines the problem to be
   solved in terms *SfePy* can understand.
 
@@ -125,7 +127,7 @@ This section introduces the basics of running *SfePy* on the command line. The
 Postprocessing the results
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* The ``postproc.py`` script can be used for quick postprocessing and
+* The `postproc.py` script can be used for quick postprocessing and
   visualization of the *SfePy* output files. It requires `mayavi`_ installed
   on your system.
 
@@ -401,11 +403,12 @@ In the *SfePy* top-level directory, run ::
 
     $ ipython
 
-and load custom *SfePy* imports:
+and load :ref:`SfePy custom imports <sfepy-custom-imports>`:
 
 .. sourcecode:: ipython
 
     In [1]:  import numpy as nm
+
     In [2]:  from sfepy.base.base import IndexedStruct
     In [3]:  from sfepy.discrete import (FieldVariable, Material, Integral, Function,
        ...:                              Equation, Equations, Problem)

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -31,33 +31,44 @@ Invoking *SfePy* from the Command Line
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This section introduces the basics of running *SfePy* from the command line.
-The ``$`` indicates the command prompt of your terminal.
 
-* The script `simple.py` is the most basic starting point in *SfePy*. It
-  can be invoked either directly::
+The script `simple.py` is the **most basic starting point** in *SfePy*. It can
+be invoked in many (similar) ways which depends on used OS, Python distribution
+and *SfePy* build method (see :ref:`installing_sfepy` for further info). All
+(working) alternatives described below are interchangeable, so don't panic and
+feel free to pick your preferred choice (see :ref:`basic-usage` for further
+explanation and more usage examples).
 
-    $ ./simple.py <problem_description_file.py>
+Depending on selected build method and OS used we recommend:
 
-  resp. ::
+* In-place build
 
-    $ python ./simple.py <problem_description_file.py>
+  Use the top-level directory of *SfePy* source tree as your working directory
+  and use::
 
-  or use can use the main :ref:`command wrapper <SfePy-command-wrapper>`::
+    ./simple.py <problem_description_file>
 
-    $ ./sfepy-run simple <problem_description_file.py>
+  or (particularly on Windows based systems) ::
 
-  resp. ::
+    python ./simple.py <problem_description_file>
 
-    $ sfepy-run simple <problem_description_file.py>
+* Installed (local or system-wide) build
 
-  or even ::
+  Use any working directory including your `problem description file` and use::
 
-    $ python sfepy-run simple <problem_description_file.py>
+    python <path/to/installed/simple.py> <problem_description_file>
 
-Please note, that concrete command line usage may vary and highly depends on
-installed Python distribution and used OS (see :ref:`installing_sfepy` for
-further info). All (working) alternatives described above are interchangeable,
-so feel free to pick your choice.
+  or simply (on Unix based systems) ::
+
+    <path/to/installed/simple.py> <problem_description_file>
+
+  You can also use the simple *SfePy* `command-wrapper` (ensure that *SfePy*
+  installation `executable` directory is included in your PATH)::
+
+    sfepy-run simple <problem_description_file>
+
+Please note, that improper mixing of `in-place` and `install` builds on single
+command line may result in strange runtime errors.
 
 
 Using *SfePy* Interactively

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -11,8 +11,8 @@ Tutorial
 
 *SfePy* can be used in two basic ways:
   #. a black-box partial differential equation (PDE) solver,
-  #. a Python package to build custom applications involving solving PDEs by the
-     finite element (FE) method.
+  #. a Python package to build custom applications involving solving PDEs by
+     the finite element (FE) method.
 
 This tutorial focuses on the first way and introduces the basic concepts
 and nomenclature used in the following parts of the documentation. Check
@@ -33,7 +33,7 @@ approximations, solvers, solution domain and subdomains etc., see
 
 The syntax of the problem description file is very simple yet powerful,
 as the file itself is just a regular Python module that can be normally
-imported - no special parsing is necessary. The keywords mentioned above
+imported -- no special parsing is necessary. The keywords mentioned above
 are regular Python variables (usually of the `dict` type) with special
 names.
 
@@ -47,37 +47,37 @@ But let us begin with a slight detour...
 Sneak peek: what is going on under the hood
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-#. A top-level script (usually ``simple.py``, as in this tutorial) reads
+#. A top-level script (usually ``simple.py`` as in this tutorial) reads
    in an input file.
 
 #. Following the contents of the input file, a :class:`Problem
-   <sfepy.discrete.problem.Problem>` instance is created - this
+   <sfepy.discrete.problem.Problem>` instance is created -- this
    is the input file coming to life. Let us call the instance
-   ``problem``.
+   :class:`Problem <sfepy.discrete.problem.Problem>`.
 
-   * The ``problem`` sets up its domain, regions (various sub-domains),
-     fields (the FE approximations), the equations and the solvers. The
-     equations determine the materials and variables in use - only those
-     are fully instantiated, so the input file can safely contain
-     definitions of items that are not used actually.
+   * The :class:`Problem <sfepy.discrete.problem.Problem>` sets up its domain,
+     regions (various sub-domains), fields (the FE approximations), the
+     equations and the solvers. The equations determine the materials and
+     variables in use -- only those are fully instantiated, so the input
+     file can safely contain definitions of items that are not used actually.
 
-#. Prior to solution, ``problem.time_update()`` function has to be
+#. Prior to solution, `problem.time_update()` function has to be
    called to setup boundary conditions, material parameters and other
    potentially time-dependent data. This holds also for stationary
    problems with a single "time step".
 
-#. The solution is then obtained by calling ``problem.solve()``
+#. The solution is then obtained by calling `problem.solve()`
    function.
 
-#. Finally, the solution can be stored using ``problem.save_state()``.
+#. Finally, the solution can be stored using `problem.save_state()`.
 
-The above last three steps are essentially repeated for each time
-step. So that is it - using the code a black-box PDE solver shields the
-user from having to create the :class:`Problem
-<sfepy.discrete.problem.Problem>` instance by hand. But note
-that this is possible, and often necessary when the flexibility of the
+The above last three steps are essentially repeated for each time step. So that
+is it -- using the code a black-box PDE solver shields the user from having to
+create the :class:`Problem <sfepy.discrete.problem.Problem>` instance by hand.
+But note that this is possible, and often necessary when the flexibility of the
 default solvers is not enough. At the end of the tutorial an example
-demonstrating the interactive creation of the ``problem`` is shown, see
+demonstrating the interactive creation of the
+:class:`Problem <sfepy.discrete.problem.Problem>`  is shown, see
 :ref:`sec-interactive-example-linear-elasticity`.
 
 Now let us continue with running a simulation.
@@ -102,18 +102,21 @@ This section introduces the basics of running *SfePy* on the command line. The
 
     $ ./simple.py examples/diffusion/poisson_short_syntax.py
 
-  * ``examples/diffusion/poisson_short_syntax.py`` is the *SfePy*
-    *problem description* file, which defines the problem to be solved
-    in terms *SfePy* can understand.
+  or ::
 
-  * Running the above command creates the output file ``cylinder.vtk`` in the
-    *SfePy* top-level directory.
+    $ ./sfepy-run simple examples/diffusion/poisson_short_syntax.py
 
-* *SfePy* can also be invoked interactively using `IPython`_ with custom
-  imports, as described in :ref:`using-ipython`. In the SfePy top-level
-  directory, run::
+* ``examples/diffusion/poisson_short_syntax.py`` is the *SfePy*
+  :ref:`sec-problem-description-file`, which defines the problem to be
+  solved in terms *SfePy* can understand.
 
-    $ ipython --profile=sfepy
+* Running the above command creates the output file ``cylinder.vtk`` in the
+  *SfePy* top-level directory.
+
+* *SfePy* can also be invoked using `IPython`_ interactive shell from the
+  *SfePy* top-level directory::
+
+    $ ipython
 
   See :ref:`sec-interactive-example-linear-elasticity` for more information.
 
@@ -123,27 +126,26 @@ Postprocessing the results
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * The ``postproc.py`` script can be used for quick postprocessing and
-  visualization of the *SfePy* output files. It requires mayavi2 installed on
-  your system.
+  visualization of the *SfePy* output files. It requires `mayavi`_ installed
+  on your system.
 
-  * As a simple example, try::
+* As a simple example, try::
 
-    $ ./postproc.py cylinder.vtk
+  $ ./postproc.py cylinder.vtk
 
-  * The following interactive 3D window should display:
+* The following interactive 3D window should display:
 
 .. image:: images/postproc_simple.png
    :width: 70 %
    :align: center
 
-* The left mouse button by itself orbits the 3D view.
+* You can manipulate displayed image using:
 
-* Holding shift and the left mouse button pans the view.
-
-* Holding control and the left mouse button rotates about the screen normal
-    axis.
-
-* The right mouse button controls the zoom.
+  * the left mouse button by itself orbits the 3D view,
+  * holding shift and the left mouse button pans the view,
+  * holding control and the left mouse button rotates about the screen normal
+    axis,
+  * the right mouse button controls the zoom.
 
 .. _poisson-example-tutorial:
 
@@ -190,7 +192,7 @@ actual problem definition.
 
 Open the :download:`examples/diffusion/poisson_short_syntax.py
 <../examples/diffusion/poisson_short_syntax.py>` file in your favorite text
-editor. Note that the file is a regular python source code.
+editor. Note that the file is a regular Python source code.
 
 ::
 
@@ -198,7 +200,7 @@ editor. Note that the file is a regular python source code.
 
     filename_mesh = data_dir + '/meshes/3d/cylinder.mesh'
 
-The ``filename_mesh`` variable points to the file containing the mesh for the
+The `filename_mesh` variable points to the file containing the mesh for the
 particular problem. *SfePy* supports a variety of mesh formats.
 
 ::
@@ -208,8 +210,8 @@ particular problem. *SfePy* supports a variety of mesh formats.
     }
 
 Here we define just a constant coefficient :math:`c` of the Poisson
-equation, using the ``'values'`` attribute. Other possible attribute is
-``'function'``, for material coefficients computed/obtained at runtime.
+equation, using the `'values'` attribute. Other possible attribute is
+`'function'` for material coefficients computed/obtained at runtime.
 
 Many finite element problems require the definition of material parameters.
 These can be handled in *SfePy* with material variables which associate the
@@ -224,11 +226,11 @@ material parameters with the corresponding region of the mesh.
    }
 
 Regions assign names to various parts of the finite element mesh. The region
-names can later be referred to, for example when specifying portions of the mesh
-to apply boundary conditions to. Regions can be specified in a variety of ways,
-including by element or by node. Here, Omega is the elemental domain over which
-the PDE is solved and Gamma_Left and Gamma_Right define surfaces upon which the
-boundary conditions will be applied.
+names can later be referred to, for example when specifying portions of the
+mesh to apply boundary conditions to. Regions can be specified in a variety of
+ways, including by element or by node. Here, `'Omega'` is the elemental
+domain over which the PDE is solved and `'Gamma_Left'` and `'Gamma_Right'`
+define surfaces upon which the boundary conditions will be applied.
 
 ::
 
@@ -240,7 +242,7 @@ A field is used mainly to define the approximation on a (sub)domain, i.e. to
 define the discrete spaces :math:`V_h`, where we seek the solution.
 
 The Poisson equation can be used to compute e.g. a temperature distribution,
-so let us call our field ``'temperature'``. On the region ``'Omega'``
+so let us call our field `'temperature'`. On the region `'Omega'`
 it will be approximated using linear finite elements.
 
 A field in a given region defines the finite element approximation.
@@ -255,10 +257,10 @@ Several variables can use the same field, see below.
 
 One field can be used to generate discrete degrees of freedom (DOFs) of
 several variables. Here the unknown variable (the temperature) is called
-``'t'``, it's associated DOF name is ``'t.0'`` --- this will be referred
-to in the Dirichlet boundary section (``ebc``). The corresponding test
-variable of the weak formulation is called ``'s'``. Notice that the
-``'dual'`` item of a test variable must specify the unknown it
+`'t'`, it's associated DOF name is `'t.0'` -- this will be referred
+to in the Dirichlet boundary section (`ebc`). The corresponding test
+variable of the weak formulation is called `'s'`. Notice that the
+`'dual'` item of a test variable must specify the unknown it
 corresponds to.
 
 For each unknown (or state) variable there has to be a test (or virtual)
@@ -275,8 +277,8 @@ Essential (Dirichlet) boundary conditions can be specified as above.
 
 Boundary conditions place restrictions on the finite element formulation and
 create a unique solution to the problem. Here, we specify that a temperature of
-+2 is applied to the left surface of the mesh and a temperature of -2 is applied
-to the right surface.
++2 is applied to the left surface of the mesh and a temperature of -2 is
+applied to the right surface.
 
 ::
 
@@ -304,9 +306,9 @@ where :math:`\nabla u \approx \bm{G} \bm{u}`.
 
 The equations block is the heart of the *SfePy* problem definition file. Here,
 we are specifying that the Laplacian of the temperature (in the weak
-formulation) is 0, where ``coef.val`` is a material constant. We are using the
-``i`` integral defined previously, over the domain specified by the region
-Omega.
+formulation) is 0, where `coef.val` is a material constant. We are using the
+`'i'` integral defined previously, over the domain specified by the region
+`'Omega'`.
 
 The above syntax is useful for defining *custom integrals* with
 user-defined quadrature points and weights, see :ref:`ug_integrals`. The
@@ -329,11 +331,12 @@ name. The integral definition is superfluous in this case.
        }),
    }
 
-Here, we specify the linear and nonlinear solver kind and options. The convergence
-parameters can be adjusted if necessary, otherwise leave the default.
+Here, we specify the linear and nonlinear solver kind and options. The
+convergence parameters can be adjusted if necessary, otherwise leave the
+default.
 
-Even linear problems are solved by a nonlinear solver (KISS rule) - only one
-iteration is needed and the final rezidual is obtained for free.
+Even linear problems are solved by a nonlinear solver (KISS rule) -- only one
+iteration is needed and the final residual is obtained for free.
 
 ::
 
@@ -354,9 +357,9 @@ Interactive Example: Linear Elasticity
 --------------------------------------
 
 This example shows how to use *SfePy* interactively, but also how to make a
-custom simulation script. We will use `IPython`_ with custom imports, as
-described in :ref:`using-ipython`, for the explanation, but regular Python
-shell would do as well, provided the proper modules are imported.
+custom simulation script. We will use `IPython`_ interactive shell which
+allows more flexible and intuitive work (but you cau use standard Python
+shell as well).
 
 We wish to solve the following linear elasticity problem:
 
@@ -388,42 +391,58 @@ where :math:`\ul{v}` is the test function, and both :math:`\ul{u}`,
 :math:`\ul{v}` belong to a suitable function space.
 
 **Hint:** Whenever you create a new object (e.g. a Mesh instance, see
-below), try to print it using the `print` statement - it will give you
+below), try to print it using the `print` statement -- it will give you
 insight about the object internals.
 
-The whole example summarized in a script is below in
+The whole example summarized in a script is available below in
 :ref:`tutorial_interactive_source`.
 
-In the *SfePy* top-level directory, run::
+In the *SfePy* top-level directory, run ::
 
-    $ ipython --profile=sfepy
+    $ ipython
+
+and load custom *SfePy* imports:
+
+.. sourcecode:: ipython
+
+    In [1]:  import numpy as nm
+    In [2]:  from sfepy.base.base import IndexedStruct
+    In [3]:  from sfepy.discrete import (FieldVariable, Material, Integral, Function,
+       ...:                              Equation, Equations, Problem)
+    In [4]:  from sfepy.discrete.fem import Mesh, FEDomain, Field
+    In [5]:  from sfepy.terms import Term
+    In [6]:  from sfepy.discrete.conditions import Conditions, EssentialBC
+    In [7]:  from sfepy.solvers.ls import ScipyDirect
+    In [8]:  from sfepy.solvers.nls import Newton
+    In [9]:  from sfepy.postprocess.viewer import Viewer
+    In [10]: from sfepy.mechanics.matcoefs import stiffness_from_lame
 
 Read a finite element mesh, that defines the domain :math:`\Omega`.
 
 .. sourcecode:: ipython
 
-    In [1]: mesh = Mesh.from_file('meshes/2d/rectangle_tri.mesh')
+    In [11]: mesh = Mesh.from_file('meshes/2d/rectangle_tri.mesh')
 
 Create a domain. The domain allows defining regions or subdomains.
 
 .. sourcecode:: ipython
 
-    In [2]: domain = FEDomain('domain', mesh)
+    In [12]: domain = FEDomain('domain', mesh)
 
-Define the regions - the whole domain :math:`\Omega`, where the solution
+Define the regions -- the whole domain :math:`\Omega`, where the solution
 is sought, and :math:`\Gamma_1`, :math:`\Gamma_2`, where the boundary
 conditions will be applied. As the domain is rectangular, we first get a
 bounding box to get correct bounds for selecting the boundary edges.
 
 .. sourcecode:: ipython
 
-    In [3]: min_x, max_x = domain.get_mesh_bounding_box()[:, 0]
-    In [4]: eps = 1e-8 * (max_x - min_x)
-    In [5]: omega = domain.create_region('Omega', 'all')
-    In [6]: gamma1 = domain.create_region('Gamma1',
+    In [13]: min_x, max_x = domain.get_mesh_bounding_box()[:, 0]
+    In [14]: eps = 1e-8 * (max_x - min_x)
+    In [15]: omega = domain.create_region('Omega', 'all')
+    In [16]: gamma1 = domain.create_region('Gamma1',
        ...:                               'vertices in x < %.10f' % (min_x + eps),
        ...:                               'facet')
-    In [7]: gamma2 = domain.create_region('Gamma2',
+    In [17]: gamma2 = domain.create_region('Gamma2',
        ...:                               'vertices in x > %.10f' % (max_x - eps),
        ...:                               'facet')
 
@@ -432,7 +451,7 @@ Next we define the actual finite element approximation using the
 
 .. sourcecode:: ipython
 
-    In [8]: field = Field.from_args('fu', nm.float64, 'vector', omega,
+    In [18]: field = Field.from_args('fu', nm.float64, 'vector', omega,
        ...:                         space='H1', poly_space_base='lagrange',
        ...:                         approx_order=2)
 
@@ -441,38 +460,37 @@ the test variable :math:`\vb`.
 
 .. sourcecode:: ipython
 
-    In [9]: u = FieldVariable('u', 'unknown', field)
-    In [10]: v = FieldVariable('v', 'test', field, primary_var_name='u')
+    In [19]: u = FieldVariable('u', 'unknown', field)
+    In [20]: v = FieldVariable('v', 'test', field, primary_var_name='u')
 
 Before we can define the terms to build the equation of linear
 elasticity, we have to create also the materials, i.e. define the
 (constitutive) parameters. The linear elastic material `m` will be
 defined using the two Lamé constants :math:`\lambda = 1`, :math:`\mu =
-1`. The volume forces will be defined also as a material, as a constant
+1`. The volume forces will be defined also as a material as a constant
 (column) vector :math:`[0.02, 0.01]^T`.
 
 .. sourcecode:: ipython
 
-    In [11]: m = Material('m', lam=1.0, mu=1.0)
-    In [12]: f = Material('f', val=[[0.02], [0.01]])
+    In [21]: m = Material('m', lam=1.0, mu=1.0)
+    In [22]: f = Material('f', val=[[0.02], [0.01]])
 
-One more thing needs to be defined - the numerical quadrature that will
+One more thing needs to be defined -- the numerical quadrature that will
 be used to integrate each term over its domain.
 
 .. sourcecode:: ipython
 
-    In [14]: integral = Integral('i', order=3)
+    In [23]: integral = Integral('i', order=3)
 
 Now we are ready to define the two terms and build the equations.
 
 .. sourcecode:: ipython
 
-    In [15]: from sfepy.terms import Term
-    In [16]: t1 = Term.new('dw_lin_elastic_iso(m.lam, m.mu, v, u)',
+    In [24]: t1 = Term.new('dw_lin_elastic_iso(m.lam, m.mu, v, u)',
                   integral, omega, m=m, v=v, u=u)
-    In [17]: t2 = Term.new('dw_volume_lvf(f.val, v)', integral, omega, f=f, v=v)
-    In [18]: eq = Equation('balance', t1 + t2)
-    In [19]: eqs = Equations([eq])
+    In [25]: t2 = Term.new('dw_volume_lvf(f.val, v)', integral, omega, f=f, v=v)
+    In [26]: eq = Equation('balance', t1 + t2)
+    In [27]: eqs = Equations([eq])
 
 The equations have to be completed by boundary conditions. Let us clamp
 the left edge :math:`\Gamma_1`, and shift the right edge
@@ -481,50 +499,47 @@ the left edge :math:`\Gamma_1`, and shift the right edge
 
 .. sourcecode:: ipython
 
-   In [20]: from sfepy.discrete.conditions import Conditions, EssentialBC
-   In [21]: fix_u = EssentialBC('fix_u', gamma1, {'u.all' : 0.0})
-   In [22]: def shift_u_fun(ts, coors, bc=None, problem=None, shift=0.0):
+   In [28]: fix_u = EssentialBC('fix_u', gamma1, {'u.all' : 0.0})
+   In [29]: def shift_u_fun(ts, coors, bc=None, problem=None, shift=0.0):
       ....:     val = shift * coors[:,1]**2
       ....:     return val
-   In [23]: bc_fun = Function('shift_u_fun', shift_u_fun,
+   In [30]: bc_fun = Function('shift_u_fun', shift_u_fun,
       ....:                   extra_args={'shift' : 0.01})
-   In [24]: shift_u = EssentialBC('shift_u', gamma2, {'u.0' : bc_fun})
+   In [31]: shift_u = EssentialBC('shift_u', gamma2, {'u.0' : bc_fun})
 
 The last thing to define before building the problem are the
-solvers. Here we just use a sparse direct SciPy solver and the SfePy
-Newton solver with default parameters. We also wish to store the
-convergence statistics of the Newton solver. As the problem is linear,
+solvers. Here we just use a sparse direct *SciPy solver* and the *SfePy
+Newton solver* with default parameters. We also wish to store the
+convergence statistics of the Newton solver. As the problem is linear
 it should converge in one iteration.
 
 .. sourcecode:: ipython
 
-    In [25]: from sfepy.solvers.ls import ScipyDirect
-    In [26]: from sfepy.solvers.nls import Newton
-    In [27]: ls = ScipyDirect({})
-    In [28]: nls_status = IndexedStruct()
-    In [29]: nls = Newton({}, lin_solver=ls, status=nls_status)
+    In [32]: ls = ScipyDirect({})
+    In [33]: nls_status = IndexedStruct()
+    In [34]: nls = Newton({}, lin_solver=ls, status=nls_status)
 
-Now we are ready to create a :class:`Problem` instance. Note
-that the step above is not really necessary - the above solvers are
-constructed by default. We did them to get the `nls_status`.
+Now we are ready to create a :class:`Problem <sfepy.discrete.problem.Problem>`
+instance. Note that the step above is not really necessary -- the above solvers
+are constructed by default. We did them to get the `nls_status`.
 
 .. sourcecode:: ipython
 
-    In [30]: pb = Problem('elasticity', equations=eqs, nls=nls, ls=ls)
+    In [35]: pb = Problem('elasticity', equations=eqs, nls=nls, ls=ls)
 
-The :class:`Problem` has several handy methods for
-debugging. Let us try saving the regions into a VTK file.
+The :class:`Problem <sfepy.discrete.problem.Problem>` has several handy methods
+for debugging. Let us try saving the regions into a VTK file.
 
 .. sourcecode:: ipython
 
-    In [31]: pb.save_regions_as_groups('regions')
+    In [36]: pb.save_regions_as_groups('regions')
 
 And view them.
 
 .. sourcecode:: ipython
 
-    In [32]: view = Viewer('regions.vtk')
-    In [33]: view()
+    In [37]: view = Viewer('regions.vtk')
+    In [38]: view()
 
 You should see this:
 
@@ -537,12 +552,12 @@ view the results.
 
 .. sourcecode:: ipython
 
-    In [34]: pb.time_update(ebcs=Conditions([fix_u, shift_u]))
-    In [35]: vec = pb.solve()
-    In [36]: print nls_status
-    In [37]: pb.save_state('linear_elasticity.vtk', vec)
-    In [38]: view = Viewer('linear_elasticity.vtk')
-    In [39]: view()
+    In [39]: pb.time_update(ebcs=Conditions([fix_u, shift_u]))
+    In [40]: vec = pb.solve()
+    In [41]: print nls_status
+    In [42]: pb.save_state('linear_elasticity.vtk', vec)
+    In [43]: view = Viewer('linear_elasticity.vtk')
+    In [44]: view()
 
 This is the resulting image:
 
@@ -555,7 +570,7 @@ shifting the mesh. Close the previous window and do:
 
 .. sourcecode:: ipython
 
-    In [56]: view(vector_mode='warp_norm', rel_scaling=2,
+    In [45]: view(vector_mode='warp_norm', rel_scaling=2,
        ....:      is_scalar_bar=True, is_wireframe=True)
 
 And the result is:
@@ -572,8 +587,11 @@ Complete Example as a Script
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The source code: :download:`linear_elasticity.py
-<../examples/linear_elasticity/linear_elastic_interactive.py>`. It should be
-run from the *SfePy* source directory so that it finds the mesh file.
+<../examples/linear_elasticity/linear_elastic_interactive.py>`.
+
+This file should be run from the top-level *SfePy* source directory so it can
+find the mesh file correctly. Please note that the provided example script may
+differ from above tutorial in some minor details.
 
 .. literalinclude:: ../examples/linear_elasticity/linear_elastic_interactive.py
    :linenos:

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -42,7 +42,7 @@ The ``$`` indicates the command prompt of your terminal.
 
     $ python ./simple.py <problem_description_file.py>
 
-  or use can use a main :ref:`command wrapper <SfePy-command-wrapper>`::
+  or use can use the main :ref:`command wrapper <SfePy-command-wrapper>`::
 
     $ ./sfepy-run simple <problem_description_file.py>
 
@@ -66,8 +66,8 @@ Using *SfePy* Interactively
 All functions of *SfePy* package can be also used interactively (see
 :ref:`sec-interactive-example-linear-elasticity` for instance).
 
-We recommend to use `IPython`_ interactive shell for best fluent user
-experiences. You can customize your `IPython` startup profile as described in
+We recommend to use the `IPython`_ interactive shell for the best fluent user
+experience. You can customize your `IPython` startup profile as described in
 :ref:`using-ipython`.
 
 Basic Notions
@@ -99,12 +99,11 @@ Sneak Peek: What is Going on Under the Hood
 #. A top-level script (usually `simple.py` as in this tutorial) reads
    in an input file.
 
-#. Following the contents of the input file, a :class:`Problem
-   <sfepy.discrete.problem.Problem>` instance is created -- this
-   is the input file coming to life. Let us call the instance
-   :class:`Problem <sfepy.discrete.problem.Problem>`.
+#. Following the contents of the input file, a `Problem` instance is created
+   -- this is the input file coming to life. Let us call the instance
+   `Problem`.
 
-   * The :class:`Problem <sfepy.discrete.problem.Problem>` sets up its domain,
+   * The `Problem` sets up its domain,
      regions (various sub-domains), fields (the FE approximations), the
      equations and the solvers. The equations determine the materials and
      variables in use -- only those are fully instantiated, so the input
@@ -122,12 +121,10 @@ Sneak Peek: What is Going on Under the Hood
 
 The above last three steps are essentially repeated for each time step. So that
 is it -- using the code a black-box PDE solver shields the user from having to
-create the :class:`Problem <sfepy.discrete.problem.Problem>` instance by hand.
-But note that this is possible, and often necessary when the flexibility of the
-default solvers is not enough. At the end of the tutorial an example
-demonstrating the interactive creation of the
-:class:`Problem <sfepy.discrete.problem.Problem>`  is shown, see
-:ref:`sec-interactive-example-linear-elasticity`.
+create the `Problem` instance by hand. But note that this is possible, and
+often necessary when the flexibility of the default solvers is not enough. At
+the end of the tutorial an example demonstrating the interactive creation of
+the `Problem`  is shown, see :ref:`sec-interactive-example-linear-elasticity`.
 
 Now let us continue with running a simulation.
 
@@ -143,9 +140,9 @@ source tree after compiling the C extension files. See
   *SfePy* :ref:`sec-problem-description-file`, which defines the problem to be
   solved in terms *SfePy* can understand.
 
-* Use downloaded file as `<problem_description_file.py>` and run `simple.py`
-  as :ref:`described above <invoking_from_command_line>`. Successful
-  execution of the command creates output
+* Use the downloaded file in place of `<problem_description_file.py>` and
+  run `simple.py` as :ref:`described above <invoking_from_command_line>`.
+  The successful execution of the command creates output
   file ``cylinder.vtk`` in the *SfePy* top-level directory.
 
 .. _postprocessing:
@@ -332,7 +329,7 @@ The equation above directly corresponds to the discrete version of
 
 where :math:`\nabla u \approx \bm{G} \bm{u}`.
 
-The equations block is the heart of the *SfePy* problem definition file. Here,
+The equations block is the heart of the *SfePy* problem description file. Here,
 we are specifying that the Laplacian of the temperature (in the weak
 formulation) is 0, where `coef.val` is a material constant. We are using the
 `'i'` integral defined previously, over the domain specified by the region
@@ -386,7 +383,7 @@ Interactive Example: Linear Elasticity
 
 This example shows how to use *SfePy* interactively, but also how to make a
 custom simulation script. We will use `IPython`_ interactive shell which
-allows more flexible and intuitive work (but you cau use standard Python
+allows more flexible and intuitive work (but you can use standard Python
 shell as well).
 
 We wish to solve the following linear elasticity problem:
@@ -431,8 +428,8 @@ In the *SfePy* top-level directory run ::
 
 .. sourcecode:: ipython
 
-    In [1]:  import numpy as nm
-    In [2]:  from sfepy.discrete.fem import Mesh, FEDomain, Field
+    In [1]: import numpy as nm
+    In [2]: from sfepy.discrete.fem import Mesh, FEDomain, Field
 
 Read a finite element mesh, that defines the domain :math:`\Omega`.
 
@@ -469,7 +466,6 @@ Next we define the actual finite element approximation using the
 .. sourcecode:: ipython
 
     In [10]: field = Field.from_args('fu', nm.float64, 'vector', omega,
-       ...:                          space='H1', poly_space_base='lagrange',
        ...:                          approx_order=2)
 
 Using the field `fu`, we can define both the unknown variable :math:`\ub` and
@@ -550,9 +546,9 @@ it should converge in one iteration.
     In [32]: nls_status = IndexedStruct()
     In [33]: nls = Newton({}, lin_solver=ls, status=nls_status)
 
-Now we are ready to create a :class:`Problem <sfepy.discrete.problem.Problem>`
-instance. Note that the step above is not really necessary -- the above solvers
-are constructed by default. We did them to get the `nls_status`.
+Now we are ready to create a `Problem` instance. Note that the step above is
+not really necessary -- the above solvers are constructed by default. We did
+them to get the `nls_status`.
 
 .. sourcecode:: ipython
 

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -9,11 +9,14 @@ Tutorial
    :local:
    :backlinks: top
 
+Basic *SfePy* Usage
+-------------------
 
-*SfePy* package can be used in two basic ways as a: (TBD)
+*SfePy* package can be used in two basic ways as a:
 
 #. Black-box Partial Differential Equation (PDE) solver,
-#. Python package to build custom applications involving solving PDEs by the Finite Element Method (FEM).
+#. Python package to build custom applications
+   involving solving PDEs by the Finite Element Method (FEM).
 
 This tutorial focuses on the first way and introduces the basic concepts
 and nomenclature used in the following parts of the documentation. Check
@@ -22,7 +25,52 @@ also the :doc:`primer` which focuses on a particular problem in detail.
 Users not familiar with the finite element method should start with the
 :ref:`sec-solving-pdes-fem`.
 
-Basic notions
+.. _invoking_from_command_line:
+
+Invoking *SfePy* from the Command Line
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This section introduces the basics of running *SfePy* from the command line.
+The ``$`` indicates the command prompt of your terminal.
+
+* The script `simple.py` is the most basic starting point in *SfePy*. It
+  can be invoked either directly::
+
+    $ ./simple.py <problem_description_file.py>
+
+  resp. ::
+
+    $ python ./simple.py <problem_description_file.py>
+
+  or use can use a main :ref:`command wrapper <SfePy-command-wrapper>`::
+
+    $ ./sfepy-run simple <problem_description_file.py>
+
+  resp. ::
+
+    $ sfepy-run simple <problem_description_file.py>
+
+  or even ::
+
+    $ python sfepy-run simple <problem_description_file.py>
+
+Please note, that concrete command line usage may vary and highly depends on
+installed Python distribution and used OS (see :ref:`installing_sfepy` for
+further info). All (working) alternatives described above are interchangeable,
+so feel free to pick your choice.
+
+
+Using *SfePy* Interactively
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+All functions of *SfePy* package can be also used interactively (see
+:ref:`sec-interactive-example-linear-elasticity` for instance).
+
+We recommend to use `IPython`_ interactive shell for best fluent user
+experiences. You can customize your `IPython` startup profile as described in
+:ref:`using-ipython`.
+
+Basic Notions
 -------------
 
 The simplest way of using *SfePy* is to solve a system of PDEs defined
@@ -40,12 +88,12 @@ names.
 
 Below we show:
 
-#. how to solve a problem given by a problem description file, and
-#. explain the elements of the file on several examples.
+* how to solve a problem given by a problem description file, and
+* explain the elements of the file on several examples.
 
 But let us begin with a slight detour...
 
-Sneak peek: what is going on under the hood
+Sneak Peek: What is Going on Under the Hood
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 #. A top-level script (usually `simple.py` as in this tutorial) reads
@@ -83,48 +131,26 @@ demonstrating the interactive creation of the
 
 Now let us continue with running a simulation.
 
-Running a simulation
+Running a Simulation
 --------------------
 
 The following commands should be run in the top-level directory of the *SfePy*
 source tree after compiling the C extension files. See
 :ref:`introduction_installation` for full installation instructions.
 
-.. _invoking_command_line:
-
-Invoking *SfePy* from the command line
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-This section introduces the basics of running *SfePy* on the command line. The
-``$`` indicates the command prompt of your terminal.
-
-* The script ``simple.py`` is the most basic starting point in *SfePy*. It is
-  invoked as follows (depending on type of your setup)::
-
-    $ ./simple.py examples/diffusion/poisson_short_syntax.py
-
-  or use the main wrap-on *SfePy* startup script::
-
-    $ ./sfepy-run simple examples/diffusion/poisson_short_syntax.py
-
-* :download:`examples/diffusion/poisson_short_syntax.py
-  <../examples/diffusion/poisson_short_syntax.py>` is the *SfePy*
-  :ref:`sec-problem-description-file`, which defines the problem to be
+* Download :download:`examples/diffusion/poisson_short_syntax.py
+  <../examples/diffusion/poisson_short_syntax.py>`. It represents our sample
+  *SfePy* :ref:`sec-problem-description-file`, which defines the problem to be
   solved in terms *SfePy* can understand.
 
-* Running the above command creates the output file ``cylinder.vtk`` in the
-  *SfePy* top-level directory.
-
-* *SfePy* can also be invoked using `IPython`_ interactive shell from the
-  *SfePy* top-level directory::
-
-    $ ipython
-
-  See :ref:`sec-interactive-example-linear-elasticity` for more information.
+* Use downloaded file as `<problem_description_file.py>` and run `simple.py`
+  as :ref:`described above <invoking_from_command_line>`. Successful
+  execution of the command creates output
+  file ``cylinder.vtk`` in the *SfePy* top-level directory.
 
 .. _postprocessing:
 
-Postprocessing the results
+Postprocessing the Results
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * The `postproc.py` script can be used for quick postprocessing and
@@ -151,7 +177,7 @@ Postprocessing the results
 
 .. _poisson-example-tutorial:
 
-Example problem description file
+Example Problem Description File
 --------------------------------
 
 Here we discuss the contents of the
@@ -351,7 +377,7 @@ The solvers to use are specified in the options block. We can define multiple
 solvers with different convergence parameters if necessary.
 
 That's it! Now it is possible to proceed as described in
-:ref:`invoking_command_line`.
+:ref:`invoking_from_command_line`.
 
 .. _sec-interactive-example-linear-elasticity:
 
@@ -408,29 +434,19 @@ and load :ref:`SfePy custom imports <sfepy-custom-imports>`:
 .. sourcecode:: ipython
 
     In [1]:  import numpy as nm
-
-    In [2]:  from sfepy.base.base import IndexedStruct
-    In [3]:  from sfepy.discrete import (FieldVariable, Material, Integral, Function,
-       ...:                              Equation, Equations, Problem)
-    In [4]:  from sfepy.discrete.fem import Mesh, FEDomain, Field
-    In [5]:  from sfepy.terms import Term
-    In [6]:  from sfepy.discrete.conditions import Conditions, EssentialBC
-    In [7]:  from sfepy.solvers.ls import ScipyDirect
-    In [8]:  from sfepy.solvers.nls import Newton
-    In [9]:  from sfepy.postprocess.viewer import Viewer
-    In [10]: from sfepy.mechanics.matcoefs import stiffness_from_lame
+    In [2]:  from sfepy.discrete.fem import Mesh, FEDomain, Field
 
 Read a finite element mesh, that defines the domain :math:`\Omega`.
 
 .. sourcecode:: ipython
 
-    In [11]: mesh = Mesh.from_file('meshes/2d/rectangle_tri.mesh')
+    In [3]: mesh = Mesh.from_file('meshes/2d/rectangle_tri.mesh')
 
 Create a domain. The domain allows defining regions or subdomains.
 
 .. sourcecode:: ipython
 
-    In [12]: domain = FEDomain('domain', mesh)
+    In [4]: domain = FEDomain('domain', mesh)
 
 Define the regions -- the whole domain :math:`\Omega`, where the solution
 is sought, and :math:`\Gamma_1`, :math:`\Gamma_2`, where the boundary
@@ -439,13 +455,13 @@ bounding box to get correct bounds for selecting the boundary edges.
 
 .. sourcecode:: ipython
 
-    In [13]: min_x, max_x = domain.get_mesh_bounding_box()[:, 0]
-    In [14]: eps = 1e-8 * (max_x - min_x)
-    In [15]: omega = domain.create_region('Omega', 'all')
-    In [16]: gamma1 = domain.create_region('Gamma1',
+    In [5]: min_x, max_x = domain.get_mesh_bounding_box()[:, 0]
+    In [6]: eps = 1e-8 * (max_x - min_x)
+    In [7]: omega = domain.create_region('Omega', 'all')
+    In [8]: gamma1 = domain.create_region('Gamma1',
        ...:                               'vertices in x < %.10f' % (min_x + eps),
        ...:                               'facet')
-    In [17]: gamma2 = domain.create_region('Gamma2',
+    In [9]: gamma2 = domain.create_region('Gamma2',
        ...:                               'vertices in x > %.10f' % (max_x - eps),
        ...:                               'facet')
 
@@ -454,17 +470,20 @@ Next we define the actual finite element approximation using the
 
 .. sourcecode:: ipython
 
-    In [18]: field = Field.from_args('fu', nm.float64, 'vector', omega,
-       ...:                         space='H1', poly_space_base='lagrange',
-       ...:                         approx_order=2)
+    In [10]: field = Field.from_args('fu', nm.float64, 'vector', omega,
+       ...:                          space='H1', poly_space_base='lagrange',
+       ...:                          approx_order=2)
 
 Using the field `fu`, we can define both the unknown variable :math:`\ub` and
 the test variable :math:`\vb`.
 
 .. sourcecode:: ipython
 
-    In [19]: u = FieldVariable('u', 'unknown', field)
-    In [20]: v = FieldVariable('v', 'test', field, primary_var_name='u')
+    In [11]: from sfepy.discrete import (FieldVariable, Material, Integral, Function,
+        ...:                             Equation, Equations, Problem)
+
+    In [12]: u = FieldVariable('u', 'unknown', field)
+    In [13]: v = FieldVariable('v', 'test', field, primary_var_name='u')
 
 Before we can define the terms to build the equation of linear
 elasticity, we have to create also the materials, i.e. define the
@@ -475,25 +494,28 @@ defined using the two Lamé constants :math:`\lambda = 1`, :math:`\mu =
 
 .. sourcecode:: ipython
 
-    In [21]: m = Material('m', lam=1.0, mu=1.0)
-    In [22]: f = Material('f', val=[[0.02], [0.01]])
+    In [14]: m = Material('m', lam=1.0, mu=1.0)
+    In [15]: f = Material('f', val=[[0.02], [0.01]])
 
 One more thing needs to be defined -- the numerical quadrature that will
 be used to integrate each term over its domain.
 
 .. sourcecode:: ipython
 
-    In [23]: integral = Integral('i', order=3)
+    In [16]: integral = Integral('i', order=3)
 
 Now we are ready to define the two terms and build the equations.
 
 .. sourcecode:: ipython
 
-    In [24]: t1 = Term.new('dw_lin_elastic_iso(m.lam, m.mu, v, u)',
-                  integral, omega, m=m, v=v, u=u)
-    In [25]: t2 = Term.new('dw_volume_lvf(f.val, v)', integral, omega, f=f, v=v)
-    In [26]: eq = Equation('balance', t1 + t2)
-    In [27]: eqs = Equations([eq])
+    In [17]: from sfepy.terms import Term
+
+    In [18]: Term.new('dw_lin_elastic_iso(m.lam, m.mu, v, u)',
+        ...:          integral, omega, m=m, v=v, u=u)
+    In [19]: t2 = Term.new('dw_volume_lvf(f.val, v)',
+        ...:               integral, omega, f=f, v=v)
+    In [20]: eq = Equation('balance', t1 + t2)
+    In [21]: eqs = Equations([eq])
 
 The equations have to be completed by boundary conditions. Let us clamp
 the left edge :math:`\Gamma_1`, and shift the right edge
@@ -502,13 +524,15 @@ the left edge :math:`\Gamma_1`, and shift the right edge
 
 .. sourcecode:: ipython
 
-   In [28]: fix_u = EssentialBC('fix_u', gamma1, {'u.all' : 0.0})
-   In [29]: def shift_u_fun(ts, coors, bc=None, problem=None, shift=0.0):
-      ....:     val = shift * coors[:,1]**2
-      ....:     return val
-   In [30]: bc_fun = Function('shift_u_fun', shift_u_fun,
-      ....:                   extra_args={'shift' : 0.01})
-   In [31]: shift_u = EssentialBC('shift_u', gamma2, {'u.0' : bc_fun})
+   In [22]: from sfepy.discrete.conditions import Conditions, EssentialBC
+
+   In [23]: fix_u = EssentialBC('fix_u', gamma1, {'u.all' : 0.0})
+   In [24]: def shift_u_fun(ts, coors, bc=None, problem=None, shift=0.0):
+       ...:                 val = shift * coors[:,1]**2
+       ...:                 return val
+   In [25]: bc_fun = Function('shift_u_fun', shift_u_fun,
+       ...:                   extra_args={'shift' : 0.01})
+   In [26]: shift_u = EssentialBC('shift_u', gamma2, {'u.0' : bc_fun})
 
 The last thing to define before building the problem are the
 solvers. Here we just use a sparse direct *SciPy solver* and the *SfePy
@@ -518,9 +542,13 @@ it should converge in one iteration.
 
 .. sourcecode:: ipython
 
-    In [32]: ls = ScipyDirect({})
-    In [33]: nls_status = IndexedStruct()
-    In [34]: nls = Newton({}, lin_solver=ls, status=nls_status)
+    In [27]: from sfepy.base.base import IndexedStruct
+    In [28]: from sfepy.solvers.ls import ScipyDirect
+    In [29]: from sfepy.solvers.nls import Newton
+
+    In [30]: ls = ScipyDirect({})
+    In [31]: nls_status = IndexedStruct()
+    In [32]: nls = Newton({}, lin_solver=ls, status=nls_status)
 
 Now we are ready to create a :class:`Problem <sfepy.discrete.problem.Problem>`
 instance. Note that the step above is not really necessary -- the above solvers
@@ -528,21 +556,23 @@ are constructed by default. We did them to get the `nls_status`.
 
 .. sourcecode:: ipython
 
-    In [35]: pb = Problem('elasticity', equations=eqs, nls=nls, ls=ls)
+    In [33]: pb = Problem('elasticity', equations=eqs, nls=nls, ls=ls)
 
 The :class:`Problem <sfepy.discrete.problem.Problem>` has several handy methods
 for debugging. Let us try saving the regions into a VTK file.
 
 .. sourcecode:: ipython
 
-    In [36]: pb.save_regions_as_groups('regions')
+    In [34]: pb.save_regions_as_groups('regions')
 
 And view them.
 
 .. sourcecode:: ipython
 
-    In [37]: view = Viewer('regions.vtk')
-    In [38]: view()
+    In [35]: from sfepy.postprocess.viewer import Viewer
+
+    In [36]: view = Viewer('regions.vtk')
+    In [37]: view()
 
 You should see this:
 
@@ -555,12 +585,14 @@ view the results.
 
 .. sourcecode:: ipython
 
-    In [39]: pb.time_update(ebcs=Conditions([fix_u, shift_u]))
-    In [40]: vec = pb.solve()
-    In [41]: print nls_status
-    In [42]: pb.save_state('linear_elasticity.vtk', vec)
-    In [43]: view = Viewer('linear_elasticity.vtk')
-    In [44]: view()
+    In [38]: pb.time_update(ebcs=Conditions([fix_u, shift_u]))
+    In [39]: vec = pb.solve()
+
+    In [40]: print(nls_status)
+
+    In [41]: pb.save_state('linear_elasticity.vtk', vec)
+    In [42]: view = Viewer('linear_elasticity.vtk')
+    In [43]: view()
 
 This is the resulting image:
 
@@ -573,8 +605,8 @@ shifting the mesh. Close the previous window and do:
 
 .. sourcecode:: ipython
 
-    In [45]: view(vector_mode='warp_norm', rel_scaling=2,
-       ....:      is_scalar_bar=True, is_wireframe=True)
+    In [44]: view(vector_mode='warp_norm', rel_scaling=2,
+        ...:      is_scalar_bar=True, is_wireframe=True)
 
 And the result is:
 

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -112,9 +112,9 @@ Sneak Peek: What is Going on Under the Hood
 
 #. Following the contents of the input file, a `Problem` instance is created
    -- this is the input file coming to life. Let us call the instance
-   `Problem`.
+   `problem`.
 
-   * The `Problem` sets up its domain,
+   * The `Problem` instance sets up its domain,
      regions (various sub-domains), fields (the FE approximations), the
      equations and the solvers. The equations determine the materials and
      variables in use -- only those are fully instantiated, so the input
@@ -135,7 +135,8 @@ is it -- using the code a black-box PDE solver shields the user from having to
 create the `Problem` instance by hand. But note that this is possible, and
 often necessary when the flexibility of the default solvers is not enough. At
 the end of the tutorial an example demonstrating the interactive creation of
-the `Problem`  is shown, see :ref:`sec-interactive-example-linear-elasticity`.
+the `Problem` instance is shown, see
+:ref:`sec-interactive-example-linear-elasticity`.
 
 Now let us continue with running a simulation.
 
@@ -472,7 +473,7 @@ bounding box to get correct bounds for selecting the boundary edges.
        ...:                               'facet')
 
 Next we define the actual finite element approximation using the
-:class:`Field` class.
+:class:`Field <sfepy.discrete.common.fields.Field>` class.
 
 .. sourcecode:: ipython
 

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -39,7 +39,7 @@ and *SfePy* build method (see :ref:`installing_sfepy` for further info). All
 feel free to pick your preferred choice (see :ref:`basic-usage` for further
 explanation and more usage examples).
 
-Depending on selected build method and OS used we recommend:
+Depending on selected build method and OS used we recommend for:
 
 * In-place build
 
@@ -167,7 +167,7 @@ Postprocessing the Results
 
 * As a simple example, try::
 
-  $ ./postproc.py cylinder.vtk
+  ./postproc.py cylinder.vtk
 
 * The following interactive 3D window should display:
 
@@ -435,7 +435,7 @@ The whole example summarized in a script is available below in
 
 In the *SfePy* top-level directory run ::
 
-    $ ipython
+    ipython
 
 .. sourcecode:: ipython
 

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -9,12 +9,10 @@ Tutorial
    :local:
    :backlinks: top
 
-
-*SfePy* package can be used in two basic ways as a: (TBD)
-
-#. Black-box Partial Differential Equation (PDE) solver,
-#. Python package to build custom applications involving solving PDEs by the
- Finite Element Method (FEM).
+*SfePy* can be used in two basic ways:
+  #. a black-box partial differential equation (PDE) solver,
+  #. a Python package to build custom applications involving solving PDEs by
+     the finite element (FE) method.
 
 This tutorial focuses on the first way and introduces the basic concepts
 and nomenclature used in the following parts of the documentation. Check
@@ -27,13 +25,13 @@ Basic notions
 -------------
 
 The simplest way of using *SfePy* is to solve a system of PDEs defined
-in a `problem description file`, also referred to as `input
-file`. In such a file, the problem is described using several keywords
+in a **problem description file**, also referred to as **input
+file**. In such a file, the problem is described using several keywords
 that allow one to define the equations, variables, finite element
-approximations, solvers and solution domain and subdomains (see
-:ref:`sec-problem-description-file` for a full list of those keywords).
+approximations, solvers, solution domain and subdomains etc., see
+:ref:`sec-problem-description-file` for a full list of those keywords.
 
-The syntax of the `problem description file` is very simple yet powerful,
+The syntax of the problem description file is very simple yet powerful,
 as the file itself is just a regular Python module that can be normally
 imported -- no special parsing is necessary. The keywords mentioned above
 are regular Python variables (usually of the `dict` type) with special

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -69,7 +69,7 @@ Sneak peek: what is going on under the hood
 #. The solution is then obtained by calling ``problem.solve()``
    function.
 
-#. Finally, the solution can be stored using ``problem.save_state()``
+#. Finally, the solution can be stored using ``problem.save_state()``.
 
 The above last three steps are essentially repeated for each time
 step. So that is it - using the code a black-box PDE solver shields the
@@ -104,10 +104,10 @@ This section introduces the basics of running *SfePy* on the command line. The
 
   * ``examples/diffusion/poisson_short_syntax.py`` is the *SfePy*
     *problem description* file, which defines the problem to be solved
-    in terms *SfePy* can understand
+    in terms *SfePy* can understand.
 
   * Running the above command creates the output file ``cylinder.vtk`` in the
-    *SfePy* top-level directory
+    *SfePy* top-level directory.
 
 * *SfePy* can also be invoked interactively using `IPython`_ with custom
   imports, as described in :ref:`using-ipython`. In the SfePy top-level
@@ -136,13 +136,14 @@ Postprocessing the results
    :width: 70 %
    :align: center
 
-* The left mouse button by itself orbits the 3D view
+* The left mouse button by itself orbits the 3D view.
 
-* Holding shift and the left mouse button pans the view
+* Holding shift and the left mouse button pans the view.
 
-* Holding control and the left mouse button rotates about the screen normal axis
+* Holding control and the left mouse button rotates about the screen normal
+    axis.
 
-* The right mouse button controls the zoom
+* The right mouse button controls the zoom.
 
 .. _poisson-example-tutorial:
 
@@ -393,7 +394,7 @@ insight about the object internals.
 The whole example summarized in a script is below in
 :ref:`tutorial_interactive_source`.
 
-In the SfePy top-level directory, run::
+In the *SfePy* top-level directory, run::
 
     $ ipython --profile=sfepy
 

--- a/doc/users_guide.rst
+++ b/doc/users_guide.rst
@@ -18,6 +18,8 @@ tree after compiling the C extension files. See
 :ref:`introduction_installation` for full installation instructions info. The
 ``$`` indicates the command prompt of your terminal.
 
+.. _basic-usage:
+
 Basic Usage
 ^^^^^^^^^^^
 

--- a/doc/users_guide.rst
+++ b/doc/users_guide.rst
@@ -66,6 +66,8 @@ Applications
 
         $ ./postproc.py mesh.vtk
 
+.. _SfePy-command-wrapper:
+
 Using Command Wrapper
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -93,7 +95,7 @@ Notes
 
 * This is a "new" supported method. Any *SfePy* script can be still
   run as stand-alone (as mentioned above).
-* Both "--inplace" and "system-wide" installations are supported.
+* Both "inplace" and "system-wide" installations are supported.
 
 Stand-Alone Examples
 ^^^^^^^^^^^^^^^^^^^^

--- a/examples/linear_elasticity/linear_elastic_interactive.py
+++ b/examples/linear_elasticity/linear_elastic_interactive.py
@@ -16,6 +16,7 @@ from sfepy.discrete.conditions import Conditions, EssentialBC
 from sfepy.solvers.ls import ScipyDirect
 from sfepy.solvers.nls import Newton
 from sfepy.postprocess.viewer import Viewer
+from sfepy.mechanics.matcoefs import stiffness_from_lame
 
 
 def shift_u_fun(ts, coors, bc=None, problem=None, shift=0.0):
@@ -60,12 +61,12 @@ def main():
     u = FieldVariable('u', 'unknown', field)
     v = FieldVariable('v', 'test', field, primary_var_name='u')
 
-    m = Material('m', lam=1.0, mu=1.0)
+    m = Material('m', D=stiffness_from_lame(dim=2, lam=1.0, mu=1.0))
     f = Material('f', val=[[0.02], [0.01]])
 
     integral = Integral('i', order=3)
 
-    t1 = Term.new('dw_lin_elastic_iso(m.lam, m.mu, v, u)',
+    t1 = Term.new('dw_lin_elastic(m.D, v, u)',
                   integral, omega, m=m, v=v, u=u)
     t2 = Term.new('dw_volume_lvf(f.val, v)', integral, omega, f=f, v=v)
     eq = Equation('balance', t1 + t2)

--- a/examples/linear_elasticity/linear_elastic_interactive.py
+++ b/examples/linear_elasticity/linear_elastic_interactive.py
@@ -55,7 +55,6 @@ def main():
                                   'facet')
 
     field = Field.from_args('fu', nm.float64, 'vector', omega,
-                            space='H1', poly_space_base='lagrange',
                             approx_order=2)
 
     u = FieldVariable('u', 'unknown', field)


### PR DESCRIPTION
Updated dcoumentation according to
- issue #379 
- issue #401 

Added some further doc text cleanup:

- updated {totorial/primer/installation/user_guide}.rts doc files,

- updated tutorial/primer to follow new Python3 import conventions,
- updated "Using IPython" section,
- synced tutorial.rst with  linear_elastic_interactive.py example,
- fixed/consolidated text "markup" (highlighting),
- more typo and bug-fixes... 