### PR TITLE
Update linear solvers, new solvers with auto fallback

### DIFF
--- a/doc/developer_guide.rst
+++ b/doc/developer_guide.rst
@@ -1198,6 +1198,7 @@ sfepy.solvers package
 .. toctree::
    :maxdepth: 2
 
+   src/sfepy/solvers/auto_fallback.py
    src/sfepy/solvers/eigen
    src/sfepy/solvers/ls
    src/sfepy/solvers/ls_mumps

--- a/doc/src/sfepy/solvers/auto_fallback.rst
+++ b/doc/src/sfepy/solvers/auto_fallback.rst
@@ -1,0 +1,6 @@
+sfepy.solvers.auto_fallback module
+=============================
+
+.. automodule:: sfepy.solvers.auto_fallback
+   :members:
+   :undoc-members:

--- a/doc/users_guide.rst
+++ b/doc/users_guide.rst
@@ -840,6 +840,22 @@ Solver selection::
         'ls' : 'ls',
     }
 
+If the linear solver could be unavailable, it is possible to set ``fallback``
+option which specifies the second in line solver::
+
+    solvers = {
+        'ls': ('ls.mumps', {'fallback': 'ls2'}),
+        'ls2': ('ls.scipy_umfpack', {}),
+        'newton': ('nls.newton', {
+            'i_max'      : 1,
+            'eps_a'      : 1e-10,
+        }),
+    }
+
+Another possibility is to use a "virtual" solver that ensures the automatic
+selection of the available solver, see
+`Virtual Linear Solvers with Automatic Selection`_.
+
 Functions
 ^^^^^^^^^
 
@@ -1406,6 +1422,21 @@ The following solvers are available:
 
 See :mod:`sfepy.solvers.ls` for all available *linear* solvers and their
 options.
+
+Virtual Linear Solvers with Automatic Selection
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A "virtual" solver can be used in case it is not clear which external linear
+solvers are available. It selects the first disposable solver from
+a defined list.
+
+The following solvers are available:
+
+.. include:: solver_table.rst
+    :start-after:   .. <Virtual Solvers with Automatic Fallback>
+    :end-before:    .. </Virtual Solvers with Automatic Fallback>
+
+See :mod:`sfepy.solvers.auto_fallback` for all available *virtual* solvers.
 
 Eigenvalue Problem Solvers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/users_guide.rst
+++ b/doc/users_guide.rst
@@ -840,8 +840,9 @@ Solver selection::
         'ls' : 'ls',
     }
 
-If the linear solver could be unavailable, it is possible to set ``fallback``
-option which specifies the second in line solver::
+For the case that a chosen linear solver is not available, it is possible to
+define the ``fallback`` option of the chosen solver which specifies a possible
+alternative::
 
     solvers = {
         'ls': ('ls.mumps', {'fallback': 'ls2'}),
@@ -852,8 +853,8 @@ option which specifies the second in line solver::
         }),
     }
 
-Another possibility is to use a "virtual" solver that ensures the automatic
-selection of the available solver, see
+Another possibility is to use a "virtual" solver that ensures an automatic
+selection of an available solver, see
 `Virtual Linear Solvers with Automatic Selection`_.
 
 Functions
@@ -1427,8 +1428,8 @@ Virtual Linear Solvers with Automatic Selection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A "virtual" solver can be used in case it is not clear which external linear
-solvers are available. It selects the first disposable solver from
-a defined list.
+solvers are available. Each "virtual" solver selects the first available solver
+from a pre-defined list.
 
 The following solvers are available:
 

