### PR TITLE
resview.py: support any sfepy format

### DIFF
--- a/resview.py
+++ b/resview.py
@@ -221,14 +221,14 @@ def read_mesh(filenames, step=None, print_info=True, ret_n_steps=False,
 
             io = MeshIO.any_from_filename(fname)
 
-            mesh = io.read()
+            smesh = io.read()
             steps, times, nts = io.read_times()
             if not len(steps):
-                grid0 = make_grid_from_mesh(mesh, add_mat_id=True)
+                grid0 = make_grid_from_mesh(smesh, add_mat_id=True)
                 cache[(fname, 0)] = grid0
 
             else:
-                grid0 = make_grid_from_mesh(mesh, add_mat_id=False)
+                grid0 = make_grid_from_mesh(smesh, add_mat_id=False)
 
             for ii, _step in enumerate(steps):
                 grid = grid0.copy()
@@ -264,10 +264,10 @@ def read_mesh(filenames, step=None, print_info=True, ret_n_steps=False,
             from sfepy.discrete.fem import Mesh
 
             io = MeshIO.any_from_filename(fname)
-            mesh = Mesh(fname)
-            mesh = io.read(mesh)
+            smesh = Mesh(fname)
+            smesh = io.read(smesh)
 
-            grid = make_grid_from_mesh(mesh, add_mat_id=True)
+            grid = make_grid_from_mesh(smesh, add_mat_id=True)
             cache[(fname, 0)] = grid
             cache['n_steps'] = len(filenames)
 

--- a/resview.py
+++ b/resview.py
@@ -603,8 +603,8 @@ def pv_plot(filenames, options, plotter=None, step=None,
 
 def print_camera_position(plotter):
     cp = nm.array([k for k in plotter.camera_position]).ravel()
-    cp = ', '.join(['%g' % k for k in cp])
-    print(f'--camera-position "{cp}"')
+    cp = ','.join(['%g' % k for k in cp])
+    print(f'--camera-position="{cp}"')
 
 
 class OptsToListAction(Action):

--- a/resview.py
+++ b/resview.py
@@ -257,7 +257,21 @@ def read_mesh(filenames, step=None, print_info=True, ret_n_steps=False,
         mesh = cache[key]
 
     else:
-        raise ValueError('unknown file format! (%s)' % ext)
+        fname = filenames[0]
+        key = (fname, step)
+        if key not in cache:
+            from sfepy.discrete.fem.meshio import MeshIO
+            from sfepy.discrete.fem import Mesh
+
+            io = MeshIO.any_from_filename(fname)
+            mesh = Mesh(fname)
+            mesh = io.read(mesh)
+
+            grid = make_grid_from_mesh(mesh, add_mat_id=True)
+            cache[(fname, 0)] = grid
+            cache['n_steps'] = len(filenames)
+
+        mesh = cache[key]
 
     if print_info:
         arrs = {'s': [], 'v': [], 'o': []}


### PR DESCRIPTION
Hi @vlukes, I also wanted to move the ` mesh = cache[key]` line which is common in all if branches in `read_data()` to the end of the function, but found that `mesh` is incorrectly used on line 185 (xdmf branch). How can this be fixed?