### PR TITLE
Term docs cleanup, closes #773

### DIFF
--- a/doc/terms_overview.rst
+++ b/doc/terms_overview.rst
@@ -38,18 +38,14 @@ The following notation is used:
      - any vector function
    * - :math:`\ul{n}`
      - unit outward normal
-   * - :math:`q`, :math:`s`
+   * - :math:`q`
      - scalar test or parameter function
-   * - :math:`p`, :math:`r`
+   * - :math:`p`
      - scalar unknown or parameter function
-   * - :math:`\bar{p}`
-     - scalar parameter function
    * - :math:`\ul{v}`
      - vector test or parameter function
    * - :math:`\ul{w}`, :math:`\ul{u}`
      - vector unknown or parameter function
-   * - :math:`\ul{b}`
-     - vector parameter function
    * - :math:`\ull{e}(\ul{u})`
      - Cauchy strain tensor (:math:`\frac{1}{2}((\nabla u) + (\nabla u)^T)`)
    * - :math:`\ull{F}`
@@ -71,7 +67,7 @@ The following notation is used:
      - density
    * - :math:`\nu`
      - kinematic viscosity
-   * - :math:`c`
+   * - :math:`c`, :math:`\ul{c}`, :math:`\ull{c}`
      - any constant
    * - :math:`\delta_{ij}, \ull{I}`
      - Kronecker delta, identity matrix

--- a/doc/terms_overview.rst
+++ b/doc/terms_overview.rst
@@ -110,6 +110,22 @@ Term names are (usually) prefixed according to the following conventions:
      - any (work in progress)
      - multi-linear terms defined using an enriched einsum notation
 
+Evaluation modes 'eval', 'el_avg' and 'qp' are defined as follows:
+
+.. list-table:: Evaluation modes.
+   :widths: 20 80
+   :header-rows: 1
+
+   * - mode
+     - definition
+   * - 'eval'
+     - :math:`\int_{\cal{D}} (\cdot)`
+   * - 'el_avg'
+     - vector for :math:`K \from \Ical_h: \int_{T_K} (\cdot) / \int_{T_K} 1`
+   * - 'qp'
+     - :math:`(\cdot)|_{qp}`
+
+
 .. _term_table:
 
 Term Table

--- a/sfepy/terms/terms_basic.py
+++ b/sfepy/terms/terms_basic.py
@@ -53,22 +53,6 @@ class IntegrateTerm(Term):
         \int_{\cal{D}} c y \mbox{ , } \int_{\cal{D}} c \ul{y}
         \mbox{ , } \int_\Gamma c \ul{y} \cdot \ul{n} \mbox{ flux }
 
-    .. math::
-        \mbox{vector for } K \from \Ical_h:
-        \int_{T_K} y / \int_{T_K} 1 \mbox{ , }
-        \int_{T_K} \ul{y} / \int_{T_K} 1 \mbox{ , }
-        \int_{T_K} (\ul{y} \cdot \ul{n}) / \int_{T_K} 1 \\
-        \mbox{vector for } K \from \Ical_h:
-        \int_{T_K} c y / \int_{T_K} 1 \mbox{ , }
-        \int_{T_K} c \ul{y} / \int_{T_K} 1 \mbox{ , }
-        \int_{T_K} (c \ul{y} \cdot \ul{n}) / \int_{T_K} 1
-
-    .. math::
-        y|_{qp} \mbox{ , } \ul{y}|_{qp}
-        \mbox{ , } (\ul{y} \cdot \ul{n})|_{qp} \mbox{ flux } \\
-        c y|_{qp} \mbox{ , } c \ul{y}|_{qp}
-        \mbox{ , } (c \ul{y} \cdot \ul{n})|_{qp} \mbox{ flux }
-
     :Arguments:
         - material : :math:`c` (optional)
         - parameter : :math:`y` or :math:`\ul{y}`

--- a/sfepy/terms/terms_basic.py
+++ b/sfepy/terms/terms_basic.py
@@ -269,16 +269,10 @@ class IntegrateMatTerm(Term):
     :Definition:
 
     .. math::
