### PR TITLE
fix material_opt.py: Python 2/3 compatibility issue - part II.

### DIFF
--- a/examples/homogenization/homogenization_opt.py
+++ b/examples/homogenization/homogenization_opt.py
@@ -22,7 +22,7 @@ def get_mat(coors, mode, pb):
 
         nqp = coors.shape[0]
         nel = pb.domain.mesh.n_el
-        nqpe = nqp / nel
+        nqpe = nqp // nel
         out = nm.zeros((nqp, 6, 6), dtype=nm.float64)
 
         # set values - matrix

--- a/examples/homogenization/material_opt.py
+++ b/examples/homogenization/material_opt.py
@@ -148,7 +148,7 @@ def main():
                            [160.e9, 0.25, 5.e9, 0.45],
                            [120e9, 0.2, 2e9, 0.2],
                            [200e9, 0.45, 8e9, 0.45],
-                           exp_data)
+                           list(exp_data))
 
     optim_par = mo.material_optimize()
     print('optimized parameters: ', optim_par)


### PR DESCRIPTION
This commit solves #510. But logging implemented in `sfepy.base.log` seems not working in Python 3 due to some changes in multiprocessing.