### PR TITLE
Deploment-CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -94,14 +94,9 @@ build: false
 test_script:
 
   - "python setup.py build_ext --inplace"
-  - "python run_tests.py"
-
-#
-# Probably not needed here...
-#
-#  - ps: |
-#      python run_tests.py
-#      if ($LastExitCode -ne 0) { python run_tests.py --raise }
+  - ps: |
+      python run_tests.py
+      if ($LastExitCode -ne 0) { python run_tests.py --raise }
 
 #---------------------------------#
 #         notifications           #

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -94,7 +94,8 @@ build: false
 test_script:
 
   - "python setup.py build_ext --inplace"
-  - ps: python run_tests.py
+  - "python run_tests.py"
+
 #
 # Probably not needed here...
 #

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,20 +37,10 @@ matrix:
 environment:
   matrix:
 
-    - PYTHON: "C:\\Python27_32"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "32"
-      CONDA_PY: "27"
-
     - PYTHON: "C:\\Python27_64"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
       CONDA_PY: "27"
-
-    - PYTHON: "C:\\Python36_32"
-      PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "32"
-      CONDA_PY: "36"
 
     - PYTHON: "C:\\Python36_64"
       PYTHON_VERSION: "3.6"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,116 @@
+#
+# SfePy minimal ammveyor.yml config file
+#
+# YAML Reference Config:         https://www.appveyor.com/docs/appveyor-yml/
+# Environmental Variables Guide: https://www.appveyor.com/docs/environment-variables/
+# YAML Validator:                https://ci.appveyor.com/tools/validate-yaml
+#
+
+#---------------------------------#
+#      general configuration      #
+#---------------------------------#
+
+# version format
+version: ''
+
+init:
+
+  # Set "build version number" to "short-commit-hash" or when tagged to "tag name" (Travis style)
+  - ps: >-
+      if ($env:APPVEYOR_REPO_TAG -eq "true")
+      {
+        Update-AppveyorBuild -Version "SfePy-$env:APPVEYOR_REPO_TAG_NAME"
+      }
+      else
+      {
+        Update-AppveyorBuild -Version "SfePy-$($env:APPVEYOR_REPO_COMMIT.substring(0,8))"
+      }
+
+#---------------------------------#
+#    environment configuration    #
+#---------------------------------#
+
+# this is how to allow failing jobs in the matrix
+matrix:
+  fast_finish: false
+
+environment:
+  matrix:
+
+    - PYTHON: "C:\\Python27_32"
+      PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "32"
+      CONDA_PY: "27"
+
+    - PYTHON: "C:\\Python27_64"
+      PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "64"
+      CONDA_PY: "27"
+
+    - PYTHON: "C:\\Python36_32"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "32"
+      CONDA_PY: "36"
+
+    - PYTHON: "C:\\Python36_64"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "64"
+      CONDA_PY: "36"
+
+install:
+  # If there is a newer build queued for the same PR, cancel this one.
+
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+          throw "There are newer queued builds for this pull request, failing early." }
+  #
+  # Install (and update) the appropriate Miniconda.
+  #
+  - powershell .\\deployment-CI\\miniconda-install.ps1
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
+  - "conda create -q --yes -n sfepy-test python=%PYTHON_VERSION% numpy scipy cython matplotlib pytables pyparsing sympy"
+  - activate sfepy-test
+  #
+  # TBD: (still looking for working version...)
+  #- pip install scikit-sparse "scikit-umfpack==0.2.3"
+  #
+  - conda info -a
+  - python -V
+
+#---------------------------------#
+#       build configuration       #
+#---------------------------------#
+
+# to disable automatic builds
+build: false
+
+#---------------------------------#
+#       tests configuration       #
+#---------------------------------#
+
+# to run your custom scripts instead of automatic tests
+test_script:
+
+  - "python setup.py build_ext --inplace"
+  - ps: python run_tests.py
+#
+# Probably not needed here...
+#
+#  - ps: |
+#      python run_tests.py
+#      if ($LastExitCode -ne 0) { python run_tests.py --raise }
+
+#---------------------------------#
+#         notifications           #
+#---------------------------------#
+
+# Please note: notifications settings are merged with GUI settings!
+notifications:
+
+  # Email
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,14 +56,10 @@ script:
 
   - python setup.py build_ext --inplace
   - python run_tests.py; export SFEPY_TEST_RESULTS=$?; (exit $SFEPY_TEST_RESULTS)
-
-#
-# Probably not needed here...
-#
-#  - |
-#    if [ $SFEPY_TEST_RESULTS -ne 0 ]; then
-#      python run_tests.py --raise
-#    fi
+  - |
+    if [ $SFEPY_TEST_RESULTS -ne 0 ]; then
+      python run_tests.py --raise
+    fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,20 @@
-# After changing this file, check it on: http://lint.travis-ci.org/
+#
+# SfePy minimal travis.yml config file
+#
+# YAML Validator:   http://lint.travis-ci.org/
+#
+
 language: python
+
+#
+# Enable Container-based testing
+#
+sudo: false
+dist: trusty
 
 matrix:
   include:
     - python: 2.7
-      env: MAYAVI="mayavi=4.3"
-    - python: 3.4
-      env: MAYAVI=
-    - python: 3.5
     - python: 3.6
 
 addons:
