### PR TITLE
Add reading of axisymmetric elements to AbaqusMeshIO

### DIFF
--- a/sfepy/discrete/fem/meshio.py
+++ b/sfepy/discrete/fem/meshio.py
@@ -2033,7 +2033,11 @@ class AbaqusMeshIO(MeshIO):
                         mat_tetras.append(0)
                         tetras.append([int(ic) for ic in line[1:5]])
 
-                elif line[1].find('CPS') >= 0 or line[1].find('CPE') >= 0:
+                elif (
+                        line[1].find('CPS') >= 0
+                        or line[1].find('CPE') >= 0
+                        or line[1].find('CAX') >= 0
+                ):
                     if line[1].find('4') >= 0:
                         while 1:
                             line = fd.readline().split(',')


### PR DESCRIPTION
I needed to read a mesh created in Abaqus that contained axisymmetric elements, which were not implemented. This code reads them as ordinary 2D elements (since SfePy does not take care of axial symmetry by the use of dedicated elements, AFAIK).