### PR TITLE
New: allow to reinitialize the homogenization engine

### DIFF
--- a/sfepy/homogenization/homogen_app.py
+++ b/sfepy/homogenization/homogen_app.py
@@ -203,7 +203,9 @@ class HomogenizationApp(HomogenizationEngine):
 
         ret_all = get_default(ret_all, opts.return_all)
 
-        if not hasattr(self, 'he'):
+        force_init_he = hasattr(self.problem, 'force_init_he')\
+            and self.problem.force_init_he
+        if not hasattr(self, 'he') or force_init_he:
             volumes = {}
             if hasattr(opts, 'volumes') and (opts.volumes is not None):
                 volumes.update(opts.volumes)


### PR DESCRIPTION
I have a homogenization problem and I need to change the mesh in the parametric hook. To do this, I create a new problem and I need to reinitialize the homogenization engine in `HomogenizationApp`. This can be done by this PR and by setting `new_problem.force_init_he = True` in the parametric hook.

Or do you have another idea how to change the behaviour of the "parent" application in the parametric hook where only the problem instance is available?
