### PR TITLE
new remote mirror regions: allow mirror regions with no common vertices

### DIFF
--- a/sfepy/base/conf.py
+++ b/sfepy/base/conf.py
@@ -147,6 +147,9 @@ def transform_regions(adict):
             c2 = tuple_to_conf(key, conf, ['select', 'kind'])
             if len(conf) == 3:
                 c2.parent = conf[2]
+            if len(conf) == 4:
+                c2.parent = conf[2]
+                c2.extra_options = conf[3]
             d2['region_%s__%d' % (c2.name, ii)] = c2
         else:
             c2 = transform_to_struct_1(conf)

--- a/sfepy/discrete/common/domain.py
+++ b/sfepy/discrete/common/domain.py
@@ -176,8 +176,8 @@ class Domain(Struct):
         self._bnf = create_bnf(self._region_stack)
 
     def create_region(self, name, select, kind='cell', parent=None,
-                      check_parents=True, functions=None, add_to_regions=True,
-                      allow_empty=False):
+                      check_parents=True, extra_options=None, functions=None,
+                      add_to_regions=True, allow_empty=False):
         """
         Region factory constructor. Append the new region to
         self.regions list.
@@ -203,6 +203,7 @@ class Domain(Struct):
         region.set_kind(kind)
         region.finalize(allow_empty=allow_empty)
         region.parent = parent
+        region.extra_options = extra_options
         region.update_shape()
 
         if add_to_regions:
@@ -231,6 +232,8 @@ class Domain(Struct):
                                         kind=rdef.get('kind', 'cell'),
                                         parent=rdef.get('parent', None),
                                         check_parents=False,
+                                        extra_options=rdef.get('extra_options',
+                                                               None),
                                         functions=functions,
                                         allow_empty=allow_empty)
             output(' ', region.name)

--- a/sfepy/discrete/fem/fe_surface.py
+++ b/sfepy/discrete/fem/fe_surface.py
@@ -85,7 +85,11 @@ class FESurface(Struct):
         conn = region.domain.cmesh.get_conn_as_graph(region.dim, region.dim - 1)
         oris = region.domain.cmesh.facet_oris
 
+        econn = self.econn
         ofis = region.get_facet_indices()
+        if region.mirror_map is not None:
+            ofis = ofis[region.mirror_map]
+            econn = econn[region.mirror_map]
         ooris = oris[conn.indptr[ofis[:, 0]] + ofis[:, 1]]
         mfis = mregion.get_facet_indices()
         moris = oris[conn.indptr[mfis[:, 0]] + mfis[:, 1]]
@@ -96,7 +100,7 @@ class FESurface(Struct):
         n_el, n_ep = self.econn.shape
         ii = nm.repeat(nm.arange(n_el)[:, None], n_ep, 1)
         self.meconn = nm.empty_like(self.econn)
-        self.meconn[ii, omap] = self.econn[ii, mmap]
+        self.meconn[ii, omap] = econn[ii, mmap]
 
         nodes = nm.unique(self.meconn)
         remap = prepare_remap(nodes, nodes.max() + 1)

--- a/sfepy/terms/terms.py
+++ b/sfepy/terms/terms.py
@@ -631,7 +631,12 @@ class Term(Struct):
             if field is None:
                 continue
 
-            if not nm.all(in1d(self.region.vertices,
+            region = self.region
+            if self.arg_traces[name]:
+                region.setup_mirror_region()
+                region = region.mirror_region
+
+            if not nm.all(in1d(region.vertices,
                                field.region.vertices)):
                 msg = ('%s: incompatible regions: (self, field %s)'
                        + '(%s in %s)') %\


### PR DESCRIPTION
You can define _remote_ mirror region as:  `regions = {'XX': ('...', 'facet', 'AA',  {'mirror_region': 'YY'})}`, such that `XX` a `YY` have no common vertices, but coors_XX = coors_YY  + C.