### PR TITLE
Removed "obsolete" (and trouble-making) __SDIR__ C pre-processor cmd

### DIFF
--- a/sfepy/discrete/common/extmods/setup.py
+++ b/sfepy/discrete/common/extmods/setup.py
@@ -14,10 +14,8 @@ def configuration(parent_package='', top_path=None):
     auto_name = op.split(auto_dir)[-1]
     config = Configuration(auto_name, parent_package, top_path)
 
-    sdir = '\\"%s\\"' % auto_dir.replace('\\', '\\\\')
     inline = 'inline' if system == 'posix' else '__inline'
-    defines = [('__SDIR__', sdir),
-               ('SFEPY_PLATFORM', os_flag),
+    defines = [('SFEPY_PLATFORM', os_flag),
                ('inline', inline)]
     if '-DDEBUG_FMF' in site_config.debug_flags():
         defines.append(('DEBUG_FMF', None))

--- a/sfepy/discrete/fem/extmods/setup.py
+++ b/sfepy/discrete/fem/extmods/setup.py
@@ -14,10 +14,8 @@ def configuration(parent_package='', top_path=None):
     auto_name = op.split(auto_dir)[-1]
     config = Configuration(auto_name, parent_package, top_path)
 
-    sdir = '\\"%s\\"' % auto_dir.replace('\\', '\\\\')
     inline = 'inline' if system == 'posix' else '__inline'
-    defines = [('__SDIR__', sdir),
-               ('SFEPY_PLATFORM', os_flag),
+    defines = [('SFEPY_PLATFORM', os_flag),
                ('inline', inline)]
     if '-DDEBUG_FMF' in site_config.debug_flags():
         defines.append(('DEBUG_FMF', None))

--- a/sfepy/discrete/iga/extmods/setup.py
+++ b/sfepy/discrete/iga/extmods/setup.py
@@ -14,10 +14,8 @@ def configuration(parent_package='', top_path=None):
     auto_name = op.split(auto_dir)[-1]
     config = Configuration(auto_name, parent_package, top_path)
 
-    sdir = '\\"%s\\"' % auto_dir.replace('\\', '\\\\')
     inline = 'inline' if system == 'posix' else '__inline'
-    defines = [('__SDIR__', sdir),
-               ('SFEPY_PLATFORM', os_flag),
+    defines = [('SFEPY_PLATFORM', os_flag),
                ('inline', inline)]
     if '-DDEBUG_FMF' in site_config.debug_flags():
         defines.append(('DEBUG_FMF', None))

--- a/sfepy/mechanics/extmods/setup.py
+++ b/sfepy/mechanics/extmods/setup.py
@@ -14,10 +14,8 @@ def configuration(parent_package='', top_path=None):
     auto_name = op.split(auto_dir)[-1]
     config = Configuration(auto_name, parent_package, top_path)
 
-    sdir = '\\"%s\\"' % auto_dir.replace('\\', '\\\\')
     inline = 'inline' if system == 'posix' else '__inline'
-    defines = [('__SDIR__', sdir),
-               ('SFEPY_PLATFORM', os_flag),
+    defines = [('SFEPY_PLATFORM', os_flag),
                ('inline', inline)]
     if '-DDEBUG_FMF' in site_config.debug_flags():
         defines.append(('DEBUG_FMF', None))

--- a/sfepy/terms/extmods/setup.py
+++ b/sfepy/terms/extmods/setup.py
@@ -15,10 +15,8 @@ def configuration(parent_package='', top_path=None):
     auto_name = op.split(auto_dir)[-1]
     config = Configuration(auto_name, parent_package, top_path)
 
-    sdir = '\\"%s\\"' % auto_dir.replace('\\', '\\\\')
     inline = 'inline' if system == 'posix' else '__inline'
-    defines = [('__SDIR__', sdir),
-               ('SFEPY_PLATFORM', os_flag),
+    defines = [('SFEPY_PLATFORM', os_flag),
                ('inline', inline)]
     if '-DDEBUG_FMF' in site_config.debug_flags():
         defines.append(('DEBUG_FMF', None))


### PR DESCRIPTION
Self explanatory subject...everything seems to compile more smoothly on all platforms now...
(BTW: obsoleteness consulted with SfePy creator)...