### PR TITLE
Volume/surface terms clean-up

### DIFF
--- a/doc/developer_guide.rst
+++ b/doc/developer_guide.rst
@@ -759,7 +759,7 @@ implemented as follows::
         :Definition:
 
         .. math::
-            \int_\Omega q \mbox{ or } \int_\Omega c q
+            \int_{\cal{D}} q \mbox{ or } \int_{\cal{D}} c q
 
         :Arguments:
             - material : :math:`c` (optional)

--- a/doc/terms_overview.rst
+++ b/doc/terms_overview.rst
@@ -26,6 +26,8 @@ The following notation is used:
      - volume (sub)domain
    * - :math:`\Gamma`
      - surface (sub)domain
+   * - :math:`\cal{D}`
+     - volume or surface (sub)domain
    * - :math:`d`
      - dimension of space
    * - :math:`t`

--- a/doc/users_guide.rst
+++ b/doc/users_guide.rst
@@ -1585,7 +1585,7 @@ as discussed in :ref:`miscellaneous_options`, see `'post_process_hook'` and
 - compute volume of a region (`u` is any variable defined in the region
   `Omega`)::
 
-    volume = problem.evaluate('d_volume.2.Omega(u)')
+    volume = problem.evaluate('ev_volume.2.Omega(u)')
 
 Probing
 -------

