### PR TITLE
Remove use of scipy.misc

### DIFF
--- a/sfepy/base/compat.py
+++ b/sfepy/base/compat.py
@@ -25,7 +25,7 @@ try:
     factorial = sc.factorial
 
 except AttributeError:
-    import scipy.misc as scm
+    import scipy.special as scm
 
     factorial = scm.factorial
 

--- a/sfepy/linalg/geometry.py
+++ b/sfepy/linalg/geometry.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import numpy as nm
 import numpy.linalg as nla
 
-from scipy.misc import factorial
+from scipy.special import factorial
 
 from sfepy.base.base import assert_, output
 from sfepy.linalg.utils import norm_l2_along_axis as norm


### PR DESCRIPTION
`scipy.misc` is deprecated since scipy 1.0.0 [https://docs.scipy.org/doc/scipy-1.1.0/reference/misc.html](https://docs.scipy.org/doc/scipy-1.1.0/reference/misc.html) and has been removed recently (1.3.0).