### PR TITLE
script/plot_mesh.py: do not scale axis in 3D

### DIFF
--- a/script/plot_mesh.py
+++ b/script/plot_mesh.py
@@ -101,7 +101,9 @@ def main():
     ax = pc.plot_cmesh(None, domain.cmesh,
                        wireframe_opts=wireframe_opts,
                        entities_opts=entities_opts)
-    ax.axis('image')
+    if dim == 2:
+        ax.axis('image')
+
     if not options.axes:
         ax.axis('off')
     plt.tight_layout()


### PR DESCRIPTION
Fixes the script for current matplotlib (3.4.3).