### PR TITLE
CI update

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 #
-# SfePy minimal ammveyor.yml config file
+# SfePy minimal appveyor.yml config file
 #
 # YAML Reference Config:         https://www.appveyor.com/docs/appveyor-yml/
 # Environmental Variables Guide: https://www.appveyor.com/docs/environment-variables/
@@ -42,10 +42,10 @@ environment:
       PYTHON_ARCH: "64"
       CONDA_PY: "27"
 
-    - PYTHON: "C:\\Python36_64"
-      PYTHON_VERSION: "3.6"
+    - PYTHON: "C:\\Python37_64"
+      PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
-      CONDA_PY: "36"
+      CONDA_PY: "37"
 
 install:
   # If there is a newer build queued for the same PR, cancel this one.
@@ -63,8 +63,10 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda config --add channels conda-forge
 
+  - cmd.exe /c conda init
+
   - "conda create -q -n sfepy-test python=%PYTHON_VERSION% numpy scipy cython matplotlib pytables pyparsing sympy"
-  - activate sfepy-test
+  - conda activate sfepy-test
   #
   # Scikit UMFPACK (TBD)
   #
@@ -81,8 +83,6 @@ install:
   #
   # - conda remove -q libpython
   #
-  - conda info -a
-  - python -V
 
 #---------------------------------#
 #       build configuration       #

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ language: python
 # Enable Container-based testing
 #
 sudo: false
-dist: trusty
+dist: xenial
 
 matrix:
   include:
     - python: 2.7
-    - python: 3.6
+    - python: 3.7
 
 addons:
   apt:
@@ -43,8 +43,10 @@ before_install:
 
 install:
 
-  - conda create -q -n sfepy-test python=$TRAVIS_PYTHON_VERSION numpy scipy cython matplotlib pytables pyparsing sympy atlas
-  - source activate sfepy-test
+  - conda init bash
+  - source $(conda info --root)/etc/profile.d/conda.sh # TBD: should be made better...
+  - conda create -q -n sfepy-test python=$TRAVIS_PYTHON_VERSION numpy scipy cython matplotlib pytables pyparsing sympy
+  - conda activate sfepy-test
 
   - conda info -a
   - python -V

--- a/deployment-CI/miniconda-install.ps1
+++ b/deployment-CI/miniconda-install.ps1
@@ -89,7 +89,7 @@ function UpdateConda ($python_home) {
 
 function main () {
     InstallMiniconda $env:PYTHON_VERSION $env:PYTHON_ARCH $env:PYTHON
-    UpdateConda $env:PYTHON
+###    UpdateConda $env:PYTHON
 #
 #    InstallCondaPackages $env:PYTHON "conda-build jinja2 anaconda-client"
 #


### PR DESCRIPTION
Updated existing CI config files to follow new conda-4.7.x behavior.

Notes:
- as part of PR python 3.6->3.7 config changes was made, 
- there are some known problems with latest conda command on Windows, so update was temorary disabled (but still version 4.7 is used),
- there are still no CI config for MacOS platform ;(
- some additional clean-up of config files needed in (near) future...

LK