### PR TITLE
Fix omit_facets

### DIFF
--- a/sfepy/discrete/fem/meshio.py
+++ b/sfepy/discrete/fem/meshio.py
@@ -430,8 +430,9 @@ class MeshioLibIO(MeshIO):
 
                 continue
 
-            cells.append(c.data)
-            cell_types.append(self.cell_types[(c.type, dim)])
+            if (not omit_facets) or (c.dim == dim):
+                cells.append(c.data)
+                cell_types.append(self.cell_types[(c.type, dim)])
 
             if cgdata is not None:
                 cgroups.append(nm.asarray(cgdata[ic]).flatten())


### PR DESCRIPTION
The `omit_facets` argument of `Mesh.from_file` seemed to have no effect.
This should probably fix it.