### PR TITLE
fix argument type in SplineRegion2D.create_spb()

### DIFF
--- a/sfepy/mesh/splinebox.py
+++ b/sfepy/mesh/splinebox.py
@@ -394,7 +394,7 @@ class SplineRegion2D(SplineBox):
         bnd_poly = []
         bnd_cp = []
         for s in spl_bnd:
-            s.set_param_n(rho)
+            s.set_param_n(int(rho))
             bnd_poly.append(s.eval()[:-1])
             bnd_cp.append(s.get_control_points()[:-1, :])
 


### PR DESCRIPTION
- fixes Travis CI failure for Python 3.7, numpy-1.18.1

@vlukes, do you agree with the fix? See #574 for the failure.