### PR TITLE
Rename all `d_` evaluation terms

### DIFF
--- a/doc/terms_overview.rst
+++ b/doc/terms_overview.rst
@@ -104,16 +104,11 @@ Term names are (usually) prefixed according to the following conventions:
      - `'weak'`
      - terms having a virtual (test) argument and zero or more unknown
        arguments, used for FE assembling
-   * - d
-     - discrete
-     - `'eval'`, `'el_eval'`
-     - terms having all arguments known, the result is the value of the term
-       integral evaluation
    * - ev
      - evaluate
      - `'eval'`, `'el_eval'`, `'el_avg'`, `'qp'`
-     - terms having all arguments known and supporting all evaluation modes
-       except `'weak'` (no virtual variables in arguments, no FE assembling)
+     - terms having all arguments known, modes `'el_avg'`, `'qp'` are not
+       supported by all `ev_` terms
    * - de
      - discrete einsum
      - any (work in progress)

--- a/examples/diffusion/poisson_neumann.py
+++ b/examples/diffusion/poisson_neumann.py
@@ -51,7 +51,7 @@ def post_process(out, pb, state, extend=False):
     totals = nm.zeros(3)
     for gamma in ['Gamma_N', 'Gamma_N0', 'Gamma_D']:
 
-        flux = pb.evaluate('d_surface_flux.i.%s(m.K, t)' % gamma,
+        flux = pb.evaluate('ev_surface_flux.i.%s(m.K, t)' % gamma,
                            verbose=False)
         area = pb.evaluate('ev_volume.i.%s(t)' % gamma, verbose=False)
 

--- a/sfepy/terms/terms_adj_navier_stokes.py
+++ b/sfepy/terms/terms_adj_navier_stokes.py
@@ -229,7 +229,7 @@ class SDDotVolumeTerm(Term):
         - parameter_2 : :math:`q` or :math:`\ul{w}`
         - parameter_mv : :math:`\ul{\Vcal}`
     """
-    name = 'd_sd_volume_dot'
+    name = 'ev_sd_volume_dot'
     arg_types = ('parameter_1', 'parameter_2', 'parameter_mv')
     arg_shapes = [{'parameter_1' : 'D', 'parameter_2' : 'D',
                    'parameter_mv' : 'D'},
@@ -270,7 +270,7 @@ class SDDivTerm(Term):
         - parameter_p : :math:`p`
         - parameter_mv : :math:`\ul{\Vcal}`
     """
-    name = 'd_sd_div'
+    name = 'ev_sd_div'
     arg_types = ('parameter_u', 'parameter_p', 'parameter_mv')
     arg_shapes = {'parameter_u' : 'D', 'parameter_p' : 1,
                   'parameter_mv' : 'D'}
@@ -316,7 +316,7 @@ class SDDivGradTerm(Term):
         - parameter_w : :math:`\ul{w}`
         - parameter_mv : :math:`\ul{\Vcal}`
     """
-    name = 'd_sd_div_grad'
+    name = 'ev_sd_div_grad'
     arg_types = ('opt_material', 'parameter_u', 'parameter_w',
                  'parameter_mv')
     arg_shapes = [{'opt_material' : '1, 1',
@@ -364,7 +364,7 @@ class SDConvectTerm(Term):
         - parameter_w : :math:`\ul{w}`
         - parameter_mv : :math:`\ul{\Vcal}`
     """
-    name = 'd_sd_convect'
+    name = 'ev_sd_convect'
     arg_types = ('parameter_u', 'parameter_w', 'parameter_mv')
     arg_shapes = {'parameter_u' : 'D', 'parameter_w' : 'D',
                   'parameter_mv' : 'D'}
@@ -424,7 +424,7 @@ class NSOFSurfMinDPressTerm(Term):
         - material_2 : :math:`bpress` (given pressure)
         - parameter  : :math:`p`
     """
-    name = 'd_of_ns_surf_min_d_press'
+    name = 'ev_of_ns_surf_min_d_press'
     arg_types = ('material_1', 'material_2', 'parameter')
     arg_shapes = {'material_1' : 1, 'material_2' : 1,
                   'parameter' : 1}
@@ -489,7 +489,7 @@ class SDGradDivStabilizationTerm(Term):
         - parameter_mv : :math:`\ul{\Vcal}`
         - mode        : 1 (sensitivity) or 0 (original term value)
     """
-    name = 'd_sd_st_grad_div'
+    name = 'ev_sd_st_grad_div'
     arg_types = ('material', 'parameter_u', 'parameter_w',
                  'parameter_mv')
     arg_shapes = {'material' : '1, 1',
@@ -538,7 +538,7 @@ class SDSUPGCStabilizationTerm(Term):
         - parameter_mv : :math:`\ul{\Vcal}`
         - mode        : 1 (sensitivity) or 0 (original term value)
     """
-    name = 'd_sd_st_supg_c'
+    name = 'ev_sd_st_supg_c'
     arg_types = ('material', 'parameter_b', 'parameter_u', 'parameter_w',
                 'parameter_mv')
     arg_shapes = {'material' : '1, 1',
@@ -586,7 +586,7 @@ class SDPSPGCStabilizationTerm(Term):
         - parameter_mv : :math:`\ul{\Vcal}`
         - mode        : 1 (sensitivity) or 0 (original term value)
     """
-    name = 'd_sd_st_pspg_c'
+    name = 'ev_sd_st_pspg_c'
     arg_types = ('material', 'parameter_b', 'parameter_u', 'parameter_r',
                 'parameter_mv')
     arg_shapes = {'material' : '1, 1',
@@ -631,7 +631,7 @@ class SDPSPGPStabilizationTerm(Term):
         - parameter_mv : :math:`\ul{\Vcal}`
         - mode        : 1 (sensitivity) or 0 (original term value)
     """
-    name = 'd_sd_st_pspg_p'
+    name = 'ev_sd_st_pspg_p'
     arg_types = ('material', 'parameter_r', 'parameter_p',
                 'parameter_mv')
     arg_shapes = {'material' : '1, 1',

--- a/sfepy/terms/terms_adj_navier_stokes.py
+++ b/sfepy/terms/terms_adj_navier_stokes.py
@@ -214,7 +214,7 @@ class SUPGPAdj2StabilizationTerm(Term):
 
         return grad_u, state(), mat, vg_u, vg_r, conn_r, fmode
 
-class SDDotVolumeTerm(Term):
+class SDDotTerm(Term):
     r"""
     Sensitivity (shape derivative) of dot product of scalars or vectors.
 
@@ -229,7 +229,7 @@ class SDDotVolumeTerm(Term):
         - parameter_2 : :math:`q` or :math:`\ul{w}`
         - parameter_mv : :math:`\ul{\Vcal}`
     """
-    name = 'ev_sd_volume_dot'
+    name = 'ev_sd_dot'
     arg_types = ('parameter_1', 'parameter_2', 'parameter_mv')
     arg_shapes = [{'parameter_1' : 'D', 'parameter_2' : 'D',
                    'parameter_mv' : 'D'},

--- a/sfepy/terms/terms_basic.py
+++ b/sfepy/terms/terms_basic.py
@@ -211,7 +211,7 @@ class VolumeSurfaceTerm(Term):
     :Arguments:
         - parameter : any variable
     """
-    name = 'd_volume_surface'
+    name = 'ev_volume_surface'
     arg_types = ('parameter',)
     arg_shapes = {'parameter' : 'N'}
     integration = 'surface'
@@ -247,7 +247,7 @@ class SurfaceMomentTerm(Term):
         - material  : :math:`\ul{x}_0` (special)
         - parameter : any variable
     """
-    name = 'd_surface_moment'
+    name = 'ev_surface_moment'
     arg_types = ('material', 'parameter')
     arg_shapes = {'material' : '.: D', 'parameter' : 'N'}
     integration = 'surface'
@@ -339,7 +339,7 @@ class SumNodalValuesTerm(Term):
     :Arguments:
         - parameter : :math:`p` or :math:`\ul{u}`
     """
-    name = 'd_sum_vals'
+    name = 'ev_sum_vals'
     arg_types = ('parameter',)
     arg_shapes = {'parameter' : 'N'}
 

--- a/sfepy/terms/terms_compat.py
+++ b/sfepy/terms/terms_compat.py
@@ -1,9 +1,10 @@
 from sfepy.terms.terms_dot import DotProductTerm
 from sfepy.terms.terms_basic import IntegrateTerm, IntegrateOperatorTerm,\
-    VolumeTerm, IntegrateMatTerm
+    VolumeTerm, IntegrateMatTerm, VolumeSurfaceTerm, SurfaceMomentTerm,\
+    SumNodalValuesTerm
 from sfepy.terms.terms_elastic import CauchyStrainTerm
 from sfepy.terms.terms_navier_stokes import GradTerm, DivTerm
-
+from sfepy.terms.terms_diffusion import SurfaceFluxTerm
 
 # deprecated names, will be removed in future
 
@@ -57,3 +58,19 @@ class SurfaceGradTerm(GradTerm):
 
 class SurfaceDivTerm(DivTerm):
     name = 'ev_surface_div'
+
+
+class DVolumeSurfaceTerm(VolumeSurfaceTerm):
+    name = 'd_volume_surface'
+
+
+class DSurfaceMomentTerm(SurfaceMomentTerm):
+    name = 'd_surface_moment'
+
+
+class DSumNodalValuesTerm(SumNodalValuesTerm):
+    name = 'd_sum_vals'
+
+
+class DSurfaceFluxTerm(SurfaceFluxTerm):
+    name = 'd_surface_flux'

--- a/sfepy/terms/terms_compat.py
+++ b/sfepy/terms/terms_compat.py
@@ -5,6 +5,7 @@ from sfepy.terms.terms_basic import IntegrateTerm, IntegrateOperatorTerm,\
 from sfepy.terms.terms_elastic import CauchyStrainTerm
 from sfepy.terms.terms_navier_stokes import GradTerm, DivTerm
 from sfepy.terms.terms_diffusion import SurfaceFluxTerm
+from sfepy.terms.terms_adj_navier_stokes import SDDotTerm
 
 # deprecated names, will be removed in future
 
@@ -74,3 +75,6 @@ class DSumNodalValuesTerm(SumNodalValuesTerm):
 
 class DSurfaceFluxTerm(SurfaceFluxTerm):
     name = 'd_surface_flux'
+
+class SDVolumeDotTerm(SDDotTerm):
+    name = 'ev_sd_volume_dot'

--- a/sfepy/terms/terms_diffusion.py
+++ b/sfepy/terms/terms_diffusion.py
@@ -95,7 +95,7 @@ class SDDiffusionTerm(Term):
         - parameter_p: :math:`p`
         - parameter_mesh_velocity: :math:`\ul{\Vcal}`
     """
-    name = 'd_sd_diffusion'
+    name = 'ev_sd_diffusion'
     arg_types = ('material', 'parameter_q', 'parameter_p',
                  'parameter_mesh_velocity')
     arg_shapes = {'material' : 'D, D',
@@ -369,7 +369,7 @@ class SurfaceFluxTerm(Term):
         - material: :math:`\ul{K}`
         - parameter:  :math:`\bar{p}`,
     """
-    name = 'd_surface_flux'
+    name = 'ev_surface_flux'
     arg_types = ('material', 'parameter')
     arg_shapes = {'material' : 'D, D', 'parameter' : 1}
     integration = 'surface_extra'

--- a/sfepy/terms/terms_elastic.py
+++ b/sfepy/terms/terms_elastic.py
@@ -152,7 +152,7 @@ class SDLinearElasticTerm(Term):
         - parameter_u : :math:`\ul{u}`
         - parameter_mesh_velocity : :math:`\ul{\Vcal}`
     """
-    name = 'd_sd_lin_elastic'
+    name = 'ev_sd_lin_elastic'
     arg_types = ('material', 'parameter_w', 'parameter_u',
                  'parameter_mesh_velocity')
     arg_shapes = {'material' : 'S, S',

--- a/sfepy/terms/terms_hyperelastic_tl.py
+++ b/sfepy/terms/terms_hyperelastic_tl.py
@@ -724,7 +724,7 @@ class SurfaceFluxTLTerm(HyperElasticSurfaceTLBase):
         - parameter_1 : :math:`p`
         - parameter_2 : :math:`\ul{u}^{(n-1)}`
     """
-    name = 'd_tl_surface_flux'
+    name = 'ev_tl_surface_flux'
     arg_types = ('material_1', 'material_2', 'parameter_1', 'parameter_2')
     arg_shapes = {'material_1' : 'D, D', 'material_2' : '1, 1',
                   'parameter_1' : 1, 'parameter_2' : 'D'}
@@ -824,7 +824,7 @@ class VolumeSurfaceTLTerm(HyperElasticSurfaceTLBase):
     :Arguments:
         - parameter : :math:`\ul{u}`
     """
-    name = 'd_tl_volume_surface'
+    name = 'ev_tl_volume_surface'
     arg_types = ('parameter',)
     arg_shapes = {'parameter' : 'D'}
     family_data_names = ['det_f', 'inv_f']

--- a/sfepy/terms/terms_piezo.py
+++ b/sfepy/terms/terms_piezo.py
@@ -112,7 +112,7 @@ class SDPiezoCouplingTerm(ETermBase):
         - parameter_p : :math:`p`
         - parameter_mv : :math:`\ul{\Vcal}`
     """
-    name = 'd_sd_piezo_coupling'
+    name = 'ev_sd_piezo_coupling'
     arg_types = ('material', 'parameter_u', 'parameter_p', 'parameter_mv')
     arg_shapes = {'material': 'D, S', 'parameter_u': 'D', 'parameter_p': 1,
                   'parameter_mv': 'D'}

--- a/sfepy/terms/terms_surface.py
+++ b/sfepy/terms/terms_surface.py
@@ -121,7 +121,7 @@ class SDLinearTractionTerm(Term):
         - parameter : :math:`\ul{v}`
     """
 
-    name = 'd_sd_surface_ltr'
+    name = 'ev_sd_surface_ltr'
     arg_types = ('opt_material', 'parameter', 'parameter_mv')
     arg_shapes = [{'opt_material': 'S, 1', 'parameter': 'D',
                    'parameter_mv': 'D'}, {'opt_material': '1, 1'},
@@ -555,7 +555,7 @@ class SDSufaceIntegrateTerm(Term):
         - parameter : :math:`p`
         - parameter_mesh_velocity : :math:`\ul{\Vcal}`
     """
-    name = 'd_sd_surface_integrate'
+    name = 'ev_sd_surface_integrate'
     arg_types = ('parameter', 'parameter_mesh_velocity')
     arg_shapes = {'parameter' : 1, 'parameter_mesh_velocity' : 'D'}
     integration = 'surface'

--- a/tests/test_laplace_unit_disk.py
+++ b/tests/test_laplace_unit_disk.py
@@ -137,7 +137,7 @@ class Test( TestCommon ):
 
         ok = True
         for ii, region_name in enumerate( region_names ):
-            flux_term = 'd_surface_flux.1.%s( m.K, t )' % region_name
+            flux_term = 'ev_surface_flux.1.%s( m.K, t )' % region_name
             val1 = problem.evaluate(flux_term, t=variables['t'], m=m)
 
             rvec = get_state( aux, 't', True )

--- a/tests/test_laplace_unit_square.py
+++ b/tests/test_laplace_unit_square.py
@@ -200,7 +200,7 @@ class Test( TestCommon ):
                                    update_fields=True)
             problem.domain.mesh.write( name % angle, io = 'auto' )
             for ii, region_name in enumerate( region_names ):
-                flux_term = 'd_surface_flux.i.%s( m.K, t )' % region_name
+                flux_term = 'ev_surface_flux.i.%s( m.K, t )' % region_name
                 val1 = problem.evaluate(flux_term, t=variables['t'], m=m)
 
                 rvec = get_state( aux, 't', True )

--- a/tests/test_term_sensitivity.py
+++ b/tests/test_term_sensitivity.py
@@ -55,7 +55,7 @@ equations = {}
 
 test_terms = [
     ('ev_sd_lin_elastic', 'dw_lin_elastic', 'Omega', 'mat.D', 'U1', 'U2'),
-    ('ev_sd_volume_dot', 'dw_dot', 'Omega', None, 'U1', 'U2'),
+    ('ev_sd_dot', 'dw_dot', 'Omega', None, 'U1', 'U2'),
     ('ev_sd_diffusion', 'dw_diffusion', 'Omega', 'mat.K', 'P1', 'P2'),
     ('ev_sd_div', 'dw_stokes', 'Omega', None, 'U1', 'P1'),
     ('ev_sd_div_grad', 'dw_div_grad', 'Omega', 'mat.c', 'U1', 'U2'),

--- a/tests/test_term_sensitivity.py
+++ b/tests/test_term_sensitivity.py
@@ -54,14 +54,14 @@ materials = {
 equations = {}
 
 test_terms = [
-    ('d_sd_lin_elastic', 'dw_lin_elastic', 'Omega', 'mat.D', 'U1', 'U2'),
-    ('d_sd_volume_dot', 'dw_dot', 'Omega', None, 'U1', 'U2'),
-    ('d_sd_diffusion', 'dw_diffusion', 'Omega', 'mat.K', 'P1', 'P2'),
-    ('d_sd_div', 'dw_stokes', 'Omega', None, 'U1', 'P1'),
-    ('d_sd_div_grad', 'dw_div_grad', 'Omega', 'mat.c', 'U1', 'U2'),
-    ('d_sd_piezo_coupling', 'dw_piezo_coupling', 'Omega', 'mat.g', 'U1', 'P1'),
-    ('d_sd_convect', 'de_convect', 'Omega', None, 'U1', 'U2'),
-    ('d_sd_surface_ltr', 'dw_surface_ltr', 'Interface', 'mat.s', 'U1', None),
+    ('ev_sd_lin_elastic', 'dw_lin_elastic', 'Omega', 'mat.D', 'U1', 'U2'),
+    ('ev_sd_volume_dot', 'dw_dot', 'Omega', None, 'U1', 'U2'),
+    ('ev_sd_diffusion', 'dw_diffusion', 'Omega', 'mat.K', 'P1', 'P2'),
+    ('ev_sd_div', 'dw_stokes', 'Omega', None, 'U1', 'P1'),
+    ('ev_sd_div_grad', 'dw_div_grad', 'Omega', 'mat.c', 'U1', 'U2'),
+    ('ev_sd_piezo_coupling', 'dw_piezo_coupling', 'Omega', 'mat.g', 'U1', 'P1'),
+    ('ev_sd_convect', 'de_convect', 'Omega', None, 'U1', 'U2'),
+    ('ev_sd_surface_ltr', 'dw_surface_ltr', 'Interface', 'mat.s', 'U1', None),
 ]
 
 

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -23,8 +23,8 @@ regions = {
 expressions = {
     'volume_p' : 'ev_volume.i.Omega(p)',
     'volume_u' : 'ev_volume.i.Omega(u)',
-    'surface_p' : 'd_volume_surface.i.Gamma(p)',
-    'surface_u' : 'd_volume_surface.i.Gamma(u)',
+    'surface_p' : 'ev_volume_surface.i.Gamma(p)',
+    'surface_u' : 'ev_volume_surface.i.Gamma(u)',
 }
 
 import numpy as nm
@@ -88,7 +88,7 @@ class Test(TestCommon):
         vval = self.problem.evaluate('dw_tl_volume.i.Omega( q, u )',
                                      term_mode='volume', q=var_q, u=var_u)
 
-        sval = self.problem.evaluate('d_tl_volume_surface.i.Gamma( u )',
+        sval = self.problem.evaluate('ev_tl_volume_surface.i.Gamma( u )',
                                      u=var_u)
 
         ok = abs(vval - sval) < 1e-14


### PR DESCRIPTION
All terms staring with `d_` are renamed to `ev_`. This is reflected in the documentation *User's Guide/Tem Overview*.