### PR TITLE
speed-up direct linear solver reuse in time-stepping solvers, unify presolve

### DIFF
--- a/sfepy/examples/linear_elasticity/elastodynamic.py
+++ b/sfepy/examples/linear_elasticity/elastodynamic.py
@@ -204,8 +204,13 @@ equations = {
 }
 
 solvers = {
-    'ls' : ('ls.scipy_direct', {
+    'ls' : ('ls.auto_direct', {
+        # Reuse the factorized linear system from the first time step.
         'use_presolve' : True,
+        # Speed up the above by omitting the matrix digest check used normally
+        # for verification that the current matrix corresponds to the
+        # factorized matrix stored in the solver instance. Use with care!
+        'use_mtx_digest' : False,
     }),
     'ls-i' : ('ls.petsc', {
         'method' : 'cg',

--- a/sfepy/solvers/ls.py
+++ b/sfepy/solvers/ls.py
@@ -145,6 +145,10 @@ class ScipyDirect(LinearSolver):
          'The actual solver to use.'),
         ('use_presolve', 'bool', False, False,
          'If True, pre-factorize the matrix.'),
+        ('use_mtx_digest', 'bool', True, False,
+         """If True, determine automatically a reused matrix using its
+            SHA1 digest. If False, .clear() has to be called
+            manually whenever the matrix changes - expert use only!"""),
     ]
 
     def __init__(self, conf, method=None, **kwargs):
@@ -179,22 +183,37 @@ class ScipyDirect(LinearSolver):
         else:
             self.sls.use_solver(useUmfpack=False)
 
+        self.clear()
+
     @standard_call
     def __call__(self, rhs, x0=None, conf=None, eps_a=None, eps_r=None,
                  i_max=None, mtx=None, status=None, **kwargs):
+        if not conf.use_presolve:
+            self.clear()
 
         if conf.use_presolve:
-            self.presolve(mtx)
+            self.presolve(mtx, use_mtx_digest=conf.use_mtx_digest)
 
-        if self.solve is not None:
             # Matrix is already prefactorized.
             return self.solve(rhs)
+
         else:
             return self.sls.spsolve(mtx, rhs)
 
-    def presolve(self, mtx):
-        is_new, mtx_digest = _is_new_matrix(mtx, self.mtx_digest)
-        if is_new:
+    def clear(self):
+        if self.solve is not None:
+            del self.solve
+
+        self.solve = None
+
+    def presolve(self, mtx, use_mtx_digest=True):
+        if use_mtx_digest:
+            is_new, mtx_digest = _is_new_matrix(mtx, self.mtx_digest)
+
+        else:
+            is_new, mtx_digest = False, None
+
+        if is_new or (self.solve is None):
             self.solve = self.sls.factorized(mtx)
             self.mtx_digest = mtx_digest
 
@@ -208,6 +227,10 @@ class ScipySuperLU(ScipyDirect):
     _parameters = [
         ('use_presolve', 'bool', False, False,
          'If True, pre-factorize the matrix.'),
+        ('use_mtx_digest', 'bool', True, False,
+         """If True, determine automatically a reused matrix using its
+            SHA1 digest. If False, .clear() has to be called
+            manually whenever the matrix changes - expert use only!"""),
     ]
 
     def __init__(self, conf, **kwargs):
@@ -223,6 +246,10 @@ class ScipyUmfpack(ScipyDirect):
     _parameters = [
         ('use_presolve', 'bool', False, False,
          'If True, pre-factorize the matrix.'),
+        ('use_mtx_digest', 'bool', True, False,
+         """If True, determine automatically a reused matrix using its
+            SHA1 digest. If False, .clear() has to be called
+            manually whenever the matrix changes - expert use only!"""),
     ]
 
     def __init__(self, conf, **kwargs):
@@ -761,6 +788,10 @@ class MUMPSSolver(LinearSolver):
     _parameters = [
         ('use_presolve', 'bool', False, False,
          'If True, pre-factorize the matrix.'),
+        ('use_mtx_digest', 'bool', True, False,
+         """If True, determine automatically a reused matrix using its
+            SHA1 digest. If False, .clear() has to be called
+            manually whenever the matrix changes - expert use only!"""),
         ('memory_relaxation', 'int', 20, False,
          'The percentage increase in the estimated working space.'),
     ]

--- a/sfepy/solvers/solvers.py
+++ b/sfepy/solvers/solvers.py
@@ -273,6 +273,9 @@ class LinearSolver(Solver):
         """
         return self.conf.get('eps_a', None), self.conf.get('eps_r', None)
 
+    def clear(self):
+        pass
+
     def presolve(self, mtx):
         pass
 

--- a/sfepy/solvers/ts_solvers.py
+++ b/sfepy/solvers/ts_solvers.py
@@ -404,6 +404,7 @@ class ElastodynamicsBaseTS(TimeSteppingSolver):
 
         M = self.get_matrices(nls, vec)[0]
         a0 = nls.lin_solver(-r, mtx=M)
+        nls.lin_solver.clear()
         output_array_stats(a0, 'initial acceleration', verbose=self.verbose)
         return a0
 

--- a/sfepy/solvers/ts_solvers.py
+++ b/sfepy/solvers/ts_solvers.py
@@ -832,6 +832,8 @@ class BatheTS(ElastodynamicsBaseTS):
         ElastodynamicsBaseTS.__init__(self, conf, nls=nls, context=context,
                                       **kwargs)
         self.matrix1 = None
+        self.ls1 = None
+        self.ls2 = None
 
     def create_nlst1(self, nls, dt, u0, v0, a0):
         """
@@ -846,6 +848,10 @@ class BatheTS(ElastodynamicsBaseTS):
             return dt4 * (v - v0) - a0
 
         nlst = self._create_nlst_u(nls, dt, v, a, dt4 * dt4, dt4, 'matrix1')
+        if self.ls1 is None:
+            self.ls1 = nls.lin_solver.copy()
+
+        nlst.lin_solver = self.ls1
         return nlst
 
     def create_nlst2(self, nls, dt, u0, u1, v0, v1):
@@ -863,6 +869,10 @@ class BatheTS(ElastodynamicsBaseTS):
             return dt1 * v0 - dt4 * v1 + dt3 * v
 
         nlst = self._create_nlst_u(nls, dt, v, a, dt3 * dt3, dt3, 'matrix')
+        if self.ls2 is None:
+            self.ls2 = nls.lin_solver.copy()
+
+        nlst.lin_solver = self.ls2
         return nlst
 
     @standard_ts_call


### PR DESCRIPTION
Hey @vlukes, does this work for you? Now all options of `ls.auto_direct` handle the `presolve` parameter in the same way, and omitting the matrix digest check can significantly speed up time dependent problems. You can try it using the elastodynamic.py example (use larger mesh to see anything).