### PR TITLE
do not execute code in ls_mumps_parallel.py on import

### DIFF
--- a/sfepy/solvers/ls_mumps_parallel.py
+++ b/sfepy/solvers/ls_mumps_parallel.py
@@ -37,6 +37,7 @@ def mumps_parallel_solve():
     del(mumps_ls)
 
 
-comm = MPI.Comm.Get_parent()
-mumps_parallel_solve()
-comm.Disconnect()
+if __name__ == '__main__':
+    comm = MPI.Comm.Get_parent()
+    mumps_parallel_solve()
+    comm.Disconnect()


### PR DESCRIPTION
@vlukes what do you think of this change? Running the code on import causes an error when generating the sphinx docs.