### PR TITLE
add github actions CI script that builds on PR and pushes to master

### DIFF
--- a/.github/workflows/build_and_test_matrix.yml
+++ b/.github/workflows/build_and_test_matrix.yml
@@ -38,4 +38,4 @@ jobs:
         pip install -e .
     - name: Test with pytest and coverage
       run: |
-              coverage run --source=sfepy/ -m pytest sfepy/tests -v -x --durations=10
+        coverage run --source=sfepy/ -m pytest sfepy/tests -v -x --durations=10

--- a/.github/workflows/build_and_test_matrix.yml
+++ b/.github/workflows/build_and_test_matrix.yml
@@ -1,0 +1,41 @@
+name: Build and test matrix
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+        python-version: ['3.7', '3.8', '3.9']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+         pip install --upgrade pip
+         pip install flake8 pytest coverage wheel
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 . --count --select=E9,F63,F7 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: install sfepy
+      run: |
+        pip install -e .
+    - name: Test with pytest and coverage
+      run: |
+              coverage run --source=sfepy/ -m pytest sfepy/tests -v -x --durations=10

--- a/.github/workflows/build_and_test_matrix.yml
+++ b/.github/workflows/build_and_test_matrix.yml
@@ -1,8 +1,6 @@
 name: Build and test matrix
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/build_and_test_matrix.yml
+++ b/.github/workflows/build_and_test_matrix.yml
@@ -2,9 +2,9 @@ name: Build and test matrix
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ master ]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/build_and_test_matrix.yml
+++ b/.github/workflows/build_and_test_matrix.yml
@@ -29,8 +29,8 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         flake8 . --count --select=E9,F63,F7 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        # exit-zero treats all errors as warnings. The Sfepy style should be 79 chars 
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=79 --statistics
     - name: install sfepy
       run: |
         pip install -e .

--- a/doc/developer_guide.rst
+++ b/doc/developer_guide.rst
@@ -334,6 +334,8 @@ github, then submit a "pull request" (PR):
    changes to the maintainers for review. Continuous integration (CI) will
    run and check that the changes pass tests on Windows, Linux and Mac using
    Github Actions. The results will be displayed in the Pull Request discussion.
+   The CI setup is located in the file
+   `.github/workflows/build_and_test_matrix.yml`.
    It is recommended to check that your contribution complies with the
    :ref:`notes_patches`.
 

--- a/doc/developer_guide.rst
+++ b/doc/developer_guide.rst
@@ -331,8 +331,11 @@ github, then submit a "pull request" (PR):
 
 #. Finally, when your feature is ready, and all tests pass, go to the github
    page of your sfepy repository fork, and click "Pull request" to send your
-   changes to the maintainers for review. It is recommended to check that your
-   contribution complies with the :ref:`notes_patches`.
+   changes to the maintainers for review. Continuous integration (CI) will
+   run and check that the changes pass tests on Windows, Linux and Mac using
+   Github Actions. The results will be displayed in the Pull Request discussion.
+   It is recommended to check that your contribution complies with the
+   :ref:`notes_patches`.
 
 In the above setup, your origin remote repository points to
 ``YourLogin/sfepy.git``. If you wish to fetch/merge from the main repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
-    "setuptools>=40.8.0",
+    "setuptools>=46.4,<60.0",
     "wheel",
 	"Cython>=0.29.30",
     "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,9 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
-    "setuptools<60.0",
+    "setuptools>=40.8.0",
     "wheel",
-    "Cython>=0.29.30,<3.0",
-
+	"Cython>=0.29.30",
     "matplotlib",
     "meshio",
     "numpy==1.20.*; python_version <= '3.9'", # meshio undeclared constraint.


### PR DESCRIPTION
Here’s a PR adding CI using Github actions.

It works on my fork of sfepy, see results here:
https://github.com/flothesof/sfepy/actions

This script builds and tests sfepy using pytest under windows, linux and macos.
It is configured to trigger for pushes to master and also pull requests to master.

What do you think about this @rc ?