### PR TITLE
Create list for each term of links to examples

### DIFF
--- a/script/gen_term_table.py
+++ b/script/gen_term_table.py
@@ -130,10 +130,17 @@ def typeset_term_syntax(term_class):
         text = ', '.join(['``<%s>``' % arg for arg in term_class.arg_types])
     return text
 
-link_example = ':doc:`%s<examples/%s>`'
+link_example = ':ref:`%s <%s>`'
+
+omits = [
+    'vibro_acoustic3d_mid.py',
+    'its2D_5.py',
+    'linear_elastic_probes.py',
+    '__init__.py',
+]
 
 def typeset_examples(term_class, term_use):
-    link_list = [(link_example % (exmpl, exmpl)) for exmpl in term_use[term_class.name]]
+    link_list = [(link_example % (exmpl.split('-')[-1], exmpl)) for exmpl in term_use[term_class.name]]
     return ', '.join(link_list)
 
 def get_examples(table):
@@ -148,13 +155,20 @@ def get_examples(table):
         except:
             continue
         
-        example_name = filename.split('/')[-2]
+        ebase = filename.split('examples/')[1]
+        lbase = os.path.splitext(ebase)[0]
+        label = lbase.replace('/', '-')
+
+        pyfile_name = ebase.split('/')[1]
+        if pyfile_name in omits:
+            continue
+
         use = conf.options.get('use_equations', 'equations')
         eqs_conf = getattr(conf, use)
         for key, eq_conf in six.iteritems(eqs_conf):
             term_descs = parse_definition(eq_conf)
             for td in term_descs:
-                term_use[td.name].add(example_name)
+                term_use[td.name].add(label)
 
     return term_use
 

--- a/script/gen_term_table.py
+++ b/script/gen_term_table.py
@@ -141,12 +141,14 @@ omits = [
 
 def typeset_examples(term_class, term_use):
     # e.g. fem-time_advection_diffusion -> tim.adv.dif.
-    to_shorter_name = lambda st: '.'.join([s[:3] for s in st.split('-')[-1].split('_')])
-    link_list = [(link_example % (to_shorter_name(exmpl), exmpl)) for exmpl in term_use[term_class.name]]
+    to_shorter_name = lambda st: '.'.join(
+                    [s[:3] for s in st.split('-')[-1].split('_')])
+    link_list = [(link_example % (to_shorter_name(exmpl), exmpl))
+                    for exmpl in term_use[term_class.name]]
     return ', '.join(link_list)
 
 def get_examples(table):
-    
+
     term_use = dict_from_keys_init(table.keys(), set)
     required, other = get_standard_keywords()
 
@@ -156,7 +158,7 @@ def get_examples(table):
                                          verbose=False)
         except:
             continue
-        
+
         ebase = filename.split('examples/')[1]
         lbase = os.path.splitext(ebase)[0]
         label = lbase.replace('/', '-')

--- a/script/gen_term_table.py
+++ b/script/gen_term_table.py
@@ -133,7 +133,6 @@ def typeset_term_syntax(term_class):
 link_example = ':doc:`%s<examples/%s>`'
 
 def typeset_examples(term_class, term_use):
-    print(len(term_use[term_class.name]))
     link_list = [(link_example % (exmpl, exmpl)) for exmpl in term_use[term_class.name]]
     return ', '.join(link_list)
 

--- a/script/gen_term_table.py
+++ b/script/gen_term_table.py
@@ -67,14 +67,14 @@ header = """
      - arguments
      - definition
 """
-
+# TODO add additional column
 table_row = """   * - %s
 
        :class:`%s <%s.%s>`
      - %s
      - %s
 """
-
+# TODO add additional %s 
 def format_next(text, new_text, pos, can_newline, width, ispaces):
     new_len = len(new_text)
 
@@ -125,6 +125,7 @@ def typeset_term_syntax(term_class):
 
 def typeset_term_table(fd, keys, table, title):
     """Terms are sorted by name without the d*_ prefix."""
