### PR TITLE
Fix build dependency for Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ requires = [
 
     "matplotlib",
     "meshio",
-    "oldest-supported-numpy",
+    "numpy==1.20.*; python_version <= '3.9'", # meshio undeclared constraint.
+    "oldest-supported-numpy; python_version > '3.9'",
     "pyparsing",
     "scipy",
     "tables",


### PR DESCRIPTION
As mentioned in: https://github.com/sfepy/sfepy/issues/879

Meshio has an undeclared dependency on NumPy >= 1.20 (due to use of NumPy typings). They use both a setup.cfg file and a pyproject.toml, one of which doesn't mention the version constraints, and the duplication results in wheels depending on numpy without version constraint.

SFEPy build requirements specify `oldest-supported-numpy`, which for Python 3.9 is 1.19.3. This means that when pip tries to build in an isolated environment, it installs 1.19.3 and then fails when importing meshio at setup.py run time. This hinders use of SFEPy in automeated enviroments such as CI or poetry, when using Python 3.9.

Even if meshio was fixed to specify the constraint in the wheels, it will not solve the problem, but move it to dependency resolution time.

My proposed fix: specify the requirement in SFEPy build dependencies.

Note that this is unrelated to the NumPy that is installed as *runtime* requirement for SFEPy - it's just the one chosen for the pip build environment.

### validation
By inserting a print of the numpy version in code that runs at setup.py time, and running in different conda environments having different Python versions, I get:

| Python | NumPy |
|---------|----------|
|     3.9   |    1.20.3 |
|     3.10 |    1.21.6 |