--- a/examples/homogenization/linear_homogenization_up.py
+++ b/examples/homogenization/linear_homogenization_up.py
@@ -145,6 +145,7 @@ options = {
     'output_dir': 'output',
     'coefs_filename': 'coefs_le_up',
     'recovery_hook': 'recovery_le',
+    'multiprocessing': False,
 }
 
 equation_corrs = {
@@ -199,9 +200,7 @@ requirements = {
 }
 
 solvers = {
-    'ls': ('ls.scipy_iterative', {
-        'method': 'cg',
-    }),
+    'ls': ('ls.auto_iterative', {}),
     'newton': ('nls.newton', {
         'i_max': 1,
         'eps_a': 1e2,

--- a/examples/linear_elasticity/its2D_interactive.py
+++ b/examples/linear_elasticity/its2D_interactive.py
@@ -42,7 +42,8 @@ from sfepy.discrete.fem import Mesh, FEDomain, Field
 from sfepy.terms import Term
 from sfepy.discrete.conditions import Conditions, EssentialBC
 from sfepy.mechanics.matcoefs import stiffness_from_youngpoisson
-from sfepy.solvers.ls import ScipyDirect
+from sfepy.solvers.auto_fallback import AutoDirect
+from sfepy.solvers.ls import ScipyDirect, ScipySuperLU, ScipyUmfpack, MUMPSSolver
 from sfepy.solvers.nls import Newton
 from sfepy.discrete.fem.geometry_element import geometry_data
 from sfepy.discrete.probes import LineProbe
@@ -212,7 +213,7 @@ def main():
     xsym = EssentialBC('XSym', bottom, {'u.1' : 0.0})
     ysym = EssentialBC('YSym', left, {'u.0' : 0.0})
 
-    ls = ScipyDirect({})
+    ls = AutoDirect({})
 
     nls_status = IndexedStruct()
     nls = Newton({}, lin_solver=ls, status=nls_status)

--- a/examples/linear_elasticity/linear_elastic.py
+++ b/examples/linear_elasticity/linear_elastic.py
@@ -80,8 +80,8 @@ equations = {
 }
 
 solvers = {
-    'ls' : ('ls.scipy_direct', {}),
-    'newton' : ('nls.newton', {
+    'ls': ('ls.auto_direct', {}),
+    'newton': ('nls.newton', {
         'i_max'      : 1,
         'eps_a'      : 1e-10,
     }),

--- a/examples/linear_elasticity/linear_elastic_up.py
+++ b/examples/linear_elasticity/linear_elastic_up.py
@@ -103,7 +103,12 @@ equations = {
 #! Even linear problems are solved by a nonlinear solver - only one
 #! iteration is needed and the final residual is obtained for free.
 solvers = {
-    'ls' : ('ls.scipy_direct', {}),
+    'ls': ('ls.schur_mumps', {
+        'schur_variables': ['p'],
+        'fallback': 'ls2'
+    }),
+    'ls2': ('ls.scipy_umfpack', {'fallback': 'ls3'}),
+    'ls3': ('ls.scipy_superlu', {}),
     'newton' : ('nls.newton', {
         'i_max'      : 1,
         'eps_a'      : 1e-2,

--- a/examples/linear_elasticity/shell10x_cantilever_interactive.py
+++ b/examples/linear_elasticity/shell10x_cantilever_interactive.py
@@ -65,7 +65,8 @@ from sfepy.discrete import (FieldVariable, Material, Integral,
 from sfepy.discrete.fem import Mesh, FEDomain, Field
 from sfepy.terms import Term
 from sfepy.discrete.conditions import Conditions, EssentialBC
-from sfepy.solvers.ls import ScipyDirect
+from sfepy.solvers.solvers import ls_fallback
+from sfepy.solvers.ls import MUMPSSolver, ScipyDirect
 from sfepy.solvers.nls import Newton
 from sfepy.linalg import make_axis_rotation_matrix
 from sfepy.mechanics.tensors import transform_data
@@ -169,7 +170,7 @@ def solve_problem(shape, dims, young, poisson, force, transform=None):
 
     fix_u = EssentialBC('fix_u', gamma1, {'u.all' : 0.0})
 
-    ls = ScipyDirect({})
+    ls = ls_fallback([(MUMPSSolver, {}), (ScipyDirect, {})])
 
     nls_status = IndexedStruct()
     nls = Newton({}, lin_solver=ls, status=nls_status)

--- a/examples/linear_elasticity/shell10x_cantilever_interactive.py
+++ b/examples/linear_elasticity/shell10x_cantilever_interactive.py
@@ -65,7 +65,7 @@ from sfepy.discrete import (FieldVariable, Material, Integral,
 from sfepy.discrete.fem import Mesh, FEDomain, Field
 from sfepy.terms import Term
 from sfepy.discrete.conditions import Conditions, EssentialBC
-from sfepy.solvers.solvers import ls_fallback
+from sfepy.solvers.solvers import use_first_available
 from sfepy.solvers.ls import MUMPSSolver, ScipyDirect
 from sfepy.solvers.nls import Newton
 from sfepy.linalg import make_axis_rotation_matrix
@@ -170,7 +170,7 @@ def solve_problem(shape, dims, young, poisson, force, transform=None):
 
     fix_u = EssentialBC('fix_u', gamma1, {'u.all' : 0.0})
 
-    ls = ls_fallback([(MUMPSSolver, {}), (ScipyDirect, {})])
+    ls = use_first_available([(MUMPSSolver, {}), (ScipyDirect, {})])
 
     nls_status = IndexedStruct()
     nls = Newton({}, lin_solver=ls, status=nls_status)

--- a/script/gen_solver_table.py
+++ b/script/gen_solver_table.py
@@ -14,8 +14,10 @@ import sfepy
 from sfepy.base.base import load_classes
 from sfepy.solvers import NonlinearSolver, TimeSteppingSolver, LinearSolver, \
     EigenvalueSolver, OptimizationSolver
+from sfepy.solvers.auto_fallback import AutoFallbackSolver
 
 solver_by_type_table = [
+    [[AutoFallbackSolver], "Virtual Solvers with Automatic Fallback"],
     [[TimeSteppingSolver], "Time-Stepping Solvers"],
     [[NonlinearSolver], "Nonlinear Solvers"],
     [[LinearSolver], "Linear Solvers"],

--- a/sfepy/discrete/problem.py
+++ b/sfepy/discrete/problem.py
@@ -26,7 +26,7 @@ from sfepy.discrete.evaluate import create_evaluable, eval_equations
 from sfepy.solvers.ts import TimeStepper
 from sfepy.discrete.evaluate import Evaluator
 from sfepy.solvers import Solver, NonlinearSolver
-from sfepy.solvers.solvers import ls_fallback
+from sfepy.solvers.solvers import use_first_available
 from sfepy.solvers.ts_solvers import StationarySolver
 import six
 from six.moves import range
@@ -1069,7 +1069,7 @@ class Problem(Struct):
                     break
 
             if len(fb_list) > 1:
-                ls = ls_fallback(fb_list, context=self)
+                ls = use_first_available(fb_list, context=self)
             else:
                 ls = Solver.any_from_conf(ls_conf, context=self)
 

--- a/sfepy/discrete/problem.py
+++ b/sfepy/discrete/problem.py
@@ -26,6 +26,7 @@ from sfepy.discrete.evaluate import create_evaluable, eval_equations
 from sfepy.solvers.ts import TimeStepper
 from sfepy.discrete.evaluate import Evaluator
 from sfepy.solvers import Solver, NonlinearSolver
+from sfepy.solvers.solvers import ls_fallback
 from sfepy.solvers.ts_solvers import StationarySolver
 import six
 from six.moves import range
@@ -985,18 +986,27 @@ class Problem(Struct):
     def set_conf_solvers(self, conf_solvers=None, options=None):
         """
         Choose which solvers should be used. If solvers are not set in
-        `options`, use first suitable in `conf_solvers`.
+        `options`, use the ones named `ls`, `nls` or `ts`. If such solvers
+        do not exist, us the firsts suitable in `conf_solvers`.
         """
         conf_solvers = get_default(conf_solvers, self.conf.solvers)
         self.solver_confs = {}
+
         for key, val in six.iteritems(conf_solvers):
             self.solver_confs[val.name] = val
 
         def _find_suitable(prefix):
+            cands = []
             for key, val in six.iteritems(self.solver_confs):
                 if val.kind.find(prefix) == 0:
-                    return val
-            return None
+                    if val.name == prefix[:-1]:
+                        return val
+                    else:
+                        cands.append(val)
+            if len(cands) > 0:
+                return cands[0]
+            else:
+                return None
 
         def _get_solver_conf(kind):
             try:
@@ -1050,7 +1060,18 @@ class Problem(Struct):
             nls_conf = get_default(nls_conf, self.nls_conf,
                                    'you must set nonlinear solver!')
 
-            ls = Solver.any_from_conf(ls_conf, context=self)
+            fb_list = []
+            for ii in range(100):
+                fb_list.append((ls_conf.kind, ls_conf))
+                if hasattr(ls_conf, 'fallback'):
+                    ls_conf = self.solver_confs[ls_conf.fallback]
+                else:
+                    break
+
+            if len(fb_list) > 1:
+                ls = ls_fallback(fb_list, context=self)
+            else:
+                ls = Solver.any_from_conf(ls_conf, context=self)
 
             ev = self.get_evaluator()
 

--- a/sfepy/discrete/problem.py
+++ b/sfepy/discrete/problem.py
@@ -986,8 +986,9 @@ class Problem(Struct):
     def set_conf_solvers(self, conf_solvers=None, options=None):
         """
         Choose which solvers should be used. If solvers are not set in
-        `options`, use the ones named `ls`, `nls` or `ts`. If such solvers
-        do not exist, us the firsts suitable in `conf_solvers`.
+        `options`, use the ones named `ls`, `nls` or `ts`. If such solver names
+        do not exist, use the first of each required solver kind listed in
+        `conf_solvers`.
         """
         conf_solvers = get_default(conf_solvers, self.conf.solvers)
         self.solver_confs = {}

--- a/sfepy/solvers/auto_fallback.py
+++ b/sfepy/solvers/auto_fallback.py
@@ -46,7 +46,7 @@ class AutoIterative(AutoFallbackSolver):
 
     The first available solver from the following list is used:
     `ls.petsc <sfepy.solvers.ls.PETScKrylovSolver>` and
-    `ls.scipy_iterative <sfepy.solvers.ls.MUMPSSolver>`
+    `ls.scipy_iterative <sfepy.solvers.ls.ScipyIterative>`
     """
     name = 'ls.auto_iterative'
 

--- a/sfepy/solvers/auto_fallback.py
+++ b/sfepy/solvers/auto_fallback.py
@@ -1,0 +1,56 @@
+from __future__ import absolute_import
+from sfepy.base.base import Struct
+from sfepy.solvers.solvers import Solver, ls_fallback
+
+
+class AutoFallbackSolver(Solver):
+    """
+    Base class for virtual solvers with the automatic fallback.
+    """
+    _ls_solvers = []
+
+    def __new__(cls, conf, **kwargs):
+        """
+        Choose a available solver from `self._ls_solvers`.
+
+        Parameters
+        ----------
+        conf : dict
+            The solver configuration.
+        """
+        ls_solvers = [(ls, Struct(**conf) + Struct(kind=ls))
+                      for ls, conf in cls._ls_solvers]
+
+        return ls_fallback(ls_solvers)
+
+
+class AutoDirect(AutoFallbackSolver):
+    """The automatically selected linear direct solver.
+
+    The first available solver from the following list is used:
+    `ls.mumps <sfepy.solvers.ls.MUMPSSolver>`,
+    `ls.scipy_umfpack <sfepy.solvers.ls.ScipyUmfpack>` and
+    `ls.scipy_superlu <sfepy.solvers.ls.ScipySuperLU>`.
+    """
+    name = 'ls.auto_direct'
+
+    _ls_solvers = [
+        ('ls.mumps', {}),
+        ('ls.scipy_umfpack', {}),
+        ('ls.scipy_superlu', {})
+    ]
+
+
+class AutoIterative(AutoFallbackSolver):
+    """The automatically selected linear iterative solver.
+
+    The first available solver from the following list is used:
+    `ls.petsc <sfepy.solvers.ls.PETScKrylovSolver>` and
+    `ls.scipy_iterative <sfepy.solvers.ls.MUMPSSolver>`
+    """
+    name = 'ls.auto_iterative'
+
+    _ls_solvers = [
+        ('ls.petsc', {'method': 'cg', 'precond': 'icc'}),
+        ('ls.scipy_iterative', {'method': 'cg'}),
+    ]

--- a/sfepy/solvers/auto_fallback.py
+++ b/sfepy/solvers/auto_fallback.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from sfepy.base.base import Struct
-from sfepy.solvers.solvers import Solver, ls_fallback
+from sfepy.solvers.solvers import Solver, use_first_available
 
 
 class AutoFallbackSolver(Solver):
@@ -21,7 +21,7 @@ class AutoFallbackSolver(Solver):
         ls_solvers = [(ls, Struct(**conf) + Struct(kind=ls))
                       for ls, conf in cls._ls_solvers]
 
-        return ls_fallback(ls_solvers)
+        return use_first_available(ls_solvers)
 
 
 class AutoDirect(AutoFallbackSolver):

--- a/sfepy/solvers/ls.py
+++ b/sfepy/solvers/ls.py
@@ -919,6 +919,9 @@ class SchurMumps(MUMPSSolver):
                  i_max=None, mtx=None, status=None, **kwargs):
         import scipy.linalg as sla
 
+        if not isinstance(mtx, sps.coo_matrix):
+            mtx = mtx.tocoo()
+
         system = 'complex' if mtx.dtype.name.startswith('complex') else 'real'
         self.mumps_ls = self.mumps.MumpsSolver(system=system)
 

--- a/sfepy/solvers/solvers.py
+++ b/sfepy/solvers/solvers.py
@@ -62,6 +62,21 @@ def make_option_docstring(name, kind, default, required, doc):
 
 
 def use_first_available(solver_list, context=None):
+    """
+    Use the first available solver from `solver_list`.
+
+    Parameters
+    ----------
+    solver_list : list of str or Struct
+        The list of solver names or configuration objects.
+    context : object, optional
+        An optional solver context to pass to the solver.
+
+    Returns
+    -------
+    out : Solver
+        The first available solver.
+    """
     prev_name = None
     for solver, conf in solver_list:
         name = solver if isinstance(solver, str) else solver.name

--- a/sfepy/solvers/solvers.py
+++ b/sfepy/solvers/solvers.py
@@ -2,7 +2,7 @@
 Base (abstract) solver classes.
 """
 from __future__ import absolute_import
-from sfepy.base.base import Struct
+from sfepy.base.base import Struct, output
 import six
 
 def make_get_conf(conf, kwargs):
@@ -59,6 +59,30 @@ def make_option_docstring(name, kind, default, required, doc):
     entry += typeset_to_indent(doc, 8, 75)
 
     return entry
+
+
+def ls_fallback(ls_list, context=None):
+    prev_name = None
+    for ls, conf in ls_list:
+        name = ls if isinstance(ls, str) else ls.name
+        if prev_name is not None:
+            output("'%s' not available, trying '%s'" % (prev_name, name))
+
+        try:
+            if isinstance(ls, str):
+                out = Solver.any_from_conf(conf, context=context)
+            else:
+                out = ls(conf, contex=context)
+
+            output("using '%s' linear solver" % name)
+            break
+        except (ValueError, OSError):
+            prev_name = name
+
+    else:
+        raise ValueError('no linear solver available!')
+
+    return out
 
 par_template = \
 """

--- a/sfepy/solvers/solvers.py
+++ b/sfepy/solvers/solvers.py
@@ -93,7 +93,7 @@ def use_first_available(solver_list, context=None):
 
             output("using '%s' solver" % name)
             break
-        except (ValueError, OSError):
+        except (ValueError, OSError, ImportError):
             prev_name = name
 
     else:

--- a/sfepy/solvers/solvers.py
+++ b/sfepy/solvers/solvers.py
@@ -61,28 +61,29 @@ def make_option_docstring(name, kind, default, required, doc):
     return entry
 
 
-def ls_fallback(ls_list, context=None):
+def use_first_available(solver_list, context=None):
     prev_name = None
-    for ls, conf in ls_list:
-        name = ls if isinstance(ls, str) else ls.name
+    for solver, conf in solver_list:
+        name = solver if isinstance(solver, str) else solver.name
         if prev_name is not None:
             output("'%s' not available, trying '%s'" % (prev_name, name))
 
         try:
             _conf = conf.copy()
             _conf.__dict__.pop('fallback', None)
-            if isinstance(ls, str):
+            if isinstance(solver, str):
                 out = Solver.any_from_conf(_conf, context=context)
             else:
-                out = ls(_conf, contex=context)
+                out = solver(_conf, contex=context)
 
-            output("using '%s' linear solver" % name)
+            output("using '%s' solver" % name)
             break
         except (ValueError, OSError):
             prev_name = name
 
     else:
-        raise ValueError('no linear solver available!')
+        raise ValueError('no solver available from %s!'
+                         % [ii[0] for ii in solver_list])
 
     return out
 

--- a/sfepy/solvers/solvers.py
+++ b/sfepy/solvers/solvers.py
@@ -93,7 +93,7 @@ def use_first_available(solver_list, context=None):
 
             output("using '%s' solver" % name)
             break
-        except (ValueError, OSError, ImportError):
+        except (ValueError, OSError, ImportError, TypeError):
             prev_name = name
 
     else:

--- a/sfepy/solvers/solvers.py
+++ b/sfepy/solvers/solvers.py
@@ -69,10 +69,12 @@ def ls_fallback(ls_list, context=None):
             output("'%s' not available, trying '%s'" % (prev_name, name))
 
         try:
+            _conf = conf.copy()
+            _conf.__dict__.pop('fallback', None)
             if isinstance(ls, str):
-                out = Solver.any_from_conf(conf, context=context)
+                out = Solver.any_from_conf(_conf, context=context)
             else:
-                out = ls(conf, contex=context)
+                out = ls(_conf, contex=context)
 
             output("using '%s' linear solver" % name)
             break

--- a/tests/test_linear_solvers.py
+++ b/tests/test_linear_solvers.py
@@ -67,10 +67,13 @@ def setup_petsc_precond(mtx, problem):
 
 solvers = {
     'd00' : ('ls.scipy_direct',
+             {}
+    ),
+    'd01' : ('ls.scipy_direct',
              {'method' : 'umfpack',
               'warn' : True,}
     ),
-    'd01' : ('ls.scipy_direct',
+    'd02' : ('ls.scipy_direct',
              {'method' : 'superlu',
               'warn' : True,}
     ),
@@ -155,7 +158,8 @@ from sfepy.base.testing import TestCommon
 output_name = 'test_linear_solvers_%s.vtk'
 
 class Test(TestCommon):
-    can_fail = ['ls.pyamg', 'ls.pyamg_krylov', 'ls.petsc', 'ls.mumps',]
+    can_fail = ['ls.pyamg', 'ls.pyamg_krylov', 'ls.petsc', 'ls.mumps',
+                'ls.scipy_direct']
 
     @staticmethod
     def from_conf(conf, options):


### PR DESCRIPTION
**New:**
* new `ScipySuperLU`, `ScipyUmfpack` linear solvers - shortcuts to  `ScipyDirect(method='superlu')` and `ScipyDirect(method='umfpack')`
* `fallback` option for linear solvers
* `AutoFallbackSolver` class - fallback chain given by ` _ls_solvers` list
* `AutoDirect` and `AutoIterative` (which solvers/methods should be used?) solvers

**Updated:**
* `MUMPSSolver`,  `MUMPSParallelSolver` - consider matrix symmetry -> faster factorization and lower memory demands
* `MUMPSParallelSolver` - accept verbose option
* examples - using `AutoDirect` and `AutoIterative`
* documentation related to the above