+    #TODO add somehow list of term used in examples
     sec_list = []
     current_section = ['']
     parser = create_parser(sec_list, current_section)
@@ -151,7 +152,7 @@ def typeset_term_table(fd, keys, table, title):
                 dd = dd[0]
             else:
                 dd = ''
-
+            # TODO add new column
             dds = dd.strip().split('\n\n')
             definition = '\n\n'.join(typeset_to_indent(dd, 7, 11, 65)
                                      for dd in dds)[7:]

--- a/script/gen_term_table.py
+++ b/script/gen_term_table.py
@@ -62,9 +62,9 @@ newpage = r"""
 """
 
 header = """
-.. tabularcolumns:: |p{0.17\linewidth}|p{0.17\linewidth}|p{0.5\linewidth}|p{0.16\linewidth}|
+.. tabularcolumns:: |p{0.15\linewidth}|p{0.10\linewidth}|p{0.6\linewidth}|p{0.15\linewidth}|
 .. list-table:: %s terms
-   :widths: 17 17 50 16
+   :widths: 15 10 60 15
    :header-rows: 1
    :class: longtable
 
@@ -140,7 +140,9 @@ omits = [
 ]
 
 def typeset_examples(term_class, term_use):
-    link_list = [(link_example % (exmpl.split('-')[-1], exmpl)) for exmpl in term_use[term_class.name]]
+    # e.g. fem-time_advection_diffusion -> tim.adv.dif.
+    to_shorter_name = lambda st: '.'.join([s[:3] for s in st.split('-')[-1].split('_')])
+    link_list = [(link_example % (to_shorter_name(exmpl), exmpl)) for exmpl in term_use[term_class.name]]
     return ', '.join(link_list)
 
 def get_examples(table):

--- a/script/show_terms_use.py
+++ b/script/show_terms_use.py
@@ -21,7 +21,6 @@ helps = {
 }
 
 def main():
-    # TODO add return value
     parser = ArgumentParser(description=__doc__)
     parser.add_argument('--version', action='version', version='%(prog)s')
     parser.add_argument('-c', '--counts',

--- a/script/show_terms_use.py
+++ b/script/show_terms_use.py
@@ -21,6 +21,7 @@ helps = {
 }
 
 def main():
+    # TODO add return value
     parser = ArgumentParser(description=__doc__)
     parser.add_argument('--version', action='version', version='%(prog)s')
     parser.add_argument('-c', '--counts',

--- a/sfepy/terms/terms_adj_navier_stokes.py
+++ b/sfepy/terms/terms_adj_navier_stokes.py
@@ -227,12 +227,12 @@ class SDDotVolumeTerm(Term):
     :Arguments:
         - parameter_1 : :math:`p` or :math:`\ul{u}`
         - parameter_2 : :math:`q` or :math:`\ul{w}`
-        - parameter_mesh_velocity : :math:`\ul{\Vcal}`
+        - parameter_mv : :math:`\ul{\Vcal}`
     """
     name = 'd_sd_volume_dot'
-    arg_types = ('parameter_1', 'parameter_2', 'parameter_mesh_velocity')
+    arg_types = ('parameter_1', 'parameter_2', 'parameter_mv')
     arg_shapes = [{'parameter_1' : 'D', 'parameter_2' : 'D',
-                   'parameter_mesh_velocity' : 'D'},
+                   'parameter_mv' : 'D'},
                   {'parameter_1' : 1, 'parameter_2' : 1}]
 
     function = staticmethod(terms.d_sd_volume_dot)
@@ -268,12 +268,12 @@ class SDDivTerm(Term):
     :Arguments:
         - parameter_u : :math:`\ul{u}`
         - parameter_p : :math:`p`