-        \int_{\cal{D}} m
-
-    .. math::
-        \mbox{vector for } K \from \Ical_h: \int_{T_K} m / \int_{T_K} 1
-
-    .. math::
-        m|_{qp}
+        \int_{\cal{D}} c
 
     :Arguments:
-        - material  : :math:`m` (can have up to two dimensions)
+        - material  : :math:`c` (can have up to two dimensions)
         - parameter : :math:`y`
     """
     name = 'ev_integrate_mat'

--- a/sfepy/terms/terms_biot.py
+++ b/sfepy/terms/terms_biot.py
@@ -132,11 +132,11 @@ class BiotStressTerm(CauchyStressTerm):
     :Definition:
 
     .. math::
-        - \int_{\Omega} \alpha_{ij} \bar{p}
+        - \int_{\Omega} \alpha_{ij} p
 
     :Arguments:
         - material  : :math:`\alpha_{ij}`
-        - parameter : :math:`\bar{p}`
+        - parameter : :math:`p`
     """
     name = 'ev_biot_stress'
     arg_types = ('material', 'parameter')

--- a/sfepy/terms/terms_biot.py
+++ b/sfepy/terms/terms_biot.py
@@ -134,13 +134,6 @@ class BiotStressTerm(CauchyStressTerm):
     .. math::
         - \int_{\Omega} \alpha_{ij} \bar{p}
 
-    .. math::
-        \mbox{vector for } K \from \Ical_h:
-        - \int_{T_K} \alpha_{ij} \bar{p} / \int_{T_K} 1
-
-    .. math::
-        - \alpha_{ij} \bar{p}|_{qp}
-
     :Arguments:
         - material  : :math:`\alpha_{ij}`
         - parameter : :math:`\bar{p}`

--- a/sfepy/terms/terms_diffusion.py
+++ b/sfepy/terms/terms_diffusion.py
@@ -13,18 +13,12 @@ class DiffusionTerm(Term):
     :Definition:
 
     .. math::
-        \int_{\Omega} K_{ij} \nabla_i q \nabla_j p \mbox{ , } \int_{\Omega}
-        K_{ij} \nabla_i \bar{p} \nabla_j r
+        \int_{\Omega} K_{ij} \nabla_i q \nabla_j p
 
