### PR TITLE
update mumps: use a symmetric solver if the matrix is symmetric

### DIFF
--- a/sfepy/solvers/ls.py
+++ b/sfepy/solvers/ls.py
@@ -767,10 +767,14 @@ class MUMPSSolver(LinearSolver):
         return out
 
     def presolve(self, mtx):
+        if not isinstance(mtx, sps.coo_matrix):
+            mtx = mtx.tocoo()
         if self.mumps_ls is None:
             system = 'complex' if mtx.dtype.name.startswith('complex')\
                 else 'real'
-            self.mumps_ls = self.mumps.MumpsSolver(system=system)
+            is_sym = self.mumps.coo_is_symmetric(mtx)
+            self.mumps_ls = self.mumps.MumpsSolver(system=system,
+                                                   is_sym=is_sym)
 
         is_new, mtx_digest = _is_new_matrix(mtx, self.mtx_digest)
         if is_new:


### PR DESCRIPTION
See the solution times for UMPACK, MUMPS - unsymmetric solver  and MUMPS - symmetric solver.

sfepy: matrix shape: (84861, 84861)
sfepy: matrix structural nonzeros: 6637127 (9.22e-04% fill)

![umfpack_vs_mumps](https://user-images.githubusercontent.com/1375229/47556196-0adfaa80-d90e-11e8-9d24-6aa61107d6a6.png)

What about using MUMPS as the default linear solver?