### PR TITLE
resview.py: new 'camera_position' and 'window_size' options

### DIFF
--- a/resview.py
+++ b/resview.py
@@ -561,7 +561,8 @@ def pv_plot(filenames, options, plotter=None, step=None,
 
 def print_camera_position(plotter):
     cp = nm.array([k for k in plotter.camera_position]).ravel()
-    print('camera position: ' + ', '.join(['%g' % k for k in cp]))
+    cp = ', '.join(['%g' % k for k in cp])
+    print(f'--camera-position "{cp}"')
 
 
 class OptsToListAction(Action):


### PR DESCRIPTION
The camera position can be printed by `c` key:

`camera position: 0.138479, -0.121388, 0.0731265, 0.0591157, 0.0129978, -0.00503337, 0.43314, 0.630442, 0.644152`

The printed value can be used on the command line to define the view:

`./resview.py cylinder.vtk --camera_position "0.138479, -0.121388, 0.0731265, 0.0591157, 0.0129978, -0.00503337, 0.43314, 0.630442, 0.644152" --off-screen --window_size "1800, 1200" -o fig.png`

where `window_size "1800, 1200"` specifies the figure size in pixels.