--- a/examples/acoustics/acoustics.py
+++ b/examples/acoustics/acoustics.py
@@ -57,8 +57,8 @@ integrals = {
 equations = {
     'Acoustic pressure' :
     """%s * dw_laplace.i.Omega( one.one, q, p )
-    - %s * dw_volume_dot.i.Omega( q, p )
-    - %s * dw_surface_dot.i.Gamma_out( q, p )
+    - %s * dw_dot.i.Omega( q, p )
+    - %s * dw_dot.i.Gamma_out( q, p )
     = %s * dw_integrate.i.Gamma_in( q )"""
     % (c*c, w*w, 1j*w*c, 1j*w*c*c*rho*v_n)
 }

--- a/examples/acoustics/acoustics.py
+++ b/examples/acoustics/acoustics.py
@@ -59,7 +59,7 @@ equations = {
     """%s * dw_laplace.i.Omega( one.one, q, p )
     - %s * dw_volume_dot.i.Omega( q, p )
     - %s * dw_surface_dot.i.Gamma_out( q, p )
-    = %s * dw_surface_integrate.i.Gamma_in( q )"""
+    = %s * dw_integrate.i.Gamma_in( q )"""
     % (c*c, w*w, 1j*w*c, 1j*w*c*c*rho*v_n)
 }
 

--- a/examples/acoustics/acoustics3d.py
+++ b/examples/acoustics/acoustics3d.py
@@ -83,11 +83,11 @@ integrals = {
 
 equations = {
     'Acoustic pressure' :
-    """%s * dw_volume_dot.i.Omega_1(q_1, p_1)
-     + %s * dw_volume_dot.i.Omega_2(q_2, p_2)
+    """%s * dw_dot.i.Omega_1(q_1, p_1)
+     + %s * dw_dot.i.Omega_2(q_2, p_2)
      - dw_laplace.i.Omega_1(q_1, p_1)
      - dw_laplace.i.Omega_2(q_2, p_2)
-     - %s * dw_surface_dot.i.Gamma_out(q_1, p_1)
+     - %s * dw_dot.i.Gamma_out(q_1, p_1)
      + %s * dw_jump.i.Gamma_12_1(q_1, p_1, tr(p_2))
      + %s * dw_jump.i.Gamma_12_2(q_2, p_2, tr(p_1))
      = %s * dw_integrate.i.Gamma_in(q_1)"""

--- a/examples/acoustics/acoustics3d.py
+++ b/examples/acoustics/acoustics3d.py
@@ -90,7 +90,7 @@ equations = {
      - %s * dw_surface_dot.i.Gamma_out(q_1, p_1)
      + %s * dw_jump.i.Gamma_12_1(q_1, p_1, tr(p_2))
      + %s * dw_jump.i.Gamma_12_2(q_2, p_2, tr(p_1))
-     = %s * dw_surface_integrate.i.Gamma_in(q_1)"""
+     = %s * dw_integrate.i.Gamma_in(q_1)"""
      % (k1*k1, k2*k2,
        1j*k1,
        1j*k1*rhoc1 / Z, 1j*k2*rhoc2 / Z,

--- a/examples/acoustics/vibro_acoustic3d.py
+++ b/examples/acoustics/vibro_acoustic3d.py
@@ -116,7 +116,7 @@ equations = {
       + %s * dw_surface_dot.5.GammaOut(q2, p2)
       - %s * dw_surface_dot.5.Gamma0_1(q1, g0)
       + %s * dw_surface_dot.5.Gamma0_2(q2, tr(g0))
-      = %s * dw_surface_integrate.5.GammaIn(q1)"""\
+      = %s * dw_integrate.5.GammaIn(q1)"""\
         % (c2, c2, w2, w2,
            1j * wc, 1j * wc,
            1j * wc2, 1j * wc2,

--- a/examples/acoustics/vibro_acoustic3d.py
+++ b/examples/acoustics/vibro_acoustic3d.py
@@ -110,22 +110,22 @@ equations = {
     'eq_1' : """
         %e * dw_laplace.5.Omega1(q1, p1)
       + %e * dw_laplace.5.Omega2(q2, p2)
-      - %e * dw_volume_dot.5.Omega1(q1, p1)
-      - %e * dw_volume_dot.5.Omega2(q2, p2)
-      + %s * dw_surface_dot.5.GammaIn(q1, p1)
-      + %s * dw_surface_dot.5.GammaOut(q2, p2)
-      - %s * dw_surface_dot.5.Gamma0_1(q1, g0)
-      + %s * dw_surface_dot.5.Gamma0_2(q2, tr(g0))
+      - %e * dw_dot.5.Omega1(q1, p1)
+      - %e * dw_dot.5.Omega2(q2, p2)
+      + %s * dw_dot.5.GammaIn(q1, p1)
+      + %s * dw_dot.5.GammaOut(q2, p2)
+      - %s * dw_dot.5.Gamma0_1(q1, g0)
+      + %s * dw_dot.5.Gamma0_2(q2, tr(g0))
       = %s * dw_integrate.5.GammaIn(q1)"""\
         % (c2, c2, w2, w2,
            1j * wc, 1j * wc,
            1j * wc2, 1j * wc2,
            2j * wc * p_inc),
     'eq_2' : """
-      - %s * dw_surface_dot.5.Gamma0_1(f0, p1)
-      + %s * dw_surface_dot.5.Gamma0_1(f0, tr(p2))
-      - %e * dw_surface_dot.5.Gamma0_1(ac.F, f0, g0)
-      + %e * dw_surface_dot.5.Gamma0_1(ac.c, f0, w)
+      - %s * dw_dot.5.Gamma0_1(f0, p1)
+      + %s * dw_dot.5.Gamma0_1(f0, tr(p2))
+      - %e * dw_dot.5.Gamma0_1(ac.F, f0, g0)
+      + %e * dw_dot.5.Gamma0_1(ac.c, f0, w)
       = 0"""\
         % (1j * w, 1j * w, w2, w2),
     }

--- a/examples/acoustics/vibro_acoustic3d_mid.py
+++ b/examples/acoustics/vibro_acoustic3d_mid.py
@@ -99,18 +99,18 @@ materials = {
 
 equations = {
     'eq_3': """
-        %e * dw_volume_dot.5.Gamma0(ac.c, z, g0)
-      - %e * dw_volume_dot.5.Gamma0(ac.T, z, w)
-      - %e * dw_volume_dot.5.Gamma0(ac.hR, z, w)
+        %e * dw_dot.5.Gamma0(ac.c, z, g0)
+      - %e * dw_dot.5.Gamma0(ac.T, z, w)
+      - %e * dw_dot.5.Gamma0(ac.hR, z, w)
            + dw_diffusion.5.Gamma0(ac.hG, z, w)
            - dw_v_dot_grad_s.5.Gamma0(ac.hG, theta, z)
       = 0"""\
         % (w2, w2, w2),
     'eq_4': """
-      - %e * dw_volume_dot.5.Gamma0(ac.h3R, nu, theta)
+      - %e * dw_dot.5.Gamma0(ac.h3R, nu, theta)
            + dw_lin_elastic.5.Gamma0(ac.h3C, nu, theta)
            - dw_v_dot_grad_s.5.Gamma0(ac.hG, nu, w)
-           + dw_volume_dot.5.Gamma0(ac.hG, nu, theta)
+           + dw_dot.5.Gamma0(ac.hG, nu, theta)
       = 0"""\
         % (w2, ),
     }

--- a/examples/dg/advection_1D.py
+++ b/examples/dg/advection_1D.py
@@ -97,7 +97,7 @@ def define(filename_mesh=None,
 
     equations = {
         'Advection': """
-                       dw_volume_dot.i.Omega(v, p)
+                       dw_dot.i.Omega(v, p)
                        - dw_s_dot_mgrad_s.i.Omega(a.val, p[-1], v)
                        + dw_dg_advect_laxfrie_flux.i.Omega(a.flux, a.val, v, p[-1]) = 0
                       """

--- a/examples/dg/advection_2D.py
+++ b/examples/dg/advection_2D.py
@@ -140,7 +140,7 @@ def define(filename_mesh=None,
 
     equations = {
         'Advection': """
-                       dw_volume_dot.i.Omega(v, p)
+                       dw_dot.i.Omega(v, p)
                        - dw_s_dot_mgrad_s.i.Omega(a.val, p[-1], v)
                        + dw_dg_advect_laxfrie_flux.i.Omega(a.flux, a.val, v, p[-1]) = 0
                       """

--- a/examples/dg/burgers_2D.py
+++ b/examples/dg/burgers_2D.py
@@ -237,7 +237,7 @@ def define(filename_mesh=None,
 
     equations = {
       'balance':
-         "dw_volume_dot.i.Omega(v, p)" +
+         "dw_dot.i.Omega(v, p)" +
          # non-linear hyperbolic terms
          " - dw_ns_dot_grad_s.i.Omega(burg_fun, burg_fun_d, p[-1], v)" +
          " + dw_dg_nonlinear_laxfrie_flux.i.Omega(a.flux, burg_fun, burg_fun_d, v, p[-1])" +

--- a/examples/diffusion/darcy_flow_multicomp.py
+++ b/examples/diffusion/darcy_flow_multicomp.py
@@ -59,12 +59,12 @@ equations = {
     'komp1': """dw_diffusion.5.Omega1(mat.K, q1, p1)
               + dw_volume_dot.5.Omega1(mat.G_alfa, q1, p1)
               - dw_volume_dot.5.Omega1(mat.G_alfa, q1, p2)
-              = dw_volume_integrate.5.Source(mat.f_1, q1)""",
+              = dw_integrate.5.Source(mat.f_1, q1)""",
 
     'komp2': """dw_diffusion.5.Omega2(mat.K, q2, p2)
               + dw_volume_dot.5.Omega2(mat.G_alfa, q2, p2)
               - dw_volume_dot.5.Omega2(mat.G_alfa, q2, p1)
-              = dw_volume_integrate.5.Sink(mat.f_2, q2)"""
+              = dw_integrate.5.Sink(mat.f_2, q2)"""
 }
 
 solvers = {
@@ -102,7 +102,7 @@ options = {
 }
 
 def postproc(out, pb, state, extend=False):
-    alpha = pb.evaluate('ev_volume_integrate_mat.5.Omega(mat.G_alfa, p1)',
+    alpha = pb.evaluate('ev_integrate_mat.5.Omega(mat.G_alfa, p1)',
                         mode='el_avg')
     out['alpha'] = Struct(name='output_data',
                           mode='cell',

--- a/examples/diffusion/darcy_flow_multicomp.py
+++ b/examples/diffusion/darcy_flow_multicomp.py
@@ -57,13 +57,13 @@ ebcs = {
 
 equations = {
     'komp1': """dw_diffusion.5.Omega1(mat.K, q1, p1)
-              + dw_volume_dot.5.Omega1(mat.G_alfa, q1, p1)
-              - dw_volume_dot.5.Omega1(mat.G_alfa, q1, p2)
+              + dw_dot.5.Omega1(mat.G_alfa, q1, p1)
+              - dw_dot.5.Omega1(mat.G_alfa, q1, p2)
               = dw_integrate.5.Source(mat.f_1, q1)""",
 
     'komp2': """dw_diffusion.5.Omega2(mat.K, q2, p2)
-              + dw_volume_dot.5.Omega2(mat.G_alfa, q2, p2)
-              - dw_volume_dot.5.Omega2(mat.G_alfa, q2, p1)
+              + dw_dot.5.Omega2(mat.G_alfa, q2, p2)
+              - dw_dot.5.Omega2(mat.G_alfa, q2, p1)
               = dw_integrate.5.Sink(mat.f_2, q2)"""
 }
 

--- a/examples/diffusion/poisson_field_dependent_material.py
+++ b/examples/diffusion/poisson_field_dependent_material.py
@@ -29,7 +29,7 @@ def get_conductivity(ts, coors, problem, equations=None, mode=None, **kwargs):
     if mode == 'qp':
         # T-field values in quadrature points coordinates given by integral i
         # - they are the same as in `coors` argument.
-        T_values = problem.evaluate('ev_volume_integrate.i.Omega(T)',
+        T_values = problem.evaluate('ev_integrate.i.Omega(T)',
                                     mode='qp', verbose=False)
         val = 2 + 10 * (T_values + 2)
 

--- a/examples/diffusion/poisson_functions.py
+++ b/examples/diffusion/poisson_functions.py
@@ -75,7 +75,7 @@ equations = {
     'Laplace equation' :
     """dw_laplace.i.Omega( m.c, v, u )
      - dw_convect_v_grad_s.i.Omega( v, w, u )
-     = - dw_volume_dot.i.Omega_L( load.f, v, p )"""
+     = - dw_dot.i.Omega_L( load.f, v, p )"""
 }
 
 solvers = {

--- a/examples/diffusion/poisson_neumann.py
+++ b/examples/diffusion/poisson_neumann.py
@@ -53,7 +53,7 @@ def post_process(out, pb, state, extend=False):
 
         flux = pb.evaluate('d_surface_flux.i.%s(m.K, t)' % gamma,
                            verbose=False)
-        area = pb.evaluate('d_surface.i.%s(t)' % gamma, verbose=False)
+        area = pb.evaluate('d_region.i.%s(t)' % gamma, verbose=False)
 
         flux_data = (gamma, flux, area, flux / area)
         totals += flux_data[1:]
@@ -102,7 +102,7 @@ integrals = {
 equations = {
     'Temperature' : """
            dw_diffusion.i.Omega(m.K, s, t)
-         = dw_surface_integrate.i.Gamma_N(flux.val, s)
+         = dw_integrate.i.Gamma_N(flux.val, s)
     """
 }
 

--- a/examples/diffusion/poisson_neumann.py
+++ b/examples/diffusion/poisson_neumann.py
@@ -53,7 +53,7 @@ def post_process(out, pb, state, extend=False):
 
         flux = pb.evaluate('d_surface_flux.i.%s(m.K, t)' % gamma,
                            verbose=False)
-        area = pb.evaluate('d_region.i.%s(t)' % gamma, verbose=False)
+        area = pb.evaluate('ev_volume.i.%s(t)' % gamma, verbose=False)
 
         flux_data = (gamma, flux, area, flux / area)
         totals += flux_data[1:]

--- a/examples/diffusion/poisson_periodic_boundary_condition.py
+++ b/examples/diffusion/poisson_periodic_boundary_condition.py
@@ -121,7 +121,7 @@ equations = {
         dw_volume_dot.i.fill( fill.capacity, s, dT/dt )
         dw_laplace.i.cylinder( cylinder.conductivity, s, T )
         dw_laplace.i.fill( fill.conductivity, s, T )
-        = dw_volume_integrate.i.cylinder( cylinder.power, s )"""
+        = dw_integrate.i.cylinder( cylinder.power, s )"""
 }
 
 solvers = {

--- a/examples/diffusion/poisson_periodic_boundary_condition.py
+++ b/examples/diffusion/poisson_periodic_boundary_condition.py
@@ -117,8 +117,8 @@ integrals = {
 
 equations = {
     'Temperature' :
-    """dw_volume_dot.i.cylinder( cylinder.capacity, s, dT/dt )
-        dw_volume_dot.i.fill( fill.capacity, s, dT/dt )
+    """dw_dot.i.cylinder( cylinder.capacity, s, dT/dt )
+        dw_dot.i.fill( fill.capacity, s, dT/dt )
         dw_laplace.i.cylinder( cylinder.conductivity, s, T )
         dw_laplace.i.fill( fill.conductivity, s, T )
         = dw_integrate.i.cylinder( cylinder.power, s )"""

--- a/examples/diffusion/time_advection_diffusion.py
+++ b/examples/diffusion/time_advection_diffusion.py
@@ -52,7 +52,7 @@ integrals = {
 equations = {
     'advection-diffusion' :
      """
-       dw_volume_dot.i.Omega(s, du/dt)
+       dw_dot.i.Omega(s, du/dt)
      + dw_advect_div_free.i.Omega(m.v, s, u)
      + dw_laplace.i.Omega(m.D, s, u)
      = 0

--- a/examples/diffusion/time_poisson.py
+++ b/examples/diffusion/time_poisson.py
@@ -81,7 +81,7 @@ integral_1 = {
 
 equations = {
     'Temperature' :
-    """dw_volume_dot.i.Omega( s, dT/dt )
+    """dw_dot.i.Omega( s, dT/dt )
      + dw_laplace.i.Omega( coef.val, s, T ) = 0"""
 }
 

--- a/examples/diffusion/time_poisson_explicit.py
+++ b/examples/diffusion/time_poisson_explicit.py
@@ -57,7 +57,7 @@ integrals = {
 
 equations = {
     'Temperature' :
-    """dw_volume_dot.i.Omega( s, dT/dt )
+    """dw_dot.i.Omega( s, dT/dt )
      + dw_laplace.i.Omega( coef.val, s, T[-1] ) = 0"""
 }
 

--- a/examples/homogenization/homogenization_opt.py
+++ b/examples/homogenization/homogenization_opt.py
@@ -109,7 +109,7 @@ def define(is_opt=False):
     options = {
         'coefs': 'coefs',
         'requirements': 'requirements',
-        'volume': { 'variables' : ['u'], 'expression' : 'd_volume.5.Y( u )' },
+        'volume': { 'variables' : ['u'], 'expression' : 'd_region.5.Y( u )' },
         'output_dir': 'output',
         'coefs_filename': 'coefs_le',
     }
@@ -130,7 +130,7 @@ def define(is_opt=False):
         },
         'vol': {
             'regions': ['Ym', 'Yf'],
-            'expression': 'd_volume.5.%s(u)',
+            'expression': 'd_region.5.%s(u)',
             'class': cb.VolumeFractions,
             },
         'filenames' : {},

--- a/examples/homogenization/homogenization_opt.py
+++ b/examples/homogenization/homogenization_opt.py
@@ -109,7 +109,7 @@ def define(is_opt=False):
     options = {
         'coefs': 'coefs',
         'requirements': 'requirements',
-        'volume': { 'variables' : ['u'], 'expression' : 'd_region.5.Y( u )' },
+        'volume': { 'variables' : ['u'], 'expression' : 'ev_volume.5.Y( u )' },
         'output_dir': 'output',
         'coefs_filename': 'coefs_le',
     }
@@ -130,7 +130,7 @@ def define(is_opt=False):
         },
         'vol': {
             'regions': ['Ym', 'Yf'],
-            'expression': 'd_region.5.%s(u)',
+            'expression': 'ev_volume.5.%s(u)',
             'class': cb.VolumeFractions,
             },
         'filenames' : {},

--- a/examples/homogenization/linear_homogenization.py
+++ b/examples/homogenization/linear_homogenization.py
@@ -124,7 +124,7 @@ options = {
     'coefs': 'coefs',
     'requirements': 'requirements',
     'ls': 'ls',  # linear solver to use
-    'volume': {'expression': 'd_volume.i.Y(u)'},
+    'volume': {'expression': 'd_region.i.Y(u)'},
     'output_dir': 'output',
     'coefs_filename': 'coefs_le',
     'recovery_hook': 'recovery_le',

--- a/examples/homogenization/linear_homogenization.py
+++ b/examples/homogenization/linear_homogenization.py
@@ -124,7 +124,7 @@ options = {
     'coefs': 'coefs',
     'requirements': 'requirements',
     'ls': 'ls',  # linear solver to use
-    'volume': {'expression': 'd_region.i.Y(u)'},
+    'volume': {'expression': 'ev_volume.i.Y(u)'},
     'output_dir': 'output',
     'coefs_filename': 'coefs_le',
     'recovery_hook': 'recovery_le',

--- a/examples/homogenization/linear_homogenization_up.py
+++ b/examples/homogenization/linear_homogenization_up.py
@@ -155,7 +155,7 @@ equation_corrs = {
        - dw_lin_elastic.i.Y(mat.D, v, Pi)""",
     'pressure constraint':
     """- dw_stokes.i.Y(u, q)
-       - dw_volume_dot.i.Y(mat.gamma, q, p) =
+       - dw_dot.i.Y(mat.gamma, q, p) =
        + dw_stokes.i.Y(Pi, q)""",
 }
 
@@ -169,7 +169,7 @@ coefs = {
     },
     'elastic_p': {
         'requires': ['corrs_rs'],
-        'expression': 'dw_volume_dot.i.Y(mat.gamma, Pi1p, Pi2p)',
+        'expression': 'dw_dot.i.Y(mat.gamma, Pi1p, Pi2p)',
         'set_variables': [('Pi1p', 'corrs_rs', 'p'),
                           ('Pi2p', 'corrs_rs', 'p')],
         'class': cb.CoefSymSym,

--- a/examples/homogenization/nonlinear_homogenization.py
+++ b/examples/homogenization/nonlinear_homogenization.py
@@ -138,7 +138,7 @@ dim = 2
 options = {
     'coefs': 'coefs',
     'requirements': 'requirements',
-    'volume': {'expression': 'd_region.5.Y(u)'},
+    'volume': {'expression': 'ev_volume.5.Y(u)'},
     'output_dir': './output',
     'coefs_filename': 'coefs_hyper_homog',
     'multiprocessing': True,

--- a/examples/homogenization/nonlinear_homogenization.py
+++ b/examples/homogenization/nonlinear_homogenization.py
@@ -22,7 +22,7 @@ def recovery_hook(pb, ncoors, region, ts,
         out = {}
         pb.set_mesh_coors(ncoors[ii], update_fields=True,
                           clear_all=False, actual=True)
-        stress = pb.evaluate('ev_volume_integrate_mat.3.Y(mat_he.S, u)',
+        stress = pb.evaluate('ev_integrate_mat.3.Y(mat_he.S, u)',
                              mode='el_avg')
 
         out['cauchy_stress'] = Struct(name='output_data',
@@ -30,7 +30,7 @@ def recovery_hook(pb, ncoors, region, ts,
                                       data=stress,
                                       dofs=None)
 
-        strain = pb.evaluate('ev_volume_integrate_mat.3.Y(mat_he.E, u)',
+        strain = pb.evaluate('ev_integrate_mat.3.Y(mat_he.E, u)',
                              mode='el_avg')
 
         out['green_strain'] = Struct(name='output_data',
@@ -138,7 +138,7 @@ dim = 2
 options = {
     'coefs': 'coefs',
     'requirements': 'requirements',
-    'volume': {'expression': 'd_volume.5.Y(u)'},
+    'volume': {'expression': 'd_region.5.Y(u)'},
     'output_dir': './output',
     'coefs_filename': 'coefs_hyper_homog',
     'multiprocessing': True,
@@ -201,7 +201,7 @@ coefs = {
         'class': cb.CoefNonSymNonSym,
     },
     'S': {
-        'expression': 'ev_volume_integrate_mat.3.Y(mat_he.S, u)',
+        'expression': 'ev_integrate_mat.3.Y(mat_he.S, u)',
         'class': cb.CoefOne,
     }
 }

--- a/examples/homogenization/nonlinear_hyperelastic_mM.py
+++ b/examples/homogenization/nonlinear_hyperelastic_mM.py
@@ -16,7 +16,7 @@ def post_process(out, pb, state, extend=False):
         pass
     else:
         pb.update_materials_flag = 2
-        stress = pb.evaluate('ev_volume_integrate_mat.1.Omega(solid.S, u)',
+        stress = pb.evaluate('ev_integrate_mat.1.Omega(solid.S, u)',
                              mode='el_avg')
 
         out['cauchy_stress'] = Struct(name='output_data',
@@ -24,7 +24,7 @@ def post_process(out, pb, state, extend=False):
                                       data=stress,
                                       dofs=None)
 
-        strain = pb.evaluate('ev_volume_integrate_mat.1.Omega(solid.E, u)',
+        strain = pb.evaluate('ev_integrate_mat.1.Omega(solid.E, u)',
                              mode='el_avg')
 
         out['green_strain'] = Struct(name='output_data',

--- a/examples/homogenization/perfusion_micro.py
+++ b/examples/homogenization/perfusion_micro.py
@@ -386,7 +386,7 @@ options = {
     'volumes': {
         'total': {
             'variables': ['vol_all'],
-            'expression': """d_region.iV.Y(vol_all)""",
+            'expression': """ev_volume.iV.Y(vol_all)""",
         },
         'one': {
             'value': 1.0,
@@ -404,11 +404,11 @@ for ipm in ['p', 'm']:
     options['volumes'].update({
         'bYM' + ipm: {
             'variables': ['pM'],
-            'expression': "d_region.iS.bYM%s(pM)" % ipm,
+            'expression': "ev_volume.iS.bYM%s(pM)" % ipm,
         },
         'bY' + ipm: {
             'variables': ['vol_all'],
-            'expression': "d_region.iS.bY%s(vol_all)" % ipm,
+            'expression': "ev_volume.iS.bY%s(vol_all)" % ipm,
         }
     })
 
@@ -417,14 +417,14 @@ for ch in six.iterkeys(reg_io):
         options['volumes'].update({
             ireg: {
                 'variables': ['p' + ch],
-                'expression': "d_region.iS.%s(p%s)" % (ireg, ch),
+                'expression': "ev_volume.iS.%s(p%s)" % (ireg, ch),
             }
         })
 
 coefs = {
     'vol_bYMpm': {
         'regions': ['bYMp', 'bYMm'],
-        'expression': 'd_region.iS.%s(pM)',
+        'expression': 'ev_volume.iS.%s(pM)',
         'class': cb.VolumeFractions,
     },
     'filenames': {},

--- a/examples/homogenization/perfusion_micro.py
+++ b/examples/homogenization/perfusion_micro.py
@@ -386,7 +386,7 @@ options = {
     'volumes': {
         'total': {
             'variables': ['vol_all'],
-            'expression': """d_volume.iV.Y(vol_all)""",
+            'expression': """d_region.iV.Y(vol_all)""",
         },
         'one': {
             'value': 1.0,
@@ -404,11 +404,11 @@ for ipm in ['p', 'm']:
     options['volumes'].update({
         'bYM' + ipm: {
             'variables': ['pM'],
-            'expression': "d_surface.iS.bYM%s(pM)" % ipm,
+            'expression': "d_region.iS.bYM%s(pM)" % ipm,
         },
         'bY' + ipm: {
             'variables': ['vol_all'],
-            'expression': "d_surface.iS.bY%s(vol_all)" % ipm,
+            'expression': "d_region.iS.bY%s(vol_all)" % ipm,
         }
     })
 
@@ -417,14 +417,14 @@ for ch in six.iterkeys(reg_io):
         options['volumes'].update({
             ireg: {
                 'variables': ['p' + ch],
-                'expression': "d_surface.iS.%s(p%s)" % (ireg, ch),
+                'expression': "d_region.iS.%s(p%s)" % (ireg, ch),
             }
         })
 
 coefs = {
     'vol_bYMpm': {
         'regions': ['bYMp', 'bYMm'],
-        'expression': 'd_surface.iS.%s(pM)',
+        'expression': 'd_region.iS.%s(pM)',
         'class': cb.VolumeFractions,
     },
     'filenames': {},
@@ -448,7 +448,7 @@ for ipm in ['p', 'm']:
             'epbcs': all_periodicYM,
             'equations': {
                 'eq_gamma_pm': """dw_diffusion.iV.YM(mat2M.k, qM, pM) =
-                             %e * dw_surface_integrate.iS.bYM%s(qM)"""
+                             %e * dw_integrate.iS.bYM%s(qM)"""
                                % (1.0/param_h, ipm),
                 },
             'class': cb.CorrOne,
@@ -461,7 +461,7 @@ for ipm in ['p', 'm']:
             'H' + ipm + ipm2: {  # test+
                 'requires': ['corrs_gamma_' + ipm],
                 'set_variables': [('corr_M', 'corrs_gamma_' + ipm, 'pM')],
-                'expression': 'ev_surface_integrate.iS.bYM%s(corr_M)' % ipm2,
+                'expression': 'ev_integrate.iS.bYM%s(corr_M)' % ipm2,
                 'set_volume': 'bYp',
                 'class': cb.CoefOne,
             },
@@ -577,7 +577,7 @@ for ch, val in six.iteritems(pb_def['channels']):
             'E' + ipm + ch: {  # test+
                 'requires': ['corrs_eta' + ch],
                 'set_variables': [('corr_M', 'corrs_eta' + ch, 'pM')],
-                'expression': 'ev_surface_integrate.iS.bYM%s(corr_M)' % ipm,
+                'expression': 'ev_integrate.iS.bYM%s(corr_M)' % ipm,
                 'set_volume': 'bYp',
                 'class': cb.CoefOne,
             },
@@ -586,7 +586,7 @@ for ch, val in six.iteritems(pb_def['channels']):
                 'set_variables': [('corr1_M', 'corrs_one' + ch, 'pM'),
                                   ('corr2_M', 'corrs_gamma_' + ipm, 'pM')],
                 'expression': """dw_diffusion.iV.YM(mat2M.k, corr1_M, corr2_M)
-                          - %e * ev_surface_integrate.iS.bYM%s(corr1_M)"""\
+                          - %e * ev_integrate.iS.bYM%s(corr1_M)"""\
                                  % (1.0/param_h, ipm),
                 'class': cb.CoefOne,
             },
@@ -607,7 +607,7 @@ for ch, val in six.iteritems(pb_def['channels']):
             'P' + io: {  # test+
                 'requires': ['pis_' + ch, 'corrs_pi' + ch],
                 'set_variables': set_corr_cc,
-                'expression': 'ev_surface_integrate.iS.bY%s(corr1_%s)'\
+                'expression': 'ev_integrate.iS.bY%s(corr1_%s)'\
                               % (io, ch),
                 'set_volume': 'bYp',
                 'dim': pb_def['dim'] - 1,
@@ -616,7 +616,7 @@ for ch, val in six.iteritems(pb_def['channels']):
             'S_test' + io: {
                 'requires': ['corrs_pi' + ch],
                 'set_variables': [('corr1_' + ch, 'corrs_pi' + ch, 'p' + ch)],
-                'expression': '%e * ev_surface_integrate.iS.bY%s(corr1_%s)'\
+                'expression': '%e * ev_integrate.iS.bY%s(corr1_%s)'\
                               % (1.0 / param_h, io, ch),
                 'dim': pb_def['dim'] - 1,
                 'class': cb.CoefDim,
@@ -633,7 +633,7 @@ for ch, val in six.iteritems(pb_def['channels']):
                 'equations': {
                     'eq_gamma': """dw_diffusion.iV.Y%s(mat2%s.k, q%s, p%s)
                                    + dw_volume_dot.iV.Y%s(q%s, ls%s)
-                                   = %e * dw_surface_integrate.iS.bY%s(q%s)"""
+                                   = %e * dw_integrate.iS.bY%s(q%s)"""
                                     % ((ch,) * 7 + (1.0/param_h, io, ch)),
                     'eq_imv': 'dw_volume_dot.iV.Y%s(lv%s, p%s) = 0'
                               % ((ch,) * 3),
@@ -651,7 +651,7 @@ for ch, val in six.iteritems(pb_def['channels']):
                     'requires': ['corrs_gamma_' + io2],
                     'set_variables': [('corr1_' + ch, 'corrs_gamma_' + io2,
                                        'p' + ch)],
-                    'expression': 'ev_surface_integrate.iS.bY%s(corr1_%s)'\
+                    'expression': 'ev_integrate.iS.bY%s(corr1_%s)'\
                                   % (io, ch),
                     'set_volume': 'bYp',
                     'class': cb.CoefOne,

--- a/examples/homogenization/perfusion_micro.py
+++ b/examples/homogenization/perfusion_micro.py
@@ -561,10 +561,10 @@ for ch, val in six.iteritems(pb_def['channels']):
             'lcbcs': ['imv' + ch],
             'equations': {
                 'eq_pi': """dw_diffusion.iV.Y%s(mat2%s.k, q%s, p%s)
-                            + dw_volume_dot.iV.Y%s(q%s, ls%s)
+                            + dw_dot.iV.Y%s(q%s, ls%s)
                             = - dw_diffusion.iV.Y%s(mat2%s.k, q%s, Pi_%s)"""
                             % ((ch,) * 11),
-                'eq_imv': 'dw_volume_dot.iV.Y%s(lv%s, p%s) = 0' % ((ch,) * 3),
+                'eq_imv': 'dw_dot.iV.Y%s(lv%s, p%s) = 0' % ((ch,) * 3),
             },
             'dim': pb_def['dim'] - 1,
             'class': cb.CorrDim,
@@ -632,10 +632,10 @@ for ch, val in six.iteritems(pb_def['channels']):
                 'lcbcs': ['imv' + ch],
                 'equations': {
                     'eq_gamma': """dw_diffusion.iV.Y%s(mat2%s.k, q%s, p%s)
-                                   + dw_volume_dot.iV.Y%s(q%s, ls%s)
+                                   + dw_dot.iV.Y%s(q%s, ls%s)
                                    = %e * dw_integrate.iS.bY%s(q%s)"""
                                     % ((ch,) * 7 + (1.0/param_h, io, ch)),
-                    'eq_imv': 'dw_volume_dot.iV.Y%s(lv%s, p%s) = 0'
+                    'eq_imv': 'dw_dot.iV.Y%s(lv%s, p%s) = 0'
                               % ((ch,) * 3),
                 },
                 'class': cb.CorrOne,

--- a/examples/homogenization/rs_correctors.py
+++ b/examples/homogenization/rs_correctors.py
@@ -280,7 +280,7 @@ Try to display them with:
     spause(r""">>>
 Then the volume of the domain is needed.
 ['q'/other key to quit/continue...]""")
-    volume = problem.evaluate('d_volume.i3.Y(uc)')
+    volume = problem.evaluate('d_region.i3.Y(uc)')
     print(volume)
 
     spause(r""">>>

--- a/examples/homogenization/rs_correctors.py
+++ b/examples/homogenization/rs_correctors.py
@@ -280,7 +280,7 @@ Try to display them with:
     spause(r""">>>
 Then the volume of the domain is needed.
 ['q'/other key to quit/continue...]""")
-    volume = problem.evaluate('d_region.i3.Y(uc)')
+    volume = problem.evaluate('ev_volume.i3.Y(uc)')
     print(volume)
 
     spause(r""">>>

--- a/examples/large_deformation/balloon.py
+++ b/examples/large_deformation/balloon.py
@@ -254,7 +254,7 @@ def define(plot=False):
                = 0""",
         'volume'
             : """dw_tl_volume.2.Omega(q, u)
-               = dw_volume_dot.2.Omega(q, omega)""",
+               = dw_dot.2.Omega(q, omega)""",
     }
 
     solvers = {

--- a/examples/linear_elasticity/dispersion_analysis.py
+++ b/examples/linear_elasticity/dispersion_analysis.py
@@ -199,11 +199,11 @@ def set_wave_dir(pb, wdir):
     wave_mat.set_extra_args(wdir=wdir)
 
 def save_materials(output_dir, pb, options):
-    stiffness = pb.evaluate('ev_volume_integrate_mat.2.Omega(m.D, u)',
+    stiffness = pb.evaluate('ev_integrate_mat.2.Omega(m.D, u)',
                             mode='el_avg', copy_materials=False, verbose=False)
     young, poisson = mc.youngpoisson_from_stiffness(stiffness,
                                                     plane=options.plane)
-    density = pb.evaluate('ev_volume_integrate_mat.2.Omega(m.density, u)',
+    density = pb.evaluate('ev_integrate_mat.2.Omega(m.density, u)',
                           mode='el_avg', copy_materials=False, verbose=False)
 
     out = {}
@@ -216,11 +216,11 @@ def save_materials(output_dir, pb, options):
     pb.save_state(materials_filename, out=out)
 
 def get_std_wave_fun(pb, options):
-    stiffness = pb.evaluate('ev_volume_integrate_mat.2.Omega(m.D, u)',
+    stiffness = pb.evaluate('ev_integrate_mat.2.Omega(m.D, u)',
                             mode='el_avg', copy_materials=False, verbose=False)
     young, poisson = mc.youngpoisson_from_stiffness(stiffness,
                                                     plane=options.plane)
-    density = pb.evaluate('ev_volume_integrate_mat.2.Omega(m.density, u)',
+    density = pb.evaluate('ev_integrate_mat.2.Omega(m.density, u)',
                           mode='el_avg', copy_materials=False, verbose=False)
 
     lam, mu = mc.lame_from_youngpoisson(young, poisson,

--- a/examples/linear_elasticity/dispersion_analysis.py
+++ b/examples/linear_elasticity/dispersion_analysis.py
@@ -180,7 +180,7 @@ def define(filename_mesh, pars, approx_order, refinement_level, solver_conf,
         'S' : 'dw_elastic_wave.i.Omega(m.D, wave.vec, v, u)',
         'R' : """1j * dw_elastic_wave_cauchy.i.Omega(m.D, wave.vec, u, v)
                - 1j * dw_elastic_wave_cauchy.i.Omega(m.D, wave.vec, v, u)""",
-        'M' : 'dw_volume_dot.i.Omega(m.density, v, u)',
+        'M' : 'dw_dot.i.Omega(m.density, v, u)',
     }
 
     solver_0 = solver_conf.copy()

--- a/examples/linear_elasticity/elastodynamic.py
+++ b/examples/linear_elasticity/elastodynamic.py
@@ -208,7 +208,7 @@ ics = {
 
 equations = {
     'balance_of_forces' :
-    """dw_volume_dot.i.Omega(solid.rho, ddv, ddu)
+    """dw_dot.i.Omega(solid.rho, ddv, ddu)
      + dw_zero.i.Omega(dv, du)
      + dw_lin_elastic.i.Omega(solid.D, v, u) = 0""",
 }

--- a/examples/linear_elasticity/linear_elastic_damping.py
+++ b/examples/linear_elasticity/linear_elastic_damping.py
@@ -54,7 +54,7 @@ def ebc_sin(ts, coors, **kwargs):
 
 equations = {
     'balance_of_forces in time' :
-    """dw_volume_dot.i.Omega( solid.c, v, du/dt )
+    """dw_dot.i.Omega( solid.c, v, du/dt )
      + dw_lin_elastic.i.Omega( solid.D, v, u ) = 0""",
 }
 

--- a/examples/linear_elasticity/linear_elastic_tractions.py
+++ b/examples/linear_elasticity/linear_elastic_tractions.py
@@ -55,17 +55,17 @@ def verify_tractions(out, problem, state, extend=False):
     from sfepy.discrete import Material, Function
 
     load_force = problem.evaluate(
-        'ev_surface_integrate_mat.2.Right(load.val, u)'
+        'ev_integrate_mat.2.Right(load.val, u)'
     )
     output('surface load force:', load_force)
 
     def eval_force(region_name):
         strain = problem.evaluate(
-            'ev_cauchy_strain_s.i.%s(u)' % region_name, mode='qp',
+            'ev_cauchy_strain.i.%s(u)' % region_name, mode='qp',
             verbose=False,
         )
         D = problem.evaluate(
-            'ev_surface_integrate_mat.i.%s(solid.D, u)' % region_name,
+            'ev_integrate_mat.i.%s(solid.D, u)' % region_name,
             mode='qp',
             verbose=False,
         )
@@ -86,7 +86,7 @@ def verify_tractions(out, problem, state, extend=False):
         aux = Material('aux', function=Function('get_force', get_force))
 
         middle_force = - problem.evaluate(
-            'ev_surface_integrate_mat.i.%s(aux.force, u)' % region_name,
+            'ev_integrate_mat.i.%s(aux.force, u)' % region_name,
             aux=aux,
             verbose=False,
         )

--- a/examples/linear_elasticity/linear_elastic_up.py
+++ b/examples/linear_elasticity/linear_elastic_up.py
@@ -94,7 +94,7 @@ equations = {
        = 0 """,
     'pressure constraint' :
     """- dw_stokes.i.Omega( u, q )
-       - dw_volume_dot.i.Omega( solid.gamma, q, p )
+       - dw_dot.i.Omega( solid.gamma, q, p )
        = 0""",
 }
 #! Solvers

--- a/examples/linear_elasticity/material_nonlinearity.py
+++ b/examples/linear_elasticity/material_nonlinearity.py
@@ -27,7 +27,7 @@ filename_mesh = data_dir + '/meshes/3d/cylinder.mesh'
 def post_process(out, pb, state, extend=False):
     from sfepy.base.base import Struct
 
-    mu = pb.evaluate('ev_volume_integrate_mat.2.Omega(nonlinear.mu, u)',
+    mu = pb.evaluate('ev_integrate_mat.2.Omega(nonlinear.mu, u)',
                      mode='el_avg', copy_materials=False, verbose=False)
     out['mu'] = Struct(name='mu', mode='cell', data=mu, dofs=None)
 

--- a/examples/multi_physics/piezo_elasticity.py
+++ b/examples/multi_physics/piezo_elasticity.py
@@ -150,7 +150,7 @@ integrals = {
 }
 
 equations = {
-    '1' : """- %f * dw_volume_dot.i.Y(inclusion.density, v, u)
+    '1' : """- %f * dw_dot.i.Y(inclusion.density, v, u)
              + dw_lin_elastic.i.Y(inclusion.D, v, u)
              - dw_piezo_coupling.i.Y2(inclusion.coupling, v, phi)
            = 0""" % omega_squared,

--- a/examples/multi_physics/piezo_elasticity_micro.py
+++ b/examples/multi_physics/piezo_elasticity_micro.py
@@ -234,7 +234,7 @@ def define(eps0=1e-3, filename_mesh='meshes/3d/piezo_mesh_micro.vtk'):
         },
         'vol': {
             'regions': ['Ym', 'Yc1', 'Yc2'],
-            'expression': 'd_region.i2.%s(svar)',
+            'expression': 'ev_volume.i2.%s(svar)',
             'class': cb.VolumeFractions,
         },
         'eps0': {

--- a/examples/multi_physics/piezo_elasticity_micro.py
+++ b/examples/multi_physics/piezo_elasticity_micro.py
@@ -47,7 +47,7 @@ def recovery_micro(pb, corrs, macro):
         for jj in range(dim):
             kk = coor_to_sym(ii, jj, dim)
             mvar['svar'].set_data(macro['strain'][:, kk])
-            mac_e_Ymc = pb.evaluate('ev_volume_integrate.i2.Ymc(svar)',
+            mac_e_Ymc = pb.evaluate('ev_integrate.i2.Ymc(svar)',
                                     mode='el_avg',
                                     var_dict={'svar': mvar['svar']})
 
@@ -234,7 +234,7 @@ def define(eps0=1e-3, filename_mesh='meshes/3d/piezo_mesh_micro.vtk'):
         },
         'vol': {
             'regions': ['Ym', 'Yc1', 'Yc2'],
-            'expression': 'd_volume.i2.%s(svar)',
+            'expression': 'd_region.i2.%s(svar)',
             'class': cb.VolumeFractions,
         },
         'eps0': {

--- a/examples/multi_physics/thermal_electric.py
+++ b/examples/multi_physics/thermal_electric.py
@@ -86,7 +86,7 @@ functions = {
 }
 
 equations = {
-    '2' : """%.12e * dw_volume_dot.2.Omega( s, dT/dt )
+    '2' : """%.12e * dw_dot.2.Omega( s, dT/dt )
              + dw_laplace.2.Omega( m.thermal_conductivity, s, T )
              = dw_electric_source.2.Omega( m.electric_conductivity,
                                            s, phi_known ) """ % specific_heat,

--- a/examples/navier_stokes/stokes_slip_bc.py
+++ b/examples/navier_stokes/stokes_slip_bc.py
@@ -237,10 +237,10 @@ def define(dims=(3, 1, 0.5), shape=(11, 15, 15), u_order=1, refine=0,
                 'balance' :
                 """de_div_grad.5.Omega(m.nu, v, u)
                  - de_stokes.5.Omega(v, p)
-                 + de_surface_dot.5.Gamma1_f(m.beta, v, u)
-                 + de_surface_dot.5.Gamma2_f(m.beta, v, u)
+                 + de_dot.5.Gamma1_f(m.beta, v, u)
+                 + de_dot.5.Gamma2_f(m.beta, v, u)
                  =
-                 + de_surface_dot.5.Gamma1_f(m.beta, v, u_d)""",
+                 + de_dot.5.Gamma1_f(m.beta, v, u_d)""",
                 'incompressibility' :
                 """de_laplace.5.Omega(m.mu, q, p)
                  + de_stokes.5.Omega(u, q) = 0""",
@@ -270,12 +270,12 @@ def define(dims=(3, 1, 0.5), shape=(11, 15, 15), u_order=1, refine=0,
                 'balance' :
                 """de_div_grad.5.Omega(m.nu, v, u)
                  - de_stokes.5.Omega(v, p)
-                 + de_surface_dot.5.Gamma1_f(m.beta, v, u)
-                 + de_surface_dot.5.Gamma2_f(m.beta, v, u)
+                 + de_dot.5.Gamma1_f(m.beta, v, u)
+                 + de_dot.5.Gamma2_f(m.beta, v, u)
                  + de_non_penetration_p.5.Gamma1_f(m.np_eps, v, u)
                  + de_non_penetration_p.5.Gamma2_f(m.np_eps, v, u)
                  =
-                 + de_surface_dot.5.Gamma1_f(m.beta, v, u_d)""",
+                 + de_dot.5.Gamma1_f(m.beta, v, u_d)""",
                 'incompressibility' :
                 """de_laplace.5.Omega(m.mu, q, p)
                  + de_stokes.5.Omega(u, q) = 0""",

--- a/examples/navier_stokes/stokes_slip_bc.py
+++ b/examples/navier_stokes/stokes_slip_bc.py
@@ -223,10 +223,10 @@ def define(dims=(3, 1, 0.5), shape=(11, 15, 15), u_order=1, refine=0,
                 'balance' :
                 """dw_div_grad.5.Omega(m.nu, v, u)
                  - dw_stokes.5.Omega(v, p)
-                 + dw_surface_dot.5.Gamma1_f(m.beta, v, u)
-                 + dw_surface_dot.5.Gamma2_f(m.beta, v, u)
+                 + dw_dot.5.Gamma1_f(m.beta, v, u)
+                 + dw_dot.5.Gamma2_f(m.beta, v, u)
                  =
-                 + dw_surface_dot.5.Gamma1_f(m.beta, v, u_d)""",
+                 + dw_dot.5.Gamma1_f(m.beta, v, u_d)""",
                 'incompressibility' :
                 """dw_laplace.5.Omega(m.mu, q, p)
                  + dw_stokes.5.Omega(u, q) = 0""",
@@ -254,12 +254,12 @@ def define(dims=(3, 1, 0.5), shape=(11, 15, 15), u_order=1, refine=0,
                 'balance' :
                 """dw_div_grad.5.Omega(m.nu, v, u)
                  - dw_stokes.5.Omega(v, p)
-                 + dw_surface_dot.5.Gamma1_f(m.beta, v, u)
-                 + dw_surface_dot.5.Gamma2_f(m.beta, v, u)
+                 + dw_dot.5.Gamma1_f(m.beta, v, u)
+                 + dw_dot.5.Gamma2_f(m.beta, v, u)
                  + dw_non_penetration_p.5.Gamma1_f(m.np_eps, v, u)
                  + dw_non_penetration_p.5.Gamma2_f(m.np_eps, v, u)
                  =
-                 + dw_surface_dot.5.Gamma1_f(m.beta, v, u_d)""",
+                 + dw_dot.5.Gamma1_f(m.beta, v, u_d)""",
                 'incompressibility' :
                 """dw_laplace.5.Omega(m.mu, q, p)
                  + dw_stokes.5.Omega(u, q) = 0""",

--- a/examples/phononic/band_gaps_conf.py
+++ b/examples/phononic/band_gaps_conf.py
@@ -214,7 +214,7 @@ class BandGapsConf(Struct):
         }
         equations['evp'] = {
             'lhs' : """dw_lin_elastic.i.Y_c( m.D_c, v_c, u_c )""",
-            'rhs' : """dw_volume_dot.i.Y_c( m.density_c, v_c, u_c )""",
+            'rhs' : """dw_dot.i.Y_c( m.density_c, v_c, u_c )""",
         }
 
         expr_coefs = {
@@ -397,8 +397,8 @@ class BandGapsRigidConf(BandGapsConf):
         equations['evp'] = {
             'lhs' : """dw_lin_elastic.i.Y_c( m.D_c, v, u )
                      + dw_lin_elastic.i.Y_r( m.D_r, v, u )""",
-            'rhs' : """dw_volume_dot.i.Y_c( m.density_c, v, u )
-                     + dw_volume_dot.i.Y_r( m.density_r, v, u )""",
+            'rhs' : """dw_dot.i.Y_c( m.density_c, v, u )
+                     + dw_dot.i.Y_r( m.density_r, v, u )""",
         }
 
         expr_coefs = {

--- a/examples/phononic/band_gaps_conf.py
+++ b/examples/phononic/band_gaps_conf.py
@@ -219,7 +219,7 @@ class BandGapsConf(Struct):
 
         expr_coefs = {
             'D' : """dw_lin_elastic.i.Y_m( m.D_m, u1_m, u2_m )""",
-            'VF' : """d_region.i.%s(aux)""",
+            'VF' : """ev_volume.i.%s(aux)""",
             'ema' : """ev_integrate.i.Y_c( m.density_c, u_c )""",
         }
 
@@ -402,7 +402,7 @@ class BandGapsRigidConf(BandGapsConf):
         }
 
         expr_coefs = {
-            'VF' : """d_region.i.%s(aux)""",
+            'VF' : """ev_volume.i.%s(aux)""",
             'ema' : """ev_integrate.i.Y_c( m.density_c, u )
                      + ev_integrate.i.Y_r( m.density_r, u )""",
         }

--- a/examples/phononic/band_gaps_conf.py
+++ b/examples/phononic/band_gaps_conf.py
@@ -219,8 +219,8 @@ class BandGapsConf(Struct):
 
         expr_coefs = {
             'D' : """dw_lin_elastic.i.Y_m( m.D_m, u1_m, u2_m )""",
-            'VF' : """d_volume.i.%s(aux)""",
-            'ema' : """ev_volume_integrate.i.Y_c( m.density_c, u_c )""",
+            'VF' : """d_region.i.%s(aux)""",
+            'ema' : """ev_integrate.i.Y_c( m.density_c, u_c )""",
         }
 
         return equations, expr_coefs
@@ -402,9 +402,9 @@ class BandGapsRigidConf(BandGapsConf):
         }
 
         expr_coefs = {
-            'VF' : """d_volume.i.%s(aux)""",
-            'ema' : """ev_volume_integrate.i.Y_c( m.density_c, u )
-                     + ev_volume_integrate.i.Y_r( m.density_r, u )""",
+            'VF' : """d_region.i.%s(aux)""",
+            'ema' : """ev_integrate.i.Y_c( m.density_c, u )
+                     + ev_integrate.i.Y_r( m.density_r, u )""",
         }
 
         return equations, expr_coefs

--- a/examples/quantum/quantum_common.py
+++ b/examples/quantum/quantum_common.py
@@ -111,8 +111,8 @@ def common(fun_v, get_exact=None, n_eigs=5, tau=0.0):
 
     equations = {
         'lhs' : """dw_laplace.i.Omega(m.val, v, Psi)
-                 + dw_volume_dot.i.Omega(mat_v.V, v, Psi)""",
-        'rhs' : """dw_volume_dot.i.Omega(v, Psi)""",
+                 + dw_dot.i.Omega(mat_v.V, v, Psi)""",
+        'rhs' : """dw_dot.i.Omega(v, Psi)""",
     }
 
     solvers = {

--- a/sfepy/discrete/fem/fields_base.py
+++ b/sfepy/discrete/fem/fields_base.py
@@ -443,6 +443,11 @@ class FEField(Field):
         dim = region.dim
 
         if integration in ('surface', 'surface_extra'):
+            if region_name not in self.surface_data:
+                reg = self.domain.regions[region_name]
+                self.domain.create_surface_group(reg)
+                self.setup_surface_data(reg, False, None)
+
             sd = self.surface_data[region_name]
 
             # This works also for surface fields.

--- a/sfepy/discrete/problem.py
+++ b/sfepy/discrete/problem.py
@@ -1602,7 +1602,7 @@ class Problem(Struct):
         --------
         `problem` is Problem instance.
 
-        >>> out = problem.create_evaluable('ev_volume_integrate.i1.Omega(u)')
+        >>> out = problem.create_evaluable('ev_integrate.i1.Omega(u)')
         >>> equations, variables = out
 
         `vec` is a vector of coefficients compatible with the field

--- a/sfepy/discrete/projections.py
+++ b/sfepy/discrete/projections.py
@@ -26,7 +26,7 @@ def create_mass_matrix(field):
     v = FieldVariable('v', 'test', field, primary_var_name='u')
 
     integral = Integral('i', order=field.approx_order * 2)
-    term = Term.new('dw_volume_dot(v, u)', integral, field.region, v=v, u=u)
+    term = Term.new('dw_dot(v, u)', integral, field.region, v=v, u=u)
     eq = Equation('aux', term)
     eqs = Equations([eq])
     eqs.time_update(None)
@@ -88,7 +88,7 @@ def make_l2_projection_data(target, eval_data, order=None,
     un = FieldVariable('u', 'unknown', target.field)
 
     v = FieldVariable('v', 'test', un.field, primary_var_name=un.name)
-    lhs = Term.new('dw_volume_dot(v, %s)' % un.name, integral,
+    lhs = Term.new('dw_dot(v, %s)' % un.name, integral,
                    un.field.region, v=v, **{un.name : un})
 
     def _eval_data(ts, coors, mode, **kwargs):
@@ -139,7 +139,7 @@ def make_h1_projection_data(target, eval_data):
 
     un = target.name
     v = FieldVariable('v', 'test', target.field, primary_var_name=un)
-    lhs1 = Term.new('dw_volume_dot(v, %s)' % un, integral,
+    lhs1 = Term.new('dw_dot(v, %s)' % un, integral,
                     target.field.region, v=v, **{un : target})
     lhs2 = Term.new('dw_laplace(v, %s)' % un, integral,
                     target.field.region, v=v, **{un : target})

--- a/sfepy/homogenization/coefs_base.py
+++ b/sfepy/homogenization/coefs_base.py
@@ -522,7 +522,7 @@ class CorrEqPar(CorrOne):
     Example:
 
         'equations': 'dw_diffusion.5.Y(mat.k, q, p) =
-                      dw_surface_integrate.5.%s(q)',
+                      dw_integrate.5.%s(q)',
         'eq_pars': ('bYMp', 'bYMm'),
         'class': cb.CorrEqPar,
 

--- a/sfepy/homogenization/recovery.py
+++ b/sfepy/homogenization/recovery.py
@@ -265,7 +265,7 @@ def add_stress_p(out, pb, integral, region, vp, data):
     var = pb.create_variables([vp])[vp]
     var.set_data(data)
 
-    press0 = pb.evaluate('ev_volume_integrate.%s.%s(%s)'
+    press0 = pb.evaluate('ev_integrate.%s.%s(%s)'
                          % (integral, region, vp), verbose=False,
                          mode='el_avg', **{vp: var})
     press = extend_cell_data(press0, pb.domain, region)
@@ -278,7 +278,7 @@ def add_stress_p(out, pb, integral, region, vp, data):
 
 
 def compute_mac_stress_part(pb, integral, region, material, vu, mac_strain):
-    avgmat = pb.evaluate('ev_volume_integrate_mat.%s.%s(%s, %s)'
+    avgmat = pb.evaluate('ev_integrate_mat.%s.%s(%s, %s)'
                          % (integral, region, material, vu), verbose=False,
                          mode='el_avg')
 

--- a/sfepy/homogenization/utils.py
+++ b/sfepy/homogenization/utils.py
@@ -270,7 +270,7 @@ def get_volume(problem, field_name, region_name, quad_order=1):
     var = FieldVariable('u', 'parameter', field, 1,
                         primary_var_name='(set-to-None)')
 
-    vol = problem.evaluate('d_region.%d.%s( u )' % (quad_order, region_name),
+    vol = problem.evaluate('ev_volume.%d.%s( u )' % (quad_order, region_name),
                            u=var)
 
     return vol

--- a/sfepy/homogenization/utils.py
+++ b/sfepy/homogenization/utils.py
@@ -270,7 +270,7 @@ def get_volume(problem, field_name, region_name, quad_order=1):
     var = FieldVariable('u', 'parameter', field, 1,
                         primary_var_name='(set-to-None)')
 
-    vol = problem.evaluate('d_volume.%d.%s( u )' % (quad_order, region_name),
+    vol = problem.evaluate('d_region.%d.%s( u )' % (quad_order, region_name),
                            u=var)
 
     return vol

--- a/sfepy/terms/terms.py
+++ b/sfepy/terms/terms.py
@@ -370,7 +370,6 @@ class Term(Struct):
         self.arg_str = arg_str
         self.region = region
         self._kwargs = kwargs
-        self._integration = self.integration
         self.sign = 1.0
 
         self.set_integral(integral)
@@ -924,6 +923,15 @@ class Term(Struct):
         self.has_geometry = True
 
         self.geometry_types = {}
+        if self.integration == 'by_region':
+            reg = self.region
+            if reg.kind == 'cell':
+                integration = 'volume'
+            elif reg.kind == 'face' or reg.kind == 'facet':
+                integration = getattr(self, 'surface_integration', 'surface')
+
+            self.integration = integration
+
         if isinstance(self.integration, basestr):
             for var in self.get_variables():
                 self.geometry_types[var.name] = self.integration

--- a/sfepy/terms/terms.py
+++ b/sfepy/terms/terms.py
@@ -1184,7 +1184,13 @@ class Term(Struct):
 
         arg_kinds = get_arg_kinds(self.ats)
 
-        arg_shapes_list = self.arg_shapes
+        if hasattr(self, 'arg_shapes_dict') and \
+                isinstance(self.arg_shapes_dict, dict):
+            integration = self.integration.split('_')[0]
+            arg_shapes_list = self.arg_shapes_dict[integration]
+        else:
+            arg_shapes_list = self.arg_shapes
+
         if not isinstance(arg_shapes_list, list):
             arg_shapes_list = [arg_shapes_list]
 

--- a/sfepy/terms/terms_basic.py
+++ b/sfepy/terms/terms_basic.py
@@ -176,7 +176,7 @@ class VolumeTerm(Term):
     :Arguments:
         - parameter : any variable
     """
-    name = 'd_region'
+    name = 'ev_volume'
     arg_types = ('parameter',)
     arg_shapes = [{'parameter' : 'N'}]
     integration = 'by_region'

--- a/sfepy/terms/terms_basic.py
+++ b/sfepy/terms/terms_basic.py
@@ -48,11 +48,10 @@ class IntegrateTerm(Term):
     :Definition:
 
     .. math::
-        \int_{R} y \mbox{ , } \int_{R} \ul{y}
+        \int_{\cal{D}} y \mbox{ , } \int_{\cal{D}} \ul{y}
         \mbox{ , } \int_\Gamma \ul{y} \cdot \ul{n}\\
-        \int_{R} c y \mbox{ , } \int_{R} c \ul{y}
+        \int_{\cal{D}} c y \mbox{ , } \int_{\cal{D}} c \ul{y}
         \mbox{ , } \int_\Gamma c \ul{y} \cdot \ul{n} \mbox{ flux }
-        \mbox{, where } R \in \{\Omega, \Gamma\}
 
     .. math::
         \mbox{vector for } K \from \Ical_h:
@@ -133,8 +132,7 @@ class IntegrateOperatorTerm(Term):
     :Definition:
 
     .. math::
-        \int_{R} q \mbox{ or } \int_\Omega c q
-        \mbox{, where } R \in \{\Omega, \Gamma\}
+        \int_{\cal{D}} q \mbox{ or } \int_{\cal{D}} c q
 
     :Arguments:
         - material : :math:`c` (optional)
@@ -171,7 +169,7 @@ class VolumeTerm(Term):
     :Definition:
 
     .. math::
-        \int_{R} 1 \mbox{, where } R \in \{\Omega, \Gamma\}
+        \int_{\cal{D}} 1
 
     :Arguments:
         - parameter : any variable
@@ -287,8 +285,7 @@ class IntegrateMatTerm(Term):
     :Definition:
 
     .. math::
-        \int_{R} m
-        \mbox{, where } R \in \{\Omega, \Gamma\}
+        \int_{\cal{D}} m
 
     .. math::
         \mbox{vector for } K \from \Ical_h: \int_{T_K} m / \int_{T_K} 1

--- a/sfepy/terms/terms_biot.py
+++ b/sfepy/terms/terms_biot.py
@@ -148,6 +148,7 @@ class BiotStressTerm(CauchyStressTerm):
     name = 'ev_biot_stress'
     arg_types = ('material', 'parameter')
     arg_shapes = {'material' : 'S, 1', 'parameter' : 1}
+    integration = 'volume'
 
     @staticmethod
     def function(out, val_qp, mat, vg, fmode):

--- a/sfepy/terms/terms_compat.py
+++ b/sfepy/terms/terms_compat.py
@@ -1,0 +1,59 @@
+from sfepy.terms.terms_dot import DotProductTerm
+from sfepy.terms.terms_basic import IntegrateTerm, IntegrateOperatorTerm,\
+    VolumeTerm, IntegrateMatTerm
+from sfepy.terms.terms_elastic import CauchyStrainTerm
+from sfepy.terms.terms_navier_stokes import GradTerm, DivTerm
+
+
+# deprecated names, will be removed in future
+
+class DotVolumeProductTerm(DotProductTerm):
+    name = 'dw_volume_dot'
+
+
+class DotSurfaceProductTerm(DotProductTerm):
+    name = 'dw_surface_dot'
+
+
+class IntegrateVolumeTerm(IntegrateTerm):
+    name = 'ev_volume_integrate'
+
+
+class IntegrateSurfaceTerm(IntegrateTerm):
+    name = 'ev_surface_integrate'
+
+
+class IntegrateVolumeOperatorTerm(IntegrateOperatorTerm):
+    name = 'dw_volume_integrate'
+
+
+class IntegrateSurfaceOperatorTerm(IntegrateOperatorTerm):
+    name = 'dw_surface_integrate'
+
+
+class VolumeXTerm(VolumeTerm):
+    name = 'd_volume'
+
+
+class SurfaceTerm(VolumeTerm):
+    name = 'd_surface'
+
+
+class IntegrateVolumeMatTerm(IntegrateMatTerm):
+    name = 'ev_volume_integrate_mat'
+
+
+class IntegrateSurfaceMatTerm(IntegrateMatTerm):
+    name = 'ev_surface_integrate_mat'
+
+
+class CauchyStrainSTerm(CauchyStrainTerm):
+    name = 'ev_cauchy_strain_s'
+
+
+class SurfaceGradTerm(GradTerm):
+    name = 'ev_surface_grad'
+
+
+class SurfaceDivTerm(DivTerm):
+    name = 'ev_surface_div'

--- a/sfepy/terms/terms_diffusion.py
+++ b/sfepy/terms/terms_diffusion.py
@@ -295,8 +295,7 @@ class DiffusionVelocityTerm( Term ):
     :Definition:
 
     .. math::
-        - \int_{R} K_{ij} \nabla_j \bar{p}
-        \mbox{, where } R \in \{\Omega, \Gamma\}
+        - \int_{\cal{D}} K_{ij} \nabla_j \bar{p}
 
     .. math::
         \mbox{vector for } K \from \Ical_h: - \int_{T_K} K_{ij} \nabla_j \bar{p}

--- a/sfepy/terms/terms_diffusion.py
+++ b/sfepy/terms/terms_diffusion.py
@@ -295,7 +295,8 @@ class DiffusionVelocityTerm( Term ):
     :Definition:
 
     .. math::
-        - \int_{\Omega} K_{ij} \nabla_j \bar{p}
+        - \int_{R} K_{ij} \nabla_j \bar{p}
+        \mbox{, where } R \in \{\Omega, \Gamma\}
 
     .. math::
         \mbox{vector for } K \from \Ical_h: - \int_{T_K} K_{ij} \nabla_j \bar{p}
@@ -311,6 +312,8 @@ class DiffusionVelocityTerm( Term ):
     name = 'ev_diffusion_velocity'
     arg_types = ('material', 'parameter')
     arg_shapes = {'material' : 'D, D', 'parameter' : 1}
+    integration = 'by_region'
+    surface_integration = 'surface_extra'
 
     @staticmethod
     def function(out, grad, mat, vg, fmode):

--- a/sfepy/terms/terms_dot.py
+++ b/sfepy/terms/terms_dot.py
@@ -16,18 +16,18 @@ class DotProductTerm(Term):
     :Definition:
 
     .. math::
-        \int_{R} q p \mbox{ , } \int_{R} \ul{v} \cdot \ul{u}
+        \int_{\cal{D}} q p \mbox{ , } \int_{\cal{D}} \ul{v} \cdot \ul{u}
         \mbox{ , }
         \int_\Gamma \ul{v} \cdot \ul{n} p \mbox{ , }
         \int_\Gamma q \ul{n} \cdot \ul{u} \mbox{ , }
-        \int_{R} p r \mbox{ , } \int_{R} \ul{u} \cdot \ul{w}
+        \int_{\cal{D}} p r \mbox{ , } \int_{\cal{D}} \ul{u} \cdot \ul{w}
         \mbox{ , } \int_\Gamma \ul{w} \cdot \ul{n} p \\
-        \int_{R} c q p \mbox{ , } \int_{R} c \ul{v} \cdot \ul{u}
+        \int_{\cal{D}} c q p \mbox{ , } \int_{\cal{D}} c \ul{v} \cdot \ul{u}
         \mbox{ , }
-        \int_{R} c p r \mbox{ , } \int_{R} c \ul{u} \cdot \ul{w} \\
-        \int_{R} \ul{v} \cdot \ull{M} \cdot \ul{u}
+        \int_{\cal{D}} c p r \mbox{ , } \int_{\cal{D}} c \ul{u} \cdot \ul{w} \\
+        \int_{\cal{D}} \ul{v} \cdot \ull{M} \cdot \ul{u}
         \mbox{ , }
-        \int_{R} \ul{u} \cdot \ull{M} \cdot \ul{w}
+        \int_{\cal{D}} \ul{u} \cdot \ull{M} \cdot \ul{w}
 
     :Arguments 1:
         - material : :math:`c` or :math:`\ull{M}` (optional)

--- a/sfepy/terms/terms_elastic.py
+++ b/sfepy/terms/terms_elastic.py
@@ -400,7 +400,7 @@ class CauchyStrainTerm(Term):
     :Definition:
 
     .. math::
-        \int_{\Omega} \ull{e}(\ul{w})
+        \int_{R} \ull{e}(\ul{w}) \mbox{, where } R \in \{\Omega, \Gamma\}
 
     .. math::
         \mbox{vector for } K \from \Ical_h: \int_{T_K} \ull{e}(\ul{w}) /
@@ -415,6 +415,8 @@ class CauchyStrainTerm(Term):
     name = 'ev_cauchy_strain'
     arg_types = ('parameter',)
     arg_shapes = {'parameter' : 'D'}
+    integration = 'by_region'
+    surface_integration = 'surface_extra'
 
     @staticmethod
     def function(out, strain, vg, fmode):
@@ -446,32 +448,6 @@ class CauchyStrainTerm(Term):
 
         return (n_el, n_qp, dim * (dim + 1) // 2, 1), parameter.dtype
 
-class CauchyStrainSTerm(CauchyStrainTerm):
-    r"""
-    Evaluate Cauchy strain tensor on a surface region.
-
-    See :class:`CauchyStrainTerm`.
-
-    Supports 'eval', 'el_avg' and 'qp' evaluation modes.
-
-    :Definition:
-
-    .. math::
-        \int_{\Gamma} \ull{e}(\ul{w})
-
-    .. math::
-        \mbox{vector for } K \from \Ical_h: \int_{T_K} \ull{e}(\ul{w}) /
-        \int_{T_K} 1
-
-    .. math::
-        \ull{e}(\ul{w})|_{qp}
-
-    :Arguments:
-        - parameter : :math:`\ul{w}`
-    """
-    name = 'ev_cauchy_strain_s'
-    arg_types = ('parameter',)
-    integration = 'surface_extra'
 
 class CauchyStressTerm(Term):
     r"""
@@ -486,7 +462,8 @@ class CauchyStressTerm(Term):
     :Definition:
 
     .. math::
-        \int_{\Omega} D_{ijkl} e_{kl}(\ul{w})
+        \int_{R} D_{ijkl} e_{kl}(\ul{w})
+        \mbox{, where } R \in \{\Omega, \Gamma\}
 
     .. math::
         \mbox{vector for } K \from \Ical_h:
@@ -502,6 +479,8 @@ class CauchyStressTerm(Term):
     name = 'ev_cauchy_stress'
     arg_types = ('material', 'parameter')
     arg_shapes = {'material' : 'S, S', 'parameter' : 'D'}
+    integration = 'by_region'
+    surface_integration = 'surface_extra'
 
     @staticmethod
     def function(out, coef, strain, mat, vg, fmode):

--- a/sfepy/terms/terms_elastic.py
+++ b/sfepy/terms/terms_elastic.py
@@ -400,7 +400,7 @@ class CauchyStrainTerm(Term):
     :Definition:
 
     .. math::
-        \int_{R} \ull{e}(\ul{w}) \mbox{, where } R \in \{\Omega, \Gamma\}
+        \int_{\cal{D}} \ull{e}(\ul{w})
 
     .. math::
         \mbox{vector for } K \from \Ical_h: \int_{T_K} \ull{e}(\ul{w}) /
@@ -462,8 +462,7 @@ class CauchyStressTerm(Term):
     :Definition:
 
     .. math::
-        \int_{R} D_{ijkl} e_{kl}(\ul{w})
-        \mbox{, where } R \in \{\Omega, \Gamma\}
+        \int_{\cal{D}} D_{ijkl} e_{kl}(\ul{w})
 
     .. math::
         \mbox{vector for } K \from \Ical_h:

--- a/sfepy/terms/terms_multilinear.py
+++ b/sfepy/terms/terms_multilinear.py
@@ -1088,10 +1088,10 @@ class ETermBase(Term):
                                     kind='ndarray')
         return normals
 
-class EIntegrateVolumeOperatorTerm(ETermBase):
+class EIntegrateOperatorTerm(ETermBase):
     r"""
-    Volume integral of a test function weighted by a scalar function
-    :math:`c`.
+    Volume and surface integral of a test function weighted by a scalar
+    function :math:`c`.
 
     :Definition:
 
@@ -1102,10 +1102,11 @@ class EIntegrateVolumeOperatorTerm(ETermBase):
         - material : :math:`c` (optional)
         - virtual  : :math:`q`
     """
-    name = 'de_volume_integrate'
+    name = 'de_integrate'
     arg_types = ('opt_material', 'virtual')
     arg_shapes = [{'opt_material' : '1, 1', 'virtual' : (1, None)},
                   {'opt_material' : None}]
+    integration = 'by_region'
 
     def get_function(self, mat, virtual, mode=None, term_mode=None,
                      diff_var=None, **kwargs):
@@ -1164,23 +1165,23 @@ class ELaplaceTerm(ETermBase):
 
         return fun
 
-class EVolumeDotTerm(ETermBase):
+class EDotTerm(ETermBase):
     r"""
-    Volume :math:`L^2(\Omega)` weighted dot product for both scalar and vector
-    fields. Can be evaluated. Can use derivatives.
+    Volume and surface :math:`L^2(\Omega)` weighted dot product for both
+    scalar and vector fields. Can be evaluated. Can use derivatives.
 
     :Definition:
 
     .. math::
-        \int_\Omega q p \mbox{ , } \int_\Omega \ul{v} \cdot \ul{u}
+        \int_{\cal{D}} q p \mbox{ , } \int_{\cal{D}} \ul{v} \cdot \ul{u}
         \mbox{ , }
-        \int_\Omega p r \mbox{ , } \int_\Omega \ul{u} \cdot \ul{w} \\
-        \int_\Omega c q p \mbox{ , } \int_\Omega c \ul{v} \cdot \ul{u}
+        \int_{\cal{D}} p r \mbox{ , } \int_{\cal{D}} \ul{u} \cdot \ul{w} \\
+        \int_{\cal{D}} c q p \mbox{ , } \int_{\cal{D}} c \ul{v} \cdot \ul{u}
         \mbox{ , }
-        \int_\Omega c p r \mbox{ , } \int_\Omega c \ul{u} \cdot \ul{w} \\
-        \int_\Omega \ul{v} \cdot \ull{M} \cdot \ul{u}
+        \int_{\cal{D}} c p r \mbox{ , } \int_{\cal{D}} c \ul{u} \cdot \ul{w} \\
+        \int_{\cal{D}} \ul{v} \cdot \ull{M} \cdot \ul{u}
         \mbox{ , }
-        \int_\Omega \ul{u} \cdot \ull{M} \cdot \ul{w}
+        \int_{\cal{D}} \ul{u} \cdot \ull{M} \cdot \ul{w}
 
     :Arguments 1:
         - material : :math:`c` or :math:`\ull{M}` (optional)
@@ -1192,7 +1193,7 @@ class EVolumeDotTerm(ETermBase):
         - parameter_1 : :math:`p` or :math:`\ul{u}`
         - parameter_2 : :math:`r` or :math:`\ul{w}`
     """
-    name = 'de_volume_dot'
+    name = 'de_dot'
     arg_types = (('opt_material', 'virtual', 'state'),
                  ('opt_material', 'parameter_1', 'parameter_2'))
     arg_shapes = [{'opt_material' : '1, 1', 'virtual' : (1, 'state'),
@@ -1203,6 +1204,7 @@ class EVolumeDotTerm(ETermBase):
                   {'opt_material' : 'D, D'},
                   {'opt_material' : None}]
     modes = ('weak', 'eval')
+    integration = 'by_region'
 
     def get_function(self, mat, virtual, state, mode=None, term_mode=None,
                      diff_var=None, **kwargs):
@@ -1224,36 +1226,6 @@ class EVolumeDotTerm(ETermBase):
 
         return fun
 
-class ESurfaceDotTerm(EVolumeDotTerm):
-    r"""
-    Surface :math:`L^2(\Gamma)` dot product for both scalar and vector
-    fields.
-
-    :Definition:
-
-    .. math::
-        \int_\Gamma q p \mbox{ , } \int_\Gamma \ul{v} \cdot \ul{u}
-        \mbox{ , }
-        \int_\Gamma p r \mbox{ , } \int_\Gamma \ul{u} \cdot \ul{w} \\
-        \int_\Gamma c q p \mbox{ , } \int_\Gamma c \ul{v} \cdot \ul{u}
-        \mbox{ , }
-        \int_\Gamma c p r \mbox{ , } \int_\Gamma c \ul{u} \cdot \ul{w} \\
-        \int_\Gamma \ul{v} \cdot \ull{M} \cdot \ul{u}
-        \mbox{ , }
-        \int_\Gamma \ul{u} \cdot \ull{M} \cdot \ul{w}
-
-    :Arguments 1:
-        - material : :math:`c` or :math:`\ull{M}` (optional)
-        - virtual  : :math:`q` or :math:`\ul{v}`
-        - state    : :math:`p` or :math:`\ul{u}`
-
-    :Arguments 2:
-        - material    : :math:`c` or :math:`\ull{M}` (optional)
-        - parameter_1 : :math:`p` or :math:`\ul{u}`
-        - parameter_2 : :math:`r` or :math:`\ul{w}`
-    """
-    name = 'de_surface_dot'
-    integration = 'surface'
 
 class EScalarDotMGradScalarTerm(ETermBase):
     r"""

--- a/sfepy/terms/terms_navier_stokes.py
+++ b/sfepy/terms/terms_navier_stokes.py
@@ -333,8 +333,7 @@ class GradTerm(Term):
     :Definition:
 
     .. math::
-        \int_{R} \nabla p \mbox{ or } \int_{R} \nabla \ul{w}
-        \mbox{, where } R \in \{\Omega, \Gamma\}
+        \int_{\cal{D}} \nabla p \mbox{ or } \int_{\cal{D}} \nabla \ul{w}
 
     .. math::
         \mbox{vector for } K \from \Ical_h: \int_{T_K} \nabla p /
@@ -392,8 +391,7 @@ class DivTerm(Term):
     :Definition:
 
     .. math::
-         \int_{R} \nabla \cdot \ul{u}
-         \mbox{, where } R \in \{\Omega, \Gamma\}
+         \int_{\cal{D}} \nabla \cdot \ul{u}
 
     .. math::
          \mbox{vector for } K \from \Ical_h:

--- a/sfepy/terms/terms_navier_stokes.py
+++ b/sfepy/terms/terms_navier_stokes.py
@@ -333,7 +333,8 @@ class GradTerm(Term):
     :Definition:
 
     .. math::
-        \int_{\Omega} \nabla p \mbox{ or } \int_{\Omega} \nabla \ul{w}
+        \int_{R} \nabla p \mbox{ or } \int_{R} \nabla \ul{w}
+        \mbox{, where } R \in \{\Omega, \Gamma\}
 
     .. math::
         \mbox{vector for } K \from \Ical_h: \int_{T_K} \nabla p /
@@ -349,6 +350,8 @@ class GradTerm(Term):
     name = 'ev_grad'
     arg_types = ('parameter',)
     arg_shapes = {'parameter' : 'N'}
+    integration = 'by_region'
+    surface_integration = 'surface_extra'
 
     @staticmethod
     def function(out, grad, vg, fmode):
@@ -380,12 +383,6 @@ class GradTerm(Term):
 
         return (n_el, n_qp, dim, n_c), parameter.dtype
 
-class SurfaceGradTerm(GradTerm):
-    __doc__ = GradTerm.__doc__.replace('Omega', 'Gamma')
-
-    name = 'ev_surface_grad'
-    integration = 'surface_extra'
-
 class DivTerm(Term):
     r"""
     Evaluate divergence of a vector field.
@@ -395,7 +392,8 @@ class DivTerm(Term):
     :Definition:
 
     .. math::
-         \int_{\Omega} \nabla \cdot \ul{u}
+         \int_{R} \nabla \cdot \ul{u}
+         \mbox{, where } R \in \{\Omega, \Gamma\}
 
     .. math::
          \mbox{vector for } K \from \Ical_h:
@@ -410,6 +408,8 @@ class DivTerm(Term):
     name = 'ev_div'
     arg_types = ('parameter',)
     arg_shapes = {'parameter' : 'D'}
+    integration = 'by_region'
+    surface_integration = 'surface_extra'
 
     @staticmethod
     def function(out, div, vg, fmode):
@@ -440,12 +440,6 @@ class DivTerm(Term):
             n_qp = 1
 
         return (n_el, n_qp, 1, 1), parameter.dtype
-
-class SurfaceDivTerm(DivTerm):
-    __doc__ = DivTerm.__doc__.replace('Omega', 'Gamma')
-
-    name = 'ev_surface_div'
-    integration = 'surface_extra'
 
 class DivOperatorTerm(Term):
     r"""

--- a/tests/test_high_level.py
+++ b/tests/test_high_level.py
@@ -47,7 +47,7 @@ class Test(TestCommon):
         u = FieldVariable('u', 'parameter', self.field,
                           primary_var_name='(set-to-None)')
 
-        term = Term.new('d_region(u)', integral, self.omega, u=u)
+        term = Term.new('ev_volume(u)', integral, self.omega, u=u)
         term *= 10.0
 
         term.setup()
@@ -74,8 +74,8 @@ class Test(TestCommon):
         u = FieldVariable('u', 'parameter', self.field,
                           primary_var_name='(set-to-None)')
 
-        t1 = Term.new('d_region(u)', integral, self.omega, u=u)
-        t2 = Term.new('d_region(u)', integral, self.gamma1, u=u)
+        t1 = Term.new('ev_volume(u)', integral, self.omega, u=u)
+        t2 = Term.new('ev_volume(u)', integral, self.gamma1, u=u)
 
         expr = 2.2j * (t1 * 5.5 - 3j * t2) * 0.25
 

--- a/tests/test_high_level.py
+++ b/tests/test_high_level.py
@@ -47,7 +47,7 @@ class Test(TestCommon):
         u = FieldVariable('u', 'parameter', self.field,
                           primary_var_name='(set-to-None)')
 
-        term = Term.new('d_volume(u)', integral, self.omega, u=u)
+        term = Term.new('d_region(u)', integral, self.omega, u=u)
         term *= 10.0
 
         term.setup()
@@ -74,8 +74,8 @@ class Test(TestCommon):
         u = FieldVariable('u', 'parameter', self.field,
                           primary_var_name='(set-to-None)')
 
-        t1 = Term.new('d_volume(u)', integral, self.omega, u=u)
-        t2 = Term.new('d_surface(u)', integral, self.gamma1, u=u)
+        t1 = Term.new('d_region(u)', integral, self.omega, u=u)
+        t2 = Term.new('d_region(u)', integral, self.gamma1, u=u)
 
         expr = 2.2j * (t1 * 5.5 - 3j * t2) * 0.25
 

--- a/tests/test_mesh_interp.py
+++ b/tests/test_mesh_interp.py
@@ -246,7 +246,7 @@ class Test(TestCommon):
             qps = get_physical_qps(omega, integral)
             coors = qps.values
 
-            term = Term.new('ev_volume_integrate(u)', integral, omega, u=u)
+            term = Term.new('ev_integrate(u)', integral, omega, u=u)
             term.setup()
             val1 = term.evaluate(mode='qp')
             val1 = val1.ravel()

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -12,7 +12,7 @@ class Test(TestCommon):
         from sfepy.discrete.parse_equations import create_bnf
 
         test_strs = [
-            """- d_volume.i1.Omega(uc)""",
+            """- d_region.i1.Omega(uc)""",
             """- 2 * dw_term.i1.Omega(uc)
              = - 3.0 * dw_term2.i1.Omega2(uc)""",
             """2 * dw_term.i1.Omega(uc)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -12,7 +12,7 @@ class Test(TestCommon):
         from sfepy.discrete.parse_equations import create_bnf
 
         test_strs = [
-            """- d_region.i1.Omega(uc)""",
+            """- ev_volume.i1.Omega(uc)""",
             """- 2 * dw_term.i1.Omega(uc)
              = - 3.0 * dw_term2.i1.Omega2(uc)""",
             """2 * dw_term.i1.Omega(uc)

--- a/tests/test_term_call_modes.py
+++ b/tests/test_term_call_modes.py
@@ -201,29 +201,35 @@ class Test(TestCommon):
                    or (term_cls.name == "dw_ns_dot_grad_s"):
                     continue
 
-                vint = ('volume', 'point', 'custom')
-                rname = 'Omega' if term_cls.integration in vint else 'Gamma'
-
-                self.report('<-- %s ...' % term_cls.name)
-
-                if rname == 'Gamma' and domain.mesh.dim == 1:
-                    self.report('--> 1D Gamma region: not tested!')
-
-                elif term_cls.arg_shapes:
-                    try:
-                        _ok = self._test_single_term(term_cls, domain, rname)
-
-                    except:
-                        _ok = False
-
-                    if not _ok:
-                        failed.append((domain.name, term_cls.name))
-
-                    ok = ok and _ok
-                    self.report('--> ok: %s' % _ok)
-
+                if term_cls.integration == 'by_region':
+                    rnames = ['Omega', 'Gamma']
                 else:
-                    self.report('--> not tested!')
+                    vint = ('volume', 'point', 'custom')
+                    rnames = ['Omega'] if term_cls.integration in vint\
+                        else ['Gamma']
+
+                for rname in rnames:
+                    self.report('<-- %s.%s ...' % (term_cls.name, rname))
+
+                    if rname == 'Gamma' and domain.mesh.dim == 1:
+                        self.report('--> 1D Gamma region: not tested!')
+
+                    elif term_cls.arg_shapes:
+                        try:
+                            _ok = self._test_single_term(term_cls, domain,
+                                                         rname)
+
+                        except:
+                            _ok = False
+
+                        if not _ok:
+                            failed.append((domain.name, term_cls.name))
+
+                        ok = ok and _ok
+                        self.report('--> ok: %s' % _ok)
+
+                    else:
+                        self.report('--> not tested!')
 
         self.report('failed:', failed)
 

--- a/tests/test_term_consistency.py
+++ b/tests/test_term_consistency.py
@@ -49,7 +49,7 @@ def get_pars(ts, coor, mode=None, term=None, **kwargs):
             val = nm.zeros((sym, 1), dtype=nm.float64)
             val[:dim] = 0.132
             val[dim:sym] = 0.092
-        elif 'volume_dot' in term.name:
+        elif '_dot' in term.name:
             val = 1.0 / nm.array([3.8], dtype=nm.float64)
         elif 'diffusion' in term.name:
             val = nm.eye(dim, dtype=nm.float64)
@@ -72,7 +72,7 @@ test_terms = [
      ('dw', 'pv1', ('pv1', 'ps1'), ('tv', 'ps1', 'uv', 'us', 'ts'))),
     ('%s_diffusion.i.Omega( m.val, %s, %s )',
      ('dw', 'ps1', ('ps1', 'ps2'), ('ts', 'ps1', 'us'))),
-    ('%s_volume_dot.i.Omega( m.val, %s, %s )',
+    ('%s_dot.i.Omega( m.val, %s, %s )',
      ('dw', 'ps1', ('ps1', 'ps2'), ('ts', 'ps1', 'us'))),
 ]
 

--- a/tests/test_term_consistency.py
+++ b/tests/test_term_consistency.py
@@ -209,7 +209,7 @@ class Test(TestCommon):
         vec[:] = 1.0
         us.set_data(vec)
 
-        expr = 'ev_surface_integrate.i.Left( us )'
+        expr = 'ev_integrate.i.Left( us )'
         val = problem.evaluate(expr, us=us)
         ok1 = nm.abs(val - 1.0) < 1e-15
         self.report('with unknown: %s, value: %s, ok: %s'
@@ -219,7 +219,7 @@ class Test(TestCommon):
                             primary_var_name='(set-to-None)')
         ps1.set_data(vec)
 
-        expr = 'ev_surface_integrate.i.Left( ps1 )'
+        expr = 'ev_integrate.i.Left( ps1 )'
         val = problem.evaluate(expr, ps1=ps1)
         ok2 = nm.abs(val - 1.0) < 1e-15
         self.report('with parameter: %s, value: %s, ok: %s'

--- a/tests/test_term_sensitivity.py
+++ b/tests/test_term_sensitivity.py
@@ -55,7 +55,7 @@ equations = {}
 
 test_terms = [
     ('d_sd_lin_elastic', 'dw_lin_elastic', 'Omega', 'mat.D', 'U1', 'U2'),
-    ('d_sd_volume_dot', 'dw_volume_dot', 'Omega', None, 'U1', 'U2'),
+    ('d_sd_volume_dot', 'dw_dot', 'Omega', None, 'U1', 'U2'),
     ('d_sd_diffusion', 'dw_diffusion', 'Omega', 'mat.K', 'P1', 'P2'),
     ('d_sd_div', 'dw_stokes', 'Omega', None, 'U1', 'P1'),
     ('d_sd_div_grad', 'dw_div_grad', 'Omega', 'mat.c', 'U1', 'U2'),

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -21,8 +21,8 @@ regions = {
 }
 
 expressions = {
-    'volume_p' : 'd_region.i.Omega(p)',
-    'volume_u' : 'd_region.i.Omega(u)',
+    'volume_p' : 'ev_volume.i.Omega(p)',
+    'volume_u' : 'ev_volume.i.Omega(u)',
     'surface_p' : 'd_volume_surface.i.Gamma(p)',
     'surface_u' : 'd_volume_surface.i.Gamma(u)',
 }

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -21,8 +21,8 @@ regions = {
 }
 
 expressions = {
-    'volume_p' : 'd_volume.i.Omega(p)',
-    'volume_u' : 'd_volume.i.Omega(u)',
+    'volume_p' : 'd_region.i.Omega(p)',
+    'volume_u' : 'd_region.i.Omega(u)',
     'surface_p' : 'd_volume_surface.i.Gamma(p)',
     'surface_u' : 'd_volume_surface.i.Gamma(u)',
 }


### PR DESCRIPTION
This PR unifies volume/surface terms. If the term integration is set to `'by_region'` then the integration mode, i.e. `'volume'`, `'surface'`, is determined by `term.region.kind`.  The term attribute `'surface_integration'` allows to set `'surface_extra'` integration for surface regions.

The following terms are renamed/changed:

- `dw_volume_dot` --> `dw_dot`
- `dw_surface_dot` --> `dw_dot`
- `ev_volume_integrate` --> `ev_integrate`
- `ev_surface_integrate` --> `ev_integrate`
- `ev_volume_integrate_mat` --> `ev_integrate_mat`
- `ev_surface_integrate` --> `ev_integrate_mat`
- `dw_volume_integrate` --> `dw_integrate`
- `dw_surface_integrate` --> `dw_integrate`
- `d_volume` -->  `d_region`  __I'm not sure by the name!__
- `d_surface` --> `d_region`
- `ev_cauchy_strain_s` -->  `ev_cauchy_strain`
- `ev_surface_grad` --> `ev_grad`
- `ev_surface_div` --> `ev_div`

For backward compatibility, the old term names are defined in `terms_compat.py`.