-        - parameter_mesh_velocity : :math:`\ul{\Vcal}`
+        - parameter_mv : :math:`\ul{\Vcal}`
     """
     name = 'd_sd_div'
-    arg_types = ('parameter_u', 'parameter_p', 'parameter_mesh_velocity')
+    arg_types = ('parameter_u', 'parameter_p', 'parameter_mv')
     arg_shapes = {'parameter_u' : 'D', 'parameter_p' : 1,
-                  'parameter_mesh_velocity' : 'D'}
+                  'parameter_mv' : 'D'}
 
     function = staticmethod(terms.d_sd_div)
 
@@ -315,14 +315,14 @@ class SDDivGradTerm(Term):
         - material_2  : :math:`\nu` (viscosity)
         - parameter_u : :math:`\ul{u}`
         - parameter_w : :math:`\ul{w}`
-        - parameter_mesh_velocity : :math:`\ul{\Vcal}`
+        - parameter_mv : :math:`\ul{\Vcal}`
     """
     name = 'd_sd_div_grad'
     arg_types = ('material_1', 'material_2', 'parameter_u', 'parameter_w',
-                 'parameter_mesh_velocity')
+                 'parameter_mv')
     arg_shapes = {'material_1' : '1, 1', 'material_2' : '1, 1',
                   'parameter_u' : 'D', 'parameter_w' : 'D',
-                  'parameter_mesh_velocity' : 'D'}
+                  'parameter_mv' : 'D'}
 
     function = staticmethod(terms.d_sd_div_grad)
 
@@ -359,12 +359,12 @@ class SDConvectTerm(Term):
     :Arguments:
         - parameter_u : :math:`\ul{u}`
         - parameter_w : :math:`\ul{w}`
-        - parameter_mesh_velocity : :math:`\ul{\Vcal}`
+        - parameter_mv : :math:`\ul{\Vcal}`
     """
     name = 'd_sd_convect'
-    arg_types = ('parameter_u', 'parameter_w', 'parameter_mesh_velocity')
+    arg_types = ('parameter_u', 'parameter_w', 'parameter_mv')
     arg_shapes = {'parameter_u' : 'D', 'parameter_w' : 'D',
-                  'parameter_mesh_velocity' : 'D'}
+                  'parameter_mv' : 'D'}
 
     function = staticmethod(terms.d_sd_convect)
 
@@ -483,15 +483,15 @@ class SDGradDivStabilizationTerm(Term):
         - material    : :math:`\gamma`
         - parameter_u : :math:`\ul{u}`
         - parameter_w : :math:`\ul{w}`
-        - parameter_mesh_velocity : :math:`\ul{\Vcal}`
+        - parameter_mv : :math:`\ul{\Vcal}`
         - mode        : 1 (sensitivity) or 0 (original term value)
     """
     name = 'd_sd_st_grad_div'
     arg_types = ('material', 'parameter_u', 'parameter_w',
-                 'parameter_mesh_velocity')
+                 'parameter_mv')
     arg_shapes = {'material' : '1, 1',
                   'parameter_u' : 'D', 'parameter_w' : 'D',
-                  'parameter_mesh_velocity' : 'D'}
+                  'parameter_mv' : 'D'}
 
     function = staticmethod(terms.d_sd_st_grad_div)
 
@@ -532,15 +532,15 @@ class SDSUPGCStabilizationTerm(Term):
         - parameter_b : :math:`\ul{b}`
         - parameter_u : :math:`\ul{u}`
         - parameter_w : :math:`\ul{w}`
