### PR TITLE
Add fallback to lib*.dll name for loading mumps on win.

### DIFF
--- a/sfepy/solvers/ls_mumps.py
+++ b/sfepy/solvers/ls_mumps.py
@@ -39,6 +39,8 @@ def load_library(libname):
         from ctypes.util import find_library
 
         lib_fname = find_library(libname)
+        if lib_fname is None:
+            lib_fname = find_library('lib' + libname)
 
     else:  # Linux system
         lib_fname = 'lib' + libname + '.so'


### PR DESCRIPTION
Fixes #608
Simple fallback for win systems to `lib[libname].dll` when mumps is not found as `[libname].dll`