### PR TITLE
fix volumes in DensityVolumeInfo class

### DIFF
--- a/sfepy/homogenization/coefs_phononic.py
+++ b/sfepy/homogenization/coefs_phononic.py
@@ -718,7 +718,7 @@ class DensityVolumeInfo(MiniAppBase):
 
         return Struct(name='density_volume_info',
                       average_density=average_density,
-                      total_volume=total_volume,
+                      total_volume=true_volume,
                       volumes=volumes,
                       densities=densities,
                       to_file_txt=self.to_file_txt)


### PR DESCRIPTION
I think that all the coefficients should be divided by the whole volume of the reference cell, i.e. by `true_volume`.