-    :Arguments 1:
-        - material : :math:`K_{ij}`
-        - virtual  : :math:`q`
-        - state    : :math:`p`
-
-    :Arguments 2:
-        - material    : :math:`K_{ij}`
-        - parameter_1 : :math:`\bar{p}`
-        - parameter_2 : :math:`r`
+    :Arguments:
+        - material: :math:`K_{ij}`
+        - virtual/parameter_1: :math:`q`
+        - state/parameter_2: :math:`p`
     """
     name = 'dw_diffusion'
     arg_types = (('material', 'virtual', 'state'),
@@ -133,18 +127,12 @@ class LaplaceTerm(DiffusionTerm):
     :Definition:
 
     .. math::
-        \int_{\Omega} c \nabla q \cdot \nabla p \mbox{ , } \int_{\Omega}
-        c \nabla \bar{p} \cdot \nabla r
+        \int_{\Omega} c \nabla q \cdot \nabla p
 
     :Arguments 1:
-        - material : :math:`c`
-        - virtual  : :math:`q`
-        - state    : :math:`p`
-
-    :Arguments 2:
-        - material    : :math:`c`
-        - parameter_1 : :math:`\bar{p}`
-        - parameter_2 : :math:`r`
+        - material: :math:`c`
+        - virtual/parameter_1: :math:`q`
+        - state/parameter_2: :math:`p`
     """
     name = 'dw_laplace'
     arg_types = (('opt_material', 'virtual', 'state'),
@@ -299,18 +287,18 @@ class DiffusionVelocityTerm( Term ):
     :Definition:
 
     .. math::
-        - \int_{\cal{D}} K_{ij} \nabla_j \bar{p}
+        - \int_{\cal{D}} K_{ij} \nabla_j p
 
     .. math::
-        \mbox{vector for } K \from \Ical_h: - \int_{T_K} K_{ij} \nabla_j \bar{p}
+        \mbox{vector for } K \from \Ical_h: - \int_{T_K} K_{ij} \nabla_j p
         / \int_{T_K} 1
 
     .. math::
-        - K_{ij} \nabla_j \bar{p}
+        - K_{ij} \nabla_j p
 
     :Arguments:
         - material  : :math:`K_{ij}`
-        - parameter : :math:`\bar{p}`
+        - parameter : :math:`p`
     """
     name = 'ev_diffusion_velocity'
     arg_types = ('material', 'parameter')
@@ -359,19 +347,19 @@ class SurfaceFluxTerm(Term):
     :Definition:
 
     .. math::
-        \int_{\Gamma} \ul{n} \cdot K_{ij} \nabla_j \bar{p}
+        \int_{\Gamma} \ul{n} \cdot K_{ij} \nabla_j p
 
     .. math::
         \mbox{vector for } K \from \Ical_h: \int_{T_K} \ul{n}
-        \cdot K_{ij} \nabla_j \bar{p}\ / \int_{T_K} 1
+        \cdot K_{ij} \nabla_j p\ / \int_{T_K} 1
 
     .. math::
         \mbox{vector for } K \from \Ical_h: \int_{T_K} \ul{n}
-        \cdot K_{ij} \nabla_j \bar{p}
+        \cdot K_{ij} \nabla_j p
 
     :Arguments:
         - material: :math:`\ul{K}`
-        - parameter:  :math:`\bar{p}`,
+        - parameter:  :math:`p`,
     """
     name = 'ev_surface_flux'
     arg_types = ('material', 'parameter')

--- a/sfepy/terms/terms_diffusion.py
+++ b/sfepy/terms/terms_diffusion.py
@@ -289,13 +289,6 @@ class DiffusionVelocityTerm( Term ):
     .. math::
         - \int_{\cal{D}} K_{ij} \nabla_j p
 
-    .. math::
-        \mbox{vector for } K \from \Ical_h: - \int_{T_K} K_{ij} \nabla_j p
-        / \int_{T_K} 1
-
-    .. math::
-        - K_{ij} \nabla_j p
-
     :Arguments:
         - material  : :math:`K_{ij}`
         - parameter : :math:`p`
@@ -348,14 +341,6 @@ class SurfaceFluxTerm(Term):
 
     .. math::
         \int_{\Gamma} \ul{n} \cdot K_{ij} \nabla_j p
-
-    .. math::
-        \mbox{vector for } K \from \Ical_h: \int_{T_K} \ul{n}
-        \cdot K_{ij} \nabla_j p\ / \int_{T_K} 1
-
-    .. math::
-        \mbox{vector for } K \from \Ical_h: \int_{T_K} \ul{n}
-        \cdot K_{ij} \nabla_j p
 
     :Arguments:
         - material: :math:`\ul{K}`

--- a/sfepy/terms/terms_dot.py
+++ b/sfepy/terms/terms_dot.py
@@ -16,28 +16,18 @@ class DotProductTerm(Term):
     :Definition:
 
     .. math::
-        \int_{\cal{D}} q p \mbox{ , } \int_{\cal{D}} \ul{v} \cdot \ul{u}
-        \mbox{ , }
+        \int_{\cal{D}} q p \mbox{ , }
+        \int_{\cal{D}} \ul{v} \cdot \ul{u}\\
         \int_\Gamma \ul{v} \cdot \ul{n} p \mbox{ , }
-        \int_\Gamma q \ul{n} \cdot \ul{u} \mbox{ , }
-        \int_{\cal{D}} p r \mbox{ , } \int_{\cal{D}} \ul{u} \cdot \ul{w}
-        \mbox{ , } \int_\Gamma \ul{w} \cdot \ul{n} p \\
-        \int_{\cal{D}} c q p \mbox{ , } \int_{\cal{D}} c \ul{v} \cdot \ul{u}
-        \mbox{ , }
-        \int_{\cal{D}} c p r \mbox{ , } \int_{\cal{D}} c \ul{u} \cdot \ul{w} \\
-        \int_{\cal{D}} \ul{v} \cdot \ull{M} \cdot \ul{u}
-        \mbox{ , }
-        \int_{\cal{D}} \ul{u} \cdot \ull{M} \cdot \ul{w}
+        \int_\Gamma q \ul{n} \cdot \ul{u} \mbox{ , }\\
+        \int_{\cal{D}} c q p \mbox{ , }
+        \int_{\cal{D}} c \ul{v} \cdot \ul{u} \mbox{ , }
+        \int_{\cal{D}} \ul{v} \cdot \ull{c} \cdot \ul{u}
 
-    :Arguments 1:
-        - material : :math:`c` or :math:`\ull{M}` (optional)
-        - virtual  : :math:`q` or :math:`\ul{v}`
-        - state    : :math:`p` or :math:`\ul{u}`
-
-    :Arguments 2:
-        - material    : :math:`c` or :math:`\ull{M}` (optional)
-        - parameter_1 : :math:`p` or :math:`\ul{u}`
-        - parameter_2 : :math:`r` or :math:`\ul{w}`
+    :Arguments:
+        - material: :math:`c` or :math:`\ull{c}` (optional)
+        - virtual/parameter_1: :math:`q` or :math:`\ul{v}`
+        - state/parameter_2: :math:`p` or :math:`\ul{u}`
     """
     name = 'dw_dot'
     arg_types = (('opt_material', 'virtual', 'state'),
@@ -295,23 +285,18 @@ class VectorDotGradScalarTerm(Term):
         \int_{\Omega} \ul{u} \cdot \nabla q \\
         \int_{\Omega} c \ul{v} \cdot \nabla p \mbox{ , }
         \int_{\Omega} c \ul{u} \cdot \nabla q \\
-        \int_{\Omega} \ul{v} \cdot (\ull{M} \nabla p) \mbox{ , }
-        \int_{\Omega} \ul{u} \cdot (\ull{M} \nabla q)
+        \int_{\Omega} \ul{v} \cdot (\ull{c} \nabla p) \mbox{ , }
+        \int_{\Omega} \ul{u} \cdot (\ull{c} \nabla q)
 
     :Arguments 1:
-        - material : :math:`c` or :math:`\ull{M}` (optional)
-        - virtual  : :math:`\ul{v}`
-        - state    : :math:`p`
+        - material: :math:`c` or :math:`\ull{c}` (optional)
+        - virtual/parameter_v: :math:`\ul{v}`
+        - state/parameter_s: :math:`p`
 
     :Arguments 2:
-        - material : :math:`c` or :math:`\ull{M}` (optional)
+        - material : :math:`c` or :math:`\ull{c}` (optional)
         - state    : :math:`\ul{u}`
         - virtual  : :math:`q`
-
-    :Arguments 3:
-        - material    : :math:`c` or :math:`\ull{M}` (optional)
-        - parameter_v : :math:`\ul{u}`
-        - parameter_s : :math:`p`
     """
     name = 'dw_v_dot_grad_s'
     arg_types = (('opt_material', 'virtual', 'state'),
@@ -384,23 +369,18 @@ class VectorDotScalarTerm(Term):
     :Definition:
 
     .. math::
-        \int_{\Omega} \ul{v} \cdot \ul{m} p \mbox{ , }
-        \int_{\Omega} \ul{u} \cdot \ul{m} q\\
+        \int_{\Omega} \ul{v} \cdot \ul{c} p \mbox{ , }
+        \int_{\Omega} \ul{u} \cdot \ul{c} q\\
 
     :Arguments 1:
-        - material : :math:`\ul{m}`
-        - virtual  : :math:`\ul{v}`
-        - state    : :math:`p`
+        - material : :math:`\ul{c}`
+        - virtual/parameter_v: :math:`\ul{v}`
+        - state/parameter_s: :math:`p`
 
     :Arguments 2:
-        - material : :math:`\ul{m}`
+        - material : :math:`\ul{c}`
         - state    : :math:`\ul{u}`
         - virtual  : :math:`q`
-
-    :Arguments 3:
-        - material    : :math:`\ul{m}`
-        - parameter_v : :math:`\ul{u}`
-        - parameter_s : :math:`p`
     """
     name = 'dw_vm_dot_s'
     arg_types = (('material', 'virtual', 'state'),

--- a/sfepy/terms/terms_elastic.py
+++ b/sfepy/terms/terms_elastic.py
@@ -397,13 +397,6 @@ class CauchyStrainTerm(Term):
     .. math::
         \int_{\cal{D}} \ull{e}(\ul{w})
 
-    .. math::
-        \mbox{vector for } K \from \Ical_h: \int_{T_K} \ull{e}(\ul{w}) /
-        \int_{T_K} 1
-
-    .. math::
-        \ull{e}(\ul{w})|_{qp}
-
     :Arguments:
         - parameter : :math:`\ul{w}`
     """
@@ -458,13 +451,6 @@ class CauchyStressTerm(Term):
 
     .. math::
         \int_{\cal{D}} D_{ijkl} e_{kl}(\ul{w})
-
-    .. math::
-        \mbox{vector for } K \from \Ical_h:
-        \int_{T_K} D_{ijkl} e_{kl}(\ul{w}) / \int_{T_K} 1
-
-    .. math::
-        D_{ijkl} e_{kl}(\ul{w})|_{qp}
 
     :Arguments:
         - material  : :math:`D_{ijkl}`
@@ -525,14 +511,6 @@ class CauchyStressTHTerm(CauchyStressTerm, THTerm):
         \int_{\Omega} \int_0^t \Hcal_{ijkl}(t-\tau)\,e_{kl}(\ul{w}(\tau))
         \difd{\tau}
 
-    .. math::
-        \mbox{vector for } K \from \Ical_h:
-        \int_{T_K} \int_0^t \Hcal_{ijkl}(t-\tau)\,e_{kl}(\ul{w}(\tau))
-        \difd{\tau} / \int_{T_K} 1
-
-    .. math::
-        \int_0^t \Hcal_{ijkl}(t-\tau)\,e_{kl}(\ul{w}(\tau)) \difd{\tau}|_{qp}
-
     :Arguments:
         - ts        : :class:`TimeStepper` instance
         - material  : :math:`\Hcal_{ijkl}(\tau)`
@@ -582,14 +560,6 @@ class CauchyStressETHTerm(CauchyStressTerm, ETHTerm):
     .. math::
         \int_{\Omega} \int_0^t \Hcal_{ijkl}(t-\tau)\,e_{kl}(\ul{w}(\tau))
         \difd{\tau}
-
-    .. math::
-        \mbox{vector for } K \from \Ical_h:
-        \int_{T_K} \int_0^t \Hcal_{ijkl}(t-\tau)\,e_{kl}(\ul{w}(\tau))
-        \difd{\tau} / \int_{T_K} 1
-
-    .. math::
-        \int_0^t \Hcal_{ijkl}(t-\tau)\,e_{kl}(\ul{w}(\tau)) \difd{\tau}|_{qp}
 
     :Arguments:
         - ts         : :class:`TimeStepper` instance

--- a/sfepy/terms/terms_elastic.py
+++ b/sfepy/terms/terms_elastic.py
@@ -96,20 +96,15 @@ class LinearElasticIsotropicTerm(LinearElasticTerm):
     :Definition:
 
     .. math::
-        \int_{\Omega} D_{ijkl}\ e_{ij}(\ul{v}) e_{kl}(\ul{u}) \mbox{ with }
+        \int_{\Omega} D_{ijkl}\ e_{ij}(\ul{v}) e_{kl}(\ul{u})\\ \mbox{ with } \\
         D_{ijkl} = \mu (\delta_{ik} \delta_{jl}+\delta_{il} \delta_{jk}) +
         \lambda \ \delta_{ij} \delta_{kl}
 
     :Arguments:
-        - material_1 : :math:`\lambda`
-        - material_2 : :math:`\mu`
-        - virtual    : :math:`\ul{v}`
-        - state      : :math:`\ul{u}`
-
-    :Arguments 2:
-        - material    : :math:`D_{ijkl}`
-        - parameter_1 : :math:`\ul{w}`
-        - parameter_2 : :math:`\ul{u}`
+        - material_1: :math:`\lambda`
+        - material_2: :math:`\mu`
+        - virtual/parameter_1: :math:`\ul{v}`
+        - state/parameter_2: :math:`\ul{u}`
     """
     name = 'dw_lin_elastic_iso'
     arg_types = (('material_1', 'material_2', 'virtual', 'state'),
@@ -817,7 +812,7 @@ class ElasticWaveCauchyTerm(Term):
     :Definition:
 
     .. math::
-        \int_{\Omega} D_{ijkl}\ g_{ij}(\ul{v}) e_{kl}(\ul{u}) \;,
+        \int_{\Omega} D_{ijkl}\ g_{ij}(\ul{v}) e_{kl}(\ul{u})\\
         \int_{\Omega} D_{ijkl}\ g_{ij}(\ul{u}) e_{kl}(\ul{v})
 
     :Arguments 1:

--- a/sfepy/terms/terms_multilinear.py
+++ b/sfepy/terms/terms_multilinear.py
@@ -1239,10 +1239,10 @@ class EDotTerm(ETermBase):
     .. math::
         \int_{\cal{D}} q p \mbox{ , } \int_{\cal{D}} \ul{v} \cdot \ul{u}\\
         \int_{\cal{D}} c q p \mbox{ , } \int_{\cal{D}} c \ul{v} \cdot \ul{u}\\
-        \int_{\cal{D}} \ul{v} \cdot (\ull{M}\, \ul{u})
+        \int_{\cal{D}} \ul{v} \cdot (\ull{c}\, \ul{u})
 
     :Arguments:
-        - material: :math:`c` or :math:`\ull{M}` (optional)
+        - material: :math:`c` or :math:`\ull{c}` (optional)
         - virtual/parameter_1: :math:`q` or :math:`\ul{v}`
         - state/parameter_2: :math:`p` or :math:`\ul{u}`
     """
@@ -1415,11 +1415,11 @@ class ELinearConvectTerm(ETermBase):
     :Definition:
 
     .. math::
-        \int_{\Omega} ((\ul{b} \cdot \nabla) \ul{u}) \cdot \ul{v}
+        \int_{\Omega} ((\ul{w} \cdot \nabla) \ul{u}) \cdot \ul{v}
 
     :Arguments:
         - virtual/parameter_1: :math:`\ul{v}`
-        - parameter/parameter_2: :math:`\ul{b}`
+        - parameter/parameter_2: :math:`\ul{w}`
         - state/parameter_3: :math:`\ul{u}`
     """
     name = 'de_lin_convect'

--- a/sfepy/terms/terms_navier_stokes.py
+++ b/sfepy/terms/terms_navier_stokes.py
@@ -11,19 +11,12 @@ class DivGradTerm(Term):
 
     .. math::
         \int_{\Omega} \nu\ \nabla \ul{v} : \nabla \ul{u} \mbox{ , }
-        \int_{\Omega} \nu\ \nabla \ul{u} : \nabla \ul{w} \\
-        \int_{\Omega} \nabla \ul{v} : \nabla \ul{u} \mbox{ , }
-        \int_{\Omega} \nabla \ul{u} : \nabla \ul{w}
+        \int_{\Omega} \nabla \ul{v} : \nabla \ul{u}
 
-    :Arguments 1:
-        - material : :math:`\nu` (viscosity, optional)
-        - virtual  : :math:`\ul{v}`
-        - state    : :math:`\ul{u}`
-
-    :Arguments 2:
-        - material    : :math:`\nu` (viscosity, optional)
-        - parameter_1 : :math:`\ul{u}`
-        - parameter_2 : :math:`\ul{w}`
+    :Arguments:
+        - material: :math:`\nu` (viscosity, optional)
+        - virtualparameter_1: :math:`\ul{v}`
+        - state/parameter_2: :math:`\ul{u}`
     """
     name = 'dw_div_grad'
     arg_types = (('opt_material', 'virtual', 'state'),
@@ -134,14 +127,14 @@ class LinearConvectTerm(Term):
     :Definition:
 
     .. math::
-        \int_{\Omega} ((\ul{b} \cdot \nabla) \ul{u}) \cdot \ul{v}
+        \int_{\Omega} ((\ul{w} \cdot \nabla) \ul{u}) \cdot \ul{v}
 
     .. math::
-        ((\ul{b} \cdot \nabla) \ul{u})|_{qp}
+        ((\ul{w} \cdot \nabla) \ul{u})|_{qp}
 
     :Arguments:
         - virtual   : :math:`\ul{v}`
-        - parameter : :math:`\ul{b}`
+        - parameter : :math:`\ul{w}`
         - state     : :math:`\ul{u}`
     """
     name = 'dw_lin_convect'
@@ -185,13 +178,13 @@ class LinearConvect2Term(Term):
     :Definition:
 
     .. math::
-        \int_{\Omega} ((\ul{b} \cdot \nabla) \ul{u}) \cdot \ul{v}
+        \int_{\Omega} ((\ul{c} \cdot \nabla) \ul{u}) \cdot \ul{v}
 
     .. math::
-        ((\ul{b} \cdot \nabla) \ul{u})|_{qp}
+        ((\ul{c} \cdot \nabla) \ul{u})|_{qp}
 
     :Arguments:
-        - material : :math:`\ul{b}`
+        - material : :math:`\ul{c}`
         - virtual  : :math:`\ul{v}`
         - state    : :math:`\ul{u}`
     """
@@ -236,25 +229,20 @@ class StokesTerm(Term):
 
     .. math::
         \int_{\Omega} p\ \nabla \cdot \ul{v} \mbox{ , }
-        \int_{\Omega} q\ \nabla \cdot \ul{u}
+        \int_{\Omega} q\ \nabla \cdot \ul{u}\\
         \mbox{ or }
         \int_{\Omega} c\ p\ \nabla \cdot \ul{v} \mbox{ , }
         \int_{\Omega} c\ q\ \nabla \cdot \ul{u}
 
     :Arguments 1:
-        - material : :math:`c` (optional)
-        - virtual  : :math:`\ul{v}`
-        - state    : :math:`p`
+        - material: :math:`c` (optional)
+        - virtual/parameter_v: :math:`\ul{v}`
+        - state/parameter_s: :math:`p`
 
     :Arguments 2:
         - material : :math:`c` (optional)
         - state    : :math:`\ul{u}`
         - virtual  : :math:`q`
-
-    :Arguments 3:
-        - material    : :math:`c` (optional)
-        - parameter_v : :math:`\ul{u}`
-        - parameter_s : :math:`p`
     """
     name = 'dw_stokes'
     arg_types = (('opt_material', 'virtual', 'state'),
@@ -335,20 +323,19 @@ class GradTerm(Term):
     :Definition:
 
     .. math::
-        \int_{\cal{D}} \nabla p \mbox{ or } \int_{\cal{D}} \nabla \ul{w}
-        \mbox{ , }
-        \int_{\cal{D}} c \nabla p \mbox{ or } \int_{\cal{D}} c \nabla \ul{w}
+        \int_{\cal{D}} \nabla p \mbox{ or } \int_{\cal{D}} \nabla \ul{u}\\
+        \int_{\cal{D}} c \nabla p \mbox{ or } \int_{\cal{D}} c \nabla \ul{u}
 
     .. math::
         \mbox{vector for } K \from \Ical_h: \int_{T_K} \nabla p /
-        \int_{T_K} 1 \mbox{ or } \int_{T_K} \nabla \ul{w} /
+        \int_{T_K} 1 \mbox{ or } \int_{T_K} \nabla \ul{u} /
         \int_{T_K} 1
 
     .. math::
-        (\nabla p)|_{qp} \mbox{ or } \nabla \ul{w}|_{qp}
+        (\nabla p)|_{qp} \mbox{ or } \nabla \ul{u}|_{qp}
 
     :Arguments:
-        - parameter : :math:`p` or :math:`\ul{w}`
+        - parameter : :math:`p` or :math:`\ul{u}`
     """
     name = 'ev_grad'
     arg_types = ('opt_material', 'parameter')

--- a/sfepy/terms/terms_navier_stokes.py
+++ b/sfepy/terms/terms_navier_stokes.py
@@ -326,14 +326,6 @@ class GradTerm(Term):
         \int_{\cal{D}} \nabla p \mbox{ or } \int_{\cal{D}} \nabla \ul{u}\\
         \int_{\cal{D}} c \nabla p \mbox{ or } \int_{\cal{D}} c \nabla \ul{u}
 
-    .. math::
-        \mbox{vector for } K \from \Ical_h: \int_{T_K} \nabla p /
-        \int_{T_K} 1 \mbox{ or } \int_{T_K} \nabla \ul{u} /
-        \int_{T_K} 1
-
-    .. math::
-        (\nabla p)|_{qp} \mbox{ or } \nabla \ul{u}|_{qp}
-
     :Arguments:
         - parameter : :math:`p` or :math:`\ul{u}`
     """
@@ -386,13 +378,6 @@ class DivTerm(Term):
     .. math::
          \int_{\cal{D}} \nabla \cdot \ul{u} \mbox { , }
          \int_{\cal{D}} c \nabla \cdot \ul{u}
-
-    .. math::
-         \mbox{vector for } K \from \Ical_h:
-         \int_{T_K} \nabla \cdot \ul{u} / \int_{T_K} 1
-
-    .. math::
-        (\nabla \cdot \ul{u})|_{qp}
 
     :Arguments:
         - parameter : :math:`\ul{u}`

--- a/sfepy/terms/terms_piezo.py
+++ b/sfepy/terms/terms_piezo.py
@@ -11,23 +11,18 @@ class PiezoCouplingTerm(Term):
     :Definition:
 
     .. math::
-        \int_{\Omega} g_{kij}\ e_{ij}(\ul{v}) \nabla_k p \mbox{ , }
+        \int_{\Omega} g_{kij}\ e_{ij}(\ul{v}) \nabla_k p\\
         \int_{\Omega} g_{kij}\ e_{ij}(\ul{u}) \nabla_k q
 
     :Arguments 1:
-        - material : :math:`g_{kij}`
-        - virtual  : :math:`\ul{v}`
-        - state    : :math:`p`
+        - material: :math:`g_{kij}`
+        - virtual/parameter_v: :math:`\ul{v}`
+        - state/parameter_s: :math:`p`
 
     :Arguments 2:
         - material : :math:`g_{kij}`
         - state    : :math:`\ul{u}`
         - virtual  : :math:`q`
-
-    :Arguments 3:
-        - material    : :math:`g_{kij}`
-        - parameter_v : :math:`\ul{u}`
-        - parameter_s : :math:`p`
     """
     name = 'dw_piezo_coupling'
     arg_types = (('material', 'virtual', 'state'),


### PR DESCRIPTION
This PR:

- applies term description used for multilinear terms to the other terms, 'virtual/parameter_v' and 'state/parameter_s' is used in the term description
- 'eval', 'el_avg' and 'qp' evaluation modes are defined in a general form, not for each term
- closes #773