@@ -22,9 +29,7 @@ cache:
     - $HOME/.cache/pip
 
 before_install:
-  - sudo apt-get update
-  # We do this conditionally because it saves us some downloading if the
-  # version is the same.
+
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
       wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
     else
@@ -35,23 +40,30 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
-  # Useful for debugging any issues with conda
-  - conda info -a
 
 install:
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib sympy cython $MAYAVI pytables pyparsing
-  - source activate test-environment
+
+  - conda create -q -n sfepy-test python=$TRAVIS_PYTHON_VERSION numpy scipy cython matplotlib pytables pyparsing sympy atlas
+  - source activate sfepy-test
+
+  - conda info -a
   - python -V
+
   - pip install scikit-umfpack
   - pip install https://bitbucket.org/dalcinl/igakit/get/default.tar.gz
 
 script:
+
   - python setup.py build_ext --inplace
   - python run_tests.py; export SFEPY_TEST_RESULTS=$?; (exit $SFEPY_TEST_RESULTS)
-  - |
-    if [ $SFEPY_TEST_RESULTS -ne 0 ]; then
-      python run_tests.py --raise
-    fi
+
+#
+# Probably not needed here...
+#
+#  - |
+#    if [ $SFEPY_TEST_RESULTS -ne 0 ]; then
+#      python run_tests.py --raise
+#    fi
 
 notifications:
   email: false

--- a/deployment-CI/miniconda-install.ps1
+++ b/deployment-CI/miniconda-install.ps1
@@ -1,0 +1,98 @@
+# Sample script to install Miniconda under Windows
+# Authors: Olivier Grisel, Jonathan Helmus and Kyle Kastner, Robert McGibbon
+# License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+
+$MINICONDA_URL = "http://repo.continuum.io/miniconda/"
+
+
+function DownloadMiniconda ($python_version, $platform_suffix) {
+    $webclient = New-Object System.Net.WebClient
+    if ($python_version -match "^3.*") {
+        $filename = "Miniconda3-latest-Windows-" + $platform_suffix + ".exe"
+    } else {
+        $filename = "Miniconda2-latest-Windows-" + $platform_suffix + ".exe"
+    }
+    $url = $MINICONDA_URL + $filename
+
+    $basedir = $pwd.Path + "\"
+    $filepath = $basedir + $filename
+    if (Test-Path $filename) {
+        Write-Host "Reusing" $filepath
+        return $filepath
+    }
+
+    # Download and retry up to 3 times in case of network transient errors.
+    Write-Host "Downloading" $filename "from" $url
+    $retry_attempts = 2
+    for($i=0; $i -lt $retry_attempts; $i++){
+        try {
+            $webclient.DownloadFile($url, $filepath)
+            break
+        }
+        Catch [Exception]{
+            Start-Sleep 1
+        }
+   }
+   if (Test-Path $filepath) {
+       Write-Host "File saved at" $filepath
+   } else {
+       # Retry once to get the error message if any at the last try
+       $webclient.DownloadFile($url, $filepath)
+   }
+   return $filepath
+}
+
+
+function InstallMiniconda ($python_version, $architecture, $python_home) {
+    Write-Host "Installing Python" $python_version "for" $architecture "bit architecture to" $python_home
+    if (Test-Path $python_home) {
+        Write-Host $python_home "already exists, skipping."
+        return $false
+    }
+    if ($architecture -match "32") {
+        $platform_suffix = "x86"
+    } else {
+        $platform_suffix = "x86_64"
+    }
+
+    $filepath = DownloadMiniconda $python_version $platform_suffix
+    Write-Host "Installing" $filepath "to" $python_home
+    $install_log = $python_home + ".log"
+    $args = "/S /D=$python_home"
+    Write-Host $filepath $args
+    Start-Process -FilePath $filepath -ArgumentList $args -Wait -Passthru
+    if (Test-Path $python_home) {
+        Write-Host "Python $python_version ($architecture) installation complete"
+    } else {
+        Write-Host "Failed to install Python in $python_home"
+        Get-Content -Path $install_log
+        Exit 1
+    }
+}
+
+
+function InstallCondaPackages ($python_home, $spec) {
+    $conda_path = $python_home + "\Scripts\conda.exe"
+    $args = "install --yes " + $spec
+    Write-Host ("conda " + $args)
+    Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
+}
+
+function UpdateConda ($python_home) {
+    $conda_path = $python_home + "\Scripts\conda.exe"
+    Write-Host "Updating conda..."
+    $args = "update --yes conda"
+    Write-Host $conda_path $args
+    Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
+}
+
+
+function main () {
+    InstallMiniconda $env:PYTHON_VERSION $env:PYTHON_ARCH $env:PYTHON
+    UpdateConda $env:PYTHON
+#
+#    InstallCondaPackages $env:PYTHON "conda-build jinja2 anaconda-client"
+#
+}
+
+main


### PR DESCRIPTION
Support to enable AppVeyor CI on github #350

- updated existing .travis.yml to switch to container-based build (faster)
- added basic AppVeyor config file
  - tests on x86/x86_64 platforms
  - TBD: register (and configure) main SfePy project on appveryor.com
- updated/synced CI testing configs:
  - tests for Python 2.7/3.6 only
  - don't run 'python run_tests.py --raise' (if tests failed) (unecessary test delay? )
