### PR TITLE
Material shape update

### DIFF
--- a/doc/users_guide.rst
+++ b/doc/users_guide.rst
@@ -1055,6 +1055,10 @@ The function needs to be registered in `Functions`_::
       'get_pars' : (get_pars,),
   }
 
+If a material parameter has the same value in all quadrature points, than it is
+not necessary to repeat the constant and the array can be with shape
+`(1, n_row, n_col)`.
+
 Equations and Terms
 ^^^^^^^^^^^^^^^^^^^
 

--- a/examples/linear_elasticity/linear_viscoelastic.py
+++ b/examples/linear_elasticity/linear_viscoelastic.py
@@ -106,11 +106,8 @@ def get_th_pars(ts, coors, mode=None, times=None, kernel=None, **kwargs):
         out['H'] = interp_conv_mat(kernel, ts, times)
 
     elif mode == 'qp':
-        out['H0'] = kernel[0]
-        out['Hd'] = kernel[1, 0, 0] / kernel[0, 0, 0]
-
-        for key, val in six.iteritems(out):
-            out[key] = nm.tile(val, (coors.shape[0], 1, 1))
+        out['H0'] = kernel[0][None, ...]
+        out['Hd'] = nm.array([[[kernel[1, 0, 0] / kernel[0, 0, 0]]]])
 
     return out
 

--- a/examples/multi_physics/biot_short_syntax.py
+++ b/examples/multi_physics/biot_short_syntax.py
@@ -75,17 +75,14 @@ def get_pars(ts, coor, mode, **kwargs):
         n_nod, dim = coor.shape
 
         out = {}
-        out['D'] = nm.tile(stiffness_from_lame(dim, lam=1.7, mu=0.3),
-                           (coor.shape[0], 1, 1))
+        out['D'] = stiffness_from_lame(dim, lam=1.7, mu=0.3)[None, ...]
 
-        alpha = [[0.132, 0.092],
-                 [0.052, 0.132]]
-        out['alpha'] = nm.tile(alpha, (coor.shape[0], 1, 1))
+        out['alpha'] = nm.array([[[0.132, 0.092],
+                                  [0.052, 0.132]]])
 
-        perm = nm.eye(dim, dtype=nm.float64)
-        out['K'] = nm.tile(perm, (coor.shape[0], 1, 1))
+        out['K'] = nm.eye(dim, dtype=nm.float64)[None, ...]
 
-        out['np_eps'] = nm.tile(1e5, (coor.shape[0], 1, 1))
+        out['np_eps'] = nm.array([[[1e5]]])
 
         return out
 

--- a/examples/multi_physics/piezo_elasticity.py
+++ b/examples/multi_physics/piezo_elasticity.py
@@ -114,7 +114,7 @@ def get_inclusion_pars(ts, coor, mode=None, **kwargs):
     """TODO: implement proper 3D -> 2D transformation of constitutive
     matrices."""
     if mode == 'qp':
-        n_nod, dim = coor.shape
+        _, dim = coor.shape
         sym = (dim + 1) * dim // 2
 
         dielectric = nm.eye(dim, dtype=nm.float64)
@@ -129,11 +129,12 @@ def get_inclusion_pars(ts, coor, mode=None, **kwargs):
             'dielectric' : dielectric,
             # piezoelectric coupling
             'coupling' : coupling,
-            'density' : 0.1142, # in 1e4 kg/m3
+            'density' : nm.array([[0.1142]]), # in 1e4 kg/m3
         }
 
         for key, val in six.iteritems(out):
