### PR TITLE
update CoefMN.set_variables_default()

### DIFF
--- a/sfepy/homogenization/coefs_base.py
+++ b/sfepy/homogenization/coefs_base.py
@@ -873,7 +873,9 @@ class CoefMN(MiniAppBase):
             act_set_var = set_var
         else:
             mode2var = {'row': 0, 'col': 1}
-            act_set_var = [set_var[mode2var[mode]]] + set_var[2:]
+            aux = set_var[mode2var[mode]]
+            act_set_var = aux[:] if isinstance(aux, list) else [aux]
+            act_set_var += set_var[2:]
 
         for (var, req, comp) in act_set_var:
             if type(req) is tuple:


### PR DESCRIPTION
This PR allows for evaluation of several terms with distinct variables.

Example:
```
        'sA1': {
            'requires': ['pis_u', 'corrs_rs', 'dvelocity'],
            'expression': '   d_sd_lin_elastic.i2.Ys(matrix.D, U1, U2, V)'
                          ' - d_sd_diffusion.i2.Yp(piezo.d, R1, R2, V)',
            'set_variables': [[('U1', ('corrs_rs', 'pis_u'), 'u'),
                               ('R1', 'corrs_rs', 'r')],
                              [('U2', ('corrs_rs', 'pis_u'), 'u'),
                               ('R2', 'corrs_rs', 'r')],
                              ('V', 'dvelocity', 'v')],
            'class': cb.CoefSymSym,
        },
```