### PR TITLE
fix ls.schurs_mumps: 'bloc' -> 'block', use active dof info

### DIFF
--- a/sfepy/solvers/ls.py
+++ b/sfepy/solvers/ls.py
@@ -937,8 +937,8 @@ class SchurMumps(MUMPSSolver):
 
         schur_list = []
         for schur_var in conf.schur_variables:
-            slc = self.context.equations.variables.di.indx[schur_var]
-            schur_list.append(nm.arange(slc.start, slc.stop, slc.step, dtype='i') + 1)
+            slc = self.context.equations.variables.adi.indx[schur_var]
+            schur_list.append(nm.arange(slc.start, slc.stop, slc.step, dtype='i'))
 
         self.mumps_ls.set_mtx_centralized(mtx)
         out = rhs.copy()

--- a/sfepy/solvers/ls_mumps.py
+++ b/sfepy/solvers/ls_mumps.py
@@ -407,13 +407,14 @@ class MumpsSolver(object):
             The reduced right-hand side vector. 
         """
         # Schur
-        schur_size = schur_list.shape[0]
+        slist = schur_list + 1
+        schur_size = slist.shape[0]
         schur_arr = nm.empty((schur_size**2, ), dtype='d')
         schur_rhs = nm.empty((schur_size, ), dtype='d')
         self._schur_rhs = schur_rhs
 
         self.struct.size_schur = schur_size
-        self.struct.listvar_schur = schur_list.ctypes.data_as(mumps_pint)
+        self.struct.listvar_schur = slist.ctypes.data_as(mumps_pint)
         self.struct.schur = schur_arr.ctypes.data_as(mumps_pcomplex)
         self.struct.lredrhs = schur_size
         self.struct.redrhs = schur_rhs.ctypes.data_as(mumps_pcomplex)
@@ -422,8 +423,8 @@ class MumpsSolver(object):
         self.struct.schur_lld = schur_size
         self.struct.nprow = 1
         self.struct.npcol = 1
-        self.struct.mbloc = 100
-        self.struct.nbloc = 100
+        self.struct.mblock = 100
+        self.struct.nblock = 100
 
         self.struct.icntl[18] = 3  # centr. Schur complement stored by columns
         self.struct.job = 4  # analyze + factorize


### PR DESCRIPTION
This should fix #544.