-        - parameter_mesh_velocity : :math:`\ul{\Vcal}`
+        - parameter_mv : :math:`\ul{\Vcal}`
         - mode        : 1 (sensitivity) or 0 (original term value)
     """
     name = 'd_sd_st_supg_c'
     arg_types = ('material', 'parameter_b', 'parameter_u', 'parameter_w',
-                'parameter_mesh_velocity')
+                'parameter_mv')
     arg_shapes = {'material' : '1, 1',
                   'parameter_b' : 'D', 'parameter_u' : 'D', 'parameter_w' : 'D',
-                  'parameter_mesh_velocity' : 'D'}
+                  'parameter_mv' : 'D'}
 
     function = staticmethod(terms.d_sd_st_supg_c)
 
@@ -580,15 +580,15 @@ class SDPSPGCStabilizationTerm(Term):
         - parameter_b : :math:`\ul{b}`
         - parameter_u : :math:`\ul{u}`
         - parameter_r : :math:`r`
-        - parameter_mesh_velocity : :math:`\ul{\Vcal}`
+        - parameter_mv : :math:`\ul{\Vcal}`
         - mode        : 1 (sensitivity) or 0 (original term value)
     """
     name = 'd_sd_st_pspg_c'
     arg_types = ('material', 'parameter_b', 'parameter_u', 'parameter_r',
-                'parameter_mesh_velocity')
+                'parameter_mv')
     arg_shapes = {'material' : '1, 1',
                   'parameter_b' : 'D', 'parameter_u' : 'D', 'parameter_r' : 1,
-                  'parameter_mesh_velocity' : 'D'}
+                  'parameter_mv' : 'D'}
 
     function = staticmethod(terms.d_sd_st_pspg_c)
 
@@ -625,15 +625,15 @@ class SDPSPGPStabilizationTerm(Term):
         - material    : :math:`\tau_K`
         - parameter_r : :math:`r`
         - parameter_p : :math:`p`
-        - parameter_mesh_velocity : :math:`\ul{\Vcal}`
+        - parameter_mv : :math:`\ul{\Vcal}`
         - mode        : 1 (sensitivity) or 0 (original term value)
     """
     name = 'd_sd_st_pspg_p'
     arg_types = ('material', 'parameter_r', 'parameter_p',
-                'parameter_mesh_velocity')
+                'parameter_mv')
     arg_shapes = {'material' : '1, 1',
                   'parameter_r' : 1, 'parameter_p' : 1,
-                  'parameter_mesh_velocity' : 'D'}
+                  'parameter_mv' : 'D'}
 
     function = staticmethod(terms.d_sd_st_pspg_p)
 

--- a/sfepy/terms/terms_dg.py
+++ b/sfepy/terms/terms_dg.py
@@ -283,10 +283,10 @@ class DiffusionDGFluxTerm(DGTerm):
 
     """
     name = "dw_dg_diffusion_flux"
-    arg_types = (('material_diffusion_tensor', 'state', 'virtual'), # left
-                 ('material_diffusion_tensor', 'virtual', 'state') # right
+    arg_types = (('material', 'state', 'virtual'), # left
+                 ('material', 'virtual', 'state') # right
                  )
-    arg_shapes = [{'material_diffusion_tensor': '1, 1',
+    arg_shapes = [{'material': '1, 1',
                    'virtual/avg_state': (1, None),
                    'state/avg_state' : 1,
                    'virtual/avg_virtual': (1, None),
@@ -464,9 +464,9 @@ class DiffusionInteriorPenaltyTerm(DGTerm):
     """
     name = "dw_dg_interior_penalty"
     modes = ("weak",)
-    arg_types = ('material_diffusion_tensor', 'material_Cw',
+    arg_types = ('material', 'material_Cw',
                  'virtual', 'state')
-    arg_shapes = [{'material_diffusion_tensor': '1, 1',
+    arg_shapes = [{'material': '1, 1',
                    'material_Cw': '.: 1',
                    'virtual'    : (1, 'state'),
                    'state'      : 1


### PR DESCRIPTION
In this PR, I've added a column to the table of terms in the documentation. You can find in this column links to examples that use a specific term.
The file [`script/gen_term_table.py`](https://github.com/antonykamp/sfepy/blob/374-doc-link-terms-example/script/gen_term_table.py) does this by fetching a list of examples for a term-class like [`script/show_terms_use.py`](https://github.com/antonykamp/sfepy/blob/374-doc-link-terms-example/script/gen_term_table.py). Afterward, it generates with the generated list reference-links to the file of the examples.

One little issue remains: The perfect widths of the columns. Maybe we can discuss this in this PR because the table itself crosses the edge of the site at the moment.

fixes #374 