### PR TITLE
do not set problem variables in CorrSetBCS

### DIFF
--- a/sfepy/homogenization/coefs_base.py
+++ b/sfepy/homogenization/coefs_base.py
@@ -498,7 +498,6 @@ class CorrSetBCS(CorrMiniApp):
         epbcs = Conditions.from_conf(conf_epbc, problem.domain.regions)
 
         conf_variables = select_by_names(problem.conf.variables, self.variable)
-        problem.set_variables(conf_variables)
         variables = Variables.from_conf(conf_variables, problem.fields)
         variables.equation_mapping(ebcs, epbcs, problem.ts, problem.functions)
         state = State(variables)


### PR DESCRIPTION
Fixes #551 .

Setting Problem.conf_variables can lead to subsequent failures since 1e5e66f9d6440665f0e40b1b5e396d7e15581e86 as other correctors/coefficients will use the set configuration, not the default one.
