### PR TITLE
Fix simple phonon args

### DIFF
--- a/sfepy/examples/phononic/band_gaps_conf.py
+++ b/sfepy/examples/phononic/band_gaps_conf.py
@@ -231,6 +231,9 @@ class BandGapsConf(Struct):
         ema_options = copy(self.eigenmomenta_options)
         ema_options.update({'var_name' : 'u_c'})
 
+        dispersion_options = copy(self.band_gaps_options)
+        dispersion_options.update({'log_save_name' : 'dispersion.log'})
+
         coefs = {
             # Basic.
             'VF' : {
@@ -278,7 +281,7 @@ class BandGapsConf(Struct):
             },
             'dispersion' : {
                 'requires' : ['evp', 'c.eigenmomenta', 'c.M', 'c.Gamma'],
-                'options' : self.band_gaps_options,
+                'options' : dispersion_options,
                 'class' : cp.BandGaps,
             },
             'polarization_angles' : {

--- a/sfepy/homogenization/band_gaps_app.py
+++ b/sfepy/homogenization/band_gaps_app.py
@@ -373,7 +373,7 @@ class AcousticBandGapsApp(HomogenizationApp):
 
     def call(self):
         """
-        Construct and call the homogenization engine accoring to options.
+        Construct and call the homogenization engine according to options.
         """
         options = self.options
 

--- a/sfepy/homogenization/band_gaps_app.py
+++ b/sfepy/homogenization/band_gaps_app.py
@@ -61,8 +61,7 @@ def transform_plot_data(datas, plot_transform, conf):
     dmin, dmax = min(dmax - 1e-8, dmin), max(dmin + 1e-8, dmax)
     return (dmin, dmax), tdatas
 
-def plot_eigs(ax, plot_rsc, plot_labels, valid, freq_range, plot_range,
-              show=False, new_axes=False):
+def plot_eigs(ax, plot_rsc, plot_labels, valid, freq_range, plot_range):
     """
     Plot resonance/eigen-frequencies.
 
@@ -86,16 +85,9 @@ def plot_eigs(ax, plot_rsc, plot_labels, valid, freq_range, plot_range,
     if l1:
         l1.set_label(plot_labels['masked'])
 
-    if new_axes:
-        ax.set_xlim([freq_range[0], freq_range[-1]])
-        ax.set_ylim(plot_range)
-
-    if show:
-        plt.show()
-
 def plot_logs(ax, plot_rsc, plot_labels,
               freqs, logs, valid, freq_range, plot_range,
-              draw_eigs=True, show_legend=True, show=False, new_axes=False):
+              draw_eigs=True, show_legend=True):
     """
     Plot logs of min/middle/max eigs of a mass matrix.
     """
@@ -129,15 +121,8 @@ def plot_logs(ax, plot_rsc, plot_labels,
     ax.set_xlabel(plot_labels['x_axis'])
     ax.set_ylabel(plot_labels['y_axis'])
 
-    if new_axes:
-        ax.set_xlim([fmin, fmax])
-        ax.set_ylim(plot_range)
-
     if show_legend:
         ax.legend()
-
-    if show:
-        plt.show()
 
 def plot_gap(ax, ranges, kind, kind_desc, plot_range, plot_rsc):
     """
@@ -176,8 +161,7 @@ def plot_gap(ax, ranges, kind, kind_desc, plot_range, plot_rsc):
     else:
         raise ValueError('unknown band gap kind! (%s)' % kind)
 
-def plot_gaps(ax, plot_rsc, gaps, kinds, gap_ranges, freq_range,
-              plot_range, show=False, new_axes=False):
+def plot_gaps(ax, plot_rsc, gaps, kinds, gap_ranges, freq_range, plot_range):
     """
     Plot band gaps as rectangles.
     """
@@ -201,13 +185,6 @@ def plot_gaps(ax, plot_rsc, gaps, kinds, gap_ranges, freq_range,
             plot_gap(ax, ranges, kind, kind_desc, plot_range, plot_rsc)
             output(ii, gmin[0], gmax[0], '%.8f' % f0, '%.8f' % f1)
             output(' -> %s\n    %s' %(kind_desc, ranges))
-
-    if new_axes:
-        ax.set_xlim([freq_range[0], freq_range[-1]])
-        ax.set_ylim(plot_range)
-
-    if show:
-        plt.show()
 
 def _get_fig_name(output_dir, fig_name, key, common, fig_suffix):
     """
@@ -439,6 +416,9 @@ class AcousticBandGapsApp(HomogenizationApp):
             if options.analyze_dispersion:
                 self.plot_dispersion(coefs)
 
+            if opts.plot_options['show']:
+                plt.show()
+
         if options.phase_velocity:
             keys = [key for key in coefs.to_dict()
                     if key.startswith('phase_velocity')]
@@ -474,15 +454,15 @@ class AcousticBandGapsApp(HomogenizationApp):
                       bg.freq_range_initial,
                       plot_range,
                       show_legend=plot_opts['legend'])
+
+            ax.set_xlim([bg.logs.freqs[0][0], bg.logs.freqs[-1][-1]])
+            ax.set_ylim(plot_range)
             plt.tight_layout()
 
             if opts.fig_name is not None:
                 fig_name = _get_fig_name(self.problem.output_dir, opts.fig_name,
                                          key, 'band_gaps', opts.fig_suffix)
                 fig.savefig(fig_name)
-
-        if plot_opts['show']:
-            plt.show()
 
     def plot_dispersion(self, coefs):
         opts = self.app_options
@@ -515,9 +495,11 @@ class AcousticBandGapsApp(HomogenizationApp):
                       bg.valid[bg.eig_range],
                       bg.freq_range_initial,
                       plot_range,
-                      show_legend=plot_opts['legend'],
-                      new_axes=True,
-                      )
+                      show_legend=plot_opts['legend'])
+
+            ax_1.set_xlim(
+                [bg.logs.freqs[0][0], bg.logs.freqs[-1][-1]])
+            ax_1.set_ylim(plot_range)
             plt.tight_layout()
 
             fig_name = opts.fig_name_angle
@@ -540,8 +522,10 @@ class AcousticBandGapsApp(HomogenizationApp):
                       bg.valid[bg.eig_range],
                       bg.freq_range_initial,
                       plot_range,
-                      show_legend=plot_opts['legend'],
-                      new_axes=True)
+                      show_legend=plot_opts['legend'])
+
+            ax_2.set_xlim([bg.logs.freqs[0][0], bg.logs.freqs[-1][-1]])
+            ax_2.set_ylim(plot_range)
             plt.tight_layout()
 
             fig_name = opts.fig_name_wave

--- a/sfepy/homogenization/band_gaps_app.py
+++ b/sfepy/homogenization/band_gaps_app.py
@@ -365,7 +365,7 @@ class AcousticBandGapsApp(HomogenizationApp):
     def setup_options(self):
         HomogenizationApp.setup_options(self)
 
-        if self.options.phase_velocity:
+        if self.options.phase_velocity and not self.options.plot:
             process_options = AcousticBandGapsApp.process_options_pv
         else:
             process_options = AcousticBandGapsApp.process_options

--- a/sfepy/homogenization/band_gaps_app.py
+++ b/sfepy/homogenization/band_gaps_app.py
@@ -384,11 +384,12 @@ class AcousticBandGapsApp(HomogenizationApp):
                              'missing "%s" in problem description!'
                              % opts.coefs)
 
+        keys = []
         if options.detect_band_gaps:
             # Compute band gaps coefficients and data.
-            keys = [key for key in coef_info if key.startswith('band_gaps')]
+            keys += [key for key in coef_info if key.startswith('band_gaps')]
 
-        elif options.analyze_dispersion or options.phase_velocity:
+        if options.analyze_dispersion or options.phase_velocity:
 
             # Insert incident wave direction to coefficients that need it.
             for key, val in six.iteritems(coef_info):
@@ -401,16 +402,16 @@ class AcousticBandGapsApp(HomogenizationApp):
 
             if options.analyze_dispersion:
                 # Compute dispersion coefficients and data.
-                keys = [key for key in coef_info
+                keys += [key for key in coef_info
                         if key.startswith('dispersion')
                         or key.startswith('polarization_angles')]
 
-            else:
+            if options.phase_velocity:
                 # Compute phase velocity and its requirements.
-                keys = [key for key in coef_info
+                keys += [key for key in coef_info
                         if key.startswith('phase_velocity')]
 
-        else:
+        if not keys:
             # Compute only the eigenvalue problems.
             names = [req for req in conf.get(opts.requirements, [''])
                      if req.startswith('evp')]
@@ -464,10 +465,10 @@ class AcousticBandGapsApp(HomogenizationApp):
             if options.detect_band_gaps:
                 self.plot_band_gaps(coefs)
 
-            elif options.analyze_dispersion:
+            if options.analyze_dispersion:
                 self.plot_dispersion(coefs)
 
-        elif options.phase_velocity:
+        if options.phase_velocity:
             keys = [key for key in coefs.to_dict()
                     if key.startswith('phase_velocity')]
             for key in keys:

--- a/sfepy/scripts/simple.py
+++ b/sfepy/scripts/simple.py
@@ -201,7 +201,7 @@ def main():
 
     if options.detect_band_gaps and (
             options.analyze_dispersion or options.phase_velocity):
-        raise RuntimeError(
+        parser.error(
             'The option --phonon-band-gaps can not be used together with '
             '--phonon-dispersion or --phonon-phase-velocity.')
 

--- a/sfepy/scripts/simple.py
+++ b/sfepy/scripts/simple.py
@@ -199,6 +199,12 @@ def main():
     group.add_argument('filename_in', nargs='?')
     options, petsc_opts = parser.parse_known_args()
 
+    if options.detect_band_gaps and (
+            options.analyze_dispersion or options.phase_velocity):
+        raise RuntimeError(
+            'The option --phonon-band-gaps can not be used together with '
+            '--phonon-dispersion or --phonon-phase-velocity.')
+
     if options._list is not None:
         if options._list == 'terms':
             print_terms()

--- a/sfepy/scripts/simple.py
+++ b/sfepy/scripts/simple.py
@@ -199,12 +199,6 @@ def main():
     group.add_argument('filename_in', nargs='?')
     options, petsc_opts = parser.parse_known_args()
 
-    if options.detect_band_gaps and (
-            options.analyze_dispersion or options.phase_velocity):
-        parser.error(
-            'The option --phonon-band-gaps can not be used together with '
-            '--phonon-dispersion or --phonon-phase-velocity.')
-
     if options._list is not None:
         if options._list == 'terms':
             print_terms()

--- a/sfepy/scripts/simple.py
+++ b/sfepy/scripts/simple.py
@@ -208,9 +208,8 @@ def main():
 
         return
 
-    if options.plot:
-        if not options.analyze_dispersion:
-            options.detect_band_gaps = True
+    if not (options.analyze_dispersion or options.detect_band_gaps):
+            options.plot = False
 
     if options.debug:
         from sfepy.base.base import debug_on_error; debug_on_error()


### PR DESCRIPTION
Hi, here is my understanding of how simple.py should handle phononics:

* It should either do `band_gaps` or one or both of `phase_velocity` or `dispersion`.
* In addition, `plot` can make it to plot the results of `band_gaps` or `dispersion`.

The first issue is fixed by eventually raising a `RuntimeError` in case of conflicting parameters given by the user.