-            out[key] = nm.tile(val, (coor.shape[0], 1, 1))
+            out[key] = val[None, ...]
+
         return out
 
 materials = {

--- a/sfepy/discrete/materials.py
+++ b/sfepy/discrete/materials.py
@@ -5,7 +5,7 @@ from sfepy.base.base import (Struct, Container, OneTypeList, assert_,
 from sfepy.base.timing import Timer
 from .functions import ConstantFunction, ConstantFunctionByRegion
 import six
-
+import numpy as nm
 
 class Materials(Container):
 
@@ -190,7 +190,11 @@ class Material(Struct):
                     raise ValueError('material parameter array must have'
                                      " three dimensions! ('%s' has %d)"
                                      % (dkey, val.ndim))
-                new_data[dkey] = val.reshape(qps.get_shape(val.shape))
+                qps_shape = qps.get_shape(val.shape)
+                if qps_shape[0] == 0:
+                    new_data[dkey] = nm.tile(val, (1, qps_shape[1], 1, 1))
+                else:
+                    new_data[dkey] = val.reshape(qps_shape)
 
         self.datas[key] = new_data
 

--- a/sfepy/terms/extmods/terms_adj_navier_stokes.c
+++ b/sfepy/terms/extmods/terms_adj_navier_stokes.c
@@ -591,7 +591,7 @@ int32 d_sd_div_grad( FMField *out, FMField *gradU, FMField *gradW,
     FMF_SetCell( out, ii );
     FMF_SetCell( gradU, ii );
     FMF_SetCell( gradW, ii );
-    FMF_SetCell( viscosity, ii );
+    FMF_SetCellX1( viscosity, ii );
     FMF_SetCell( vg_u->det, ii );
 
     // (gu:gw)

--- a/sfepy/terms/extmods/terms_biot.c
+++ b/sfepy/terms/extmods/terms_biot.c
@@ -98,7 +98,7 @@ int32 dw_biot_grad( FMField *out, float64 coef, FMField *pressure_qp,
 
   for (ii = 0; ii < out->nCell; ii++) {
     FMF_SetCell( out, ii );
-    FMF_SetCell( mtxD, ii );
+    FMF_SetCellX1( mtxD, ii );
     FMF_SetCell( vvg->bfGM, ii );
     FMF_SetCell( vvg->det, ii );
 
@@ -178,7 +178,7 @@ int32 dw_biot_div( FMField *out, float64 coef, FMField *strain,
 
   for (ii = 0; ii < out->nCell; ii++) {
     FMF_SetCell( out, ii );
-    FMF_SetCell( mtxD, ii );
+    FMF_SetCellX1( mtxD, ii );
     FMF_SetCell( vvg->bfGM, ii );
     FMF_SetCell( vvg->det, ii );
     FMF_SetCellX1( svg->bf, ii );
@@ -237,7 +237,7 @@ int32 d_biot_div( FMField *out, float64 coef, FMField *state, FMField *strain,
 
   for (ii = 0; ii < out->nCell; ii++) {
     FMF_SetCell( out, ii );
-    FMF_SetCell( mtxD, ii );
+    FMF_SetCellX1( mtxD, ii );
     FMF_SetCell( vg->det, ii );
     FMF_SetCell( state, ii );
     FMF_SetCell( strain, ii );

--- a/sfepy/terms/extmods/terms_diffusion.c
+++ b/sfepy/terms/extmods/terms_diffusion.c
@@ -369,9 +369,7 @@ int32 dw_diffusion( FMField *out, FMField *grad,
     FMF_SetCell( out, ii );
     FMF_SetCell( vg->bfGM, ii );
     FMF_SetCell( vg->det, ii );
-    if (mtxD->nCell > 1) {
-      FMF_SetCell( mtxD, ii );
-    }
+    FMF_SetCellX1( mtxD, ii );
 
     if (isDiff) {
       fmf_mulATB_nn( gtd, vg->bfGM, mtxD );
@@ -422,9 +420,7 @@ int32 d_diffusion( FMField *out, FMField *gradP1, FMField *gradP2,
     FMF_SetCell( vg->det, ii );
     FMF_SetCell( gradP1, ii );
     FMF_SetCell( gradP2, ii );
-    if (mtxD->nCell > 1) {
-      FMF_SetCell( mtxD, ii );
-    }
+    FMF_SetCellX1( mtxD, ii );
 
     fmf_mulAB_nn( dgp2, mtxD, gradP2 );
     fmf_mulATB_nn( gp1tdgp2, gradP1, dgp2 );
@@ -463,7 +459,7 @@ int32 d_sd_diffusion(FMField *out,
   for (ii = 0; ii < out->nCell; ii++) {
     FMF_SetCell( vg->bfGM, ii );
     FMF_SetCell( vg->det, ii );
-    FMF_SetCell( mtxD, ii );
+    FMF_SetCellX1( mtxD, ii );
     FMF_SetCell( grad_q, ii );
     FMF_SetCell( grad_p, ii );
     FMF_SetCell( grad_w, ii );
@@ -521,9 +517,7 @@ int32 dw_diffusion_r( FMField *out, FMField *mtxD, Mapping *vg )
     FMF_SetCell( out, ii );
     FMF_SetCell( vg->bfGM, ii );
     FMF_SetCell( vg->det, ii );
-    if (mtxD->nCell > 1) {
-      FMF_SetCell( mtxD, ii );
-    }
+    FMF_SetCellX1( mtxD, ii );
 
     fmf_mulATB_nn( gtd, vg->bfGM, mtxD );
     fmf_sumLevelsMulF( out, gtd, vg->det->val );
@@ -553,7 +547,7 @@ int32 d_surface_flux( FMField *out, FMField *grad,
   for (ii = 0; ii < out->nCell; ii++) {
     FMF_SetCell( out, ii );
     FMF_SetCell( grad, ii );
-    FMF_SetCell( mtxD, ii );
+    FMF_SetCellX1( mtxD, ii );
     FMF_SetCell( sg->normal, ii );
     FMF_SetCell( sg->det, ii );
 

--- a/sfepy/terms/extmods/terms_elastic.c
+++ b/sfepy/terms/extmods/terms_elastic.c
@@ -27,8 +27,8 @@ int32 mat_le_stress( FMField *stress, FMField *strain,
 
   if (sym == 6) {
     for (iell = 0; iell < stress->nCell; iell++) {
-      FMF_SetCell( lam, iell );
-      FMF_SetCell( mu, iell );
+      FMF_SetCellX1( lam, iell );
+      FMF_SetCellX1( mu, iell );
       pstress = FMF_PtrCell( stress, iell );
       pstrain = FMF_PtrCell( strain, iell );
       if ((1)) {
@@ -64,8 +64,8 @@ int32 mat_le_stress( FMField *stress, FMField *strain,
     }
   } else if (sym == 3) {
     for (iell = 0; iell < stress->nCell; iell++) {
-      FMF_SetCell( lam, iell );
-      FMF_SetCell( mu, iell );
+      FMF_SetCellX1( lam, iell );
+      FMF_SetCellX1( mu, iell );
       pstress = FMF_PtrCell( stress, iell );
       pstrain = FMF_PtrCell( strain, iell );
       if ((1)) {
@@ -126,7 +126,7 @@ int32 dw_lin_elastic( FMField *out, float64 coef, FMField *strain,
 
     for (ii = 0; ii < out->nCell; ii++) {
       FMF_SetCell( out, ii );
-      FMF_SetCell( mtxD, ii );
+      FMF_SetCellX1( mtxD, ii );
       FMF_SetCell( vg->bfGM, ii );
       FMF_SetCell( vg->det, ii );
 
@@ -142,7 +142,7 @@ int32 dw_lin_elastic( FMField *out, float64 coef, FMField *strain,
 
     for (ii = 0; ii < out->nCell; ii++) {
       FMF_SetCell( out, ii );
-      FMF_SetCell( mtxD, ii );
+      FMF_SetCellX1( mtxD, ii );
       FMF_SetCell( vg->bfGM, ii );
       FMF_SetCell( vg->det, ii );
       FMF_SetCell( strain, ii );
@@ -189,7 +189,7 @@ int32 d_lin_elastic( FMField *out, float64 coef, FMField *strainV,
 
   for (ii = 0; ii < out->nCell; ii++) {
     FMF_SetCell( out, ii );
-    FMF_SetCell( mtxD, ii );
+    FMF_SetCellX1( mtxD, ii );
     FMF_SetCell( vg->det, ii );
     FMF_SetCell( strainV, ii );
     FMF_SetCell( strainU, ii );
@@ -242,7 +242,7 @@ int32 d_sd_lin_elastic(FMField *out, float64 coef, FMField *gradV,
 
   for (ii = 0; ii < nEL; ii++) {
     FMF_SetCell(out, ii);
-    FMF_SetCell(mtxD, ii);
+    FMF_SetCellX1(mtxD, ii);
     FMF_SetCell(vg->det, ii);
     FMF_SetCell(gradv, ii);
     FMF_SetCell(gradu, ii);
@@ -355,7 +355,7 @@ int32 dw_lin_prestress( FMField *out, FMField *stress, Mapping *vg )
       FMF_SetCell( out, ii );
       FMF_SetCell( vg->bfGM, ii );
       FMF_SetCell( vg->det, ii );
-      FMF_SetCell( stress, ii );
+      FMF_SetCellX1( stress, ii );
 
       if ((stress->nRow == (dim * dim)) && (dim != 1)) {
         build_nonsym_grad(ng, vg->bfGM);
@@ -392,8 +392,8 @@ int32 dw_lin_strain_fib( FMField *out, FMField *mtxD, FMField *mat,
 
   for (ii = 0; ii < out->nCell; ii++) {
     FMF_SetCell( out, ii );
-    FMF_SetCell( mtxD, ii );
-    FMF_SetCell( mat, ii );
+    FMF_SetCellX1( mtxD, ii );
+    FMF_SetCellX1( mat, ii );
     FMF_SetCell( vg->bfGM, ii );
     FMF_SetCell( vg->det, ii );
 
@@ -459,7 +459,7 @@ int32 de_cauchy_stress( FMField *out, FMField *strain,
 
   for (ii = 0; ii < out->nCell; ii++) {
     FMF_SetCell( out, ii );
-    FMF_SetCell( mtxD, ii );
+    FMF_SetCellX1( mtxD, ii );
     FMF_SetCell( strain, ii );
     FMF_SetCell( vg->det, ii );
 
@@ -538,7 +538,7 @@ int32 dw_nonsym_elastic(FMField *out, FMField *grad, FMField *mtxD,
 
     for (ii = 0; ii < out->nCell; ii++) {
       FMF_SetCell(out, ii);
-      FMF_SetCell(mtxD, ii );
+      FMF_SetCellX1(mtxD, ii );
       FMF_SetCell(vg->bfGM, ii);
       FMF_SetCell(vg->det, ii);
 
@@ -555,7 +555,7 @@ int32 dw_nonsym_elastic(FMField *out, FMField *grad, FMField *mtxD,
 
     for (ii = 0; ii < out->nCell; ii++) {
       FMF_SetCell(out, ii);
-      FMF_SetCell(mtxD, ii);
+      FMF_SetCellX1(mtxD, ii);
       FMF_SetCell(vg->bfGM, ii);
       FMF_SetCell(vg->det, ii);
       FMF_SetCell(grad, ii);

--- a/sfepy/terms/extmods/terms_piezo.c
+++ b/sfepy/terms/extmods/terms_piezo.c
@@ -35,7 +35,7 @@ int32 dw_piezo_coupling( FMField *out, FMField *strain, FMField *charge_grad,
 
   for (ii = 0; ii < out->nCell; ii++) {
     FMF_SetCell( out, ii );
-    FMF_SetCell( mtxG, ii );
+    FMF_SetCellX1( mtxG, ii );
     FMF_SetCell( vg->bfGM, ii );
     FMF_SetCell( vg->det, ii );
 
@@ -96,7 +96,7 @@ int32 d_piezo_coupling( FMField *out, FMField *strain, FMField *charge_grad,
 
   for (ii = 0; ii < out->nCell; ii++) {
     FMF_SetCell( out, ii );
-    FMF_SetCell( mtxG, ii );
+    FMF_SetCellX1( mtxG, ii );
     FMF_SetCell( vg->det, ii );
     FMF_SetCell( strain, ii );
     FMF_SetCell( charge_grad, ii );


### PR DESCRIPTION
The PR allows for material shape (1, M, N). It is tiled into (0, 8, 1, 1) which is which is handled by `FMFSetCelX1()`. This can save a lot of memory.