### PR TITLE
Mirror region misc

### DIFF
--- a/doc/users_guide.rst
+++ b/doc/users_guide.rst
@@ -1095,6 +1095,14 @@ Additional options (including solver selection)::
 
         # string, a function to modify problem definition parameters
         'parametric_hook' : '<parametric_hook_function>',
+
+        # float, default: 1e-9. If the distance between two mesh vertices
+        # is less than this value, they are considered identical.
+        # This affects:
+        # - periodic regions matching
+        # - mirror regions matching
+        # - fixing of mesh doubled vertices
+        'mesh_eps': 1e-7,
     }
 
 * ``post_process_hook`` enables computing derived quantities, like

--- a/doc/users_guide.rst
+++ b/doc/users_guide.rst
@@ -541,7 +541,7 @@ Region Definition Syntax
 Regions are defined by the following Python dictionary::
 
         regions = {
-            <name> : (<selection>, [<kind>], [<parent>]),
+            <name> : (<selection>, [<kind>], [<parent>], [{<misc. options>}]),
         }
 
 or::
@@ -557,6 +557,13 @@ or::
           'Right' : ('vertices in (x > 0.99)', 'facet'),
           'Gamma1' : ("""(cells of group 1 *v cells of group 2)
                          +v r.Right""", 'facet', 'Omega'),
+      }
+
+The mirror region can be defined explicitly as::
+
+      regions = {
+        'Top': ('r.Y *v r.Surf1', 'facet', 'Y', {'mirror_region': 'Bottom'}),
+        'Bottom': ('r.Y *v r.Surf2', 'facet', 'Y', {'mirror_region': 'Top'}),
       }
 
 .. _User's Guide-Fields:

--- a/sfepy/terms/terms.py
+++ b/sfepy/terms/terms.py
@@ -678,7 +678,9 @@ class Term(Struct):
     def get_conn_key(self):
         """The key to be used in DOF connectivity information."""
         key = (self.name,) + tuple(self.arg_names)
-        key += (self.integral_name, self.region.name)
+        is_any_trace = reduce(lambda x, y: x or y,
+                              list(self.arg_traces.values()))
+        key += (self.integral_name, self.region.name, is_any_trace)
 
         return key
 


### PR DESCRIPTION
Explanation to `get_conn_key()`:

consider the following regions:
```
'Surf1': ('...', 'facet', 'Y', {'mirror_region': 'Surf2'}),
'Surf2': ('...', 'facet', 'Y', {'mirror_region': 'Surf1'}),
```

and two variables `p` a `v`, where the field of the virtual variable `v` is a surface field defined at `Surf1` and 'p' may be the variable of a volume field defined in region `Y`, which includes `Surf1` and `Surf2`. Than the proposed fix is required to distinguish between: 
- `dw_surface_dot.i1.Surf1(v, p)` - integration over `Surf1`, where `v` and `p` are defined 
- `dw_surface_dot.i1.Surf1(v, tr(p))` - integration over `Surf1` with the trace of `p` on `Surf2`