### PR TITLE
lower memory usage of HomogenizationEngine

### DIFF
--- a/sfepy/homogenization/engine.py
+++ b/sfepy/homogenization/engine.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division
+import gc
 from copy import copy
 
 from sfepy.base.base import output, get_default, Struct
@@ -103,6 +104,7 @@ class HomogenizationWorker(object):
                                      time_tag)
 
             dependencies[name] = val
+            gc.collect()
 
         return dependencies, save_names
 
@@ -165,7 +167,7 @@ class HomogenizationWorker(object):
             val = []
             if hasattr(mini_app, 'store_idxs') and mode == 'reqs':
                 save_name = mini_app.save_name
-            
+
             local_coors = local_state['coors']
             for im in range(len(local_coors)):
                 output('== micro %s%s-%d =='


### PR DESCRIPTION
Hi @vlukes,

I have tried forcing garbage collection in `HomogenizationWorker.__call__()` and the results are (on one of my problems):

![memory_profiles](https://user-images.githubusercontent.com/44282/79073546-91956c80-7ce7-11ea-85d8-0942df0979fb.png)

The black curve is before and the blue one is after the patch. As you can see, the improvement is significant, while the time overhead is next to none (the time steps coincide in the figure).

I wonder if the same thing can be done in the parallel workers - do you have an idea (patches welcome), where to put the `gc.collect()` calls? It would be great if you could try it on some of your large problems that you run in parallel.

For the profiling, I am using https://github.com/pythonprofilers/memory_profiler:
```
mprof run <script.py>
mprof plot
```
