### PR TITLE
Fix: fields not shown in sfepy-view with pyvista 0.38

### DIFF
--- a/sfepy/scripts/resview.py
+++ b/sfepy/scripts/resview.py
@@ -468,7 +468,7 @@ def pv_plot(filenames, options, plotter=None, step=None,
             pos2 = position // options.max_plots
             shift = pos1 * size * nm.array(options.grid_vector1)
             shift += pos2 * size * nm.array(options.grid_vector2)
-            pipe[-1].translate(shift)
+            pipe[-1].translate(shift, inplace=True)
 
         if opts.get('l', options.outline):  # outline
             plotter.add_mesh(pipe[-1].outline(), color='k')


### PR DESCRIPTION
In the interactive sfepy tutorial, showing the saved regions is shown to produce a 3-plot window. However, when Pyvista 0.38 is installed, only one plot is visible.

The cause is an unhandled deprecation. with pyvista 0.37 running sfepy-view on the saved regions yields this warning:
```
[redacted]/pyvista/pyvista/core/pointset.py:206: PyVistaDeprecationWarning: You did not specify a value for `inplace` and the default value will be changing to `False` in future versions for point-based meshes (e.g., `PolyData`). Please make sure you are not assuming this to be an inplace operation.
  warnings.warn(DEFAULT_INPLACE_WARNING, PyVistaDeprecationWarning)
```
On 0.38 the deprecation is applied (see [this pyvista commit](https://github.com/pyvista/pyvista/commit/2b0c0a9abd75e6ab8c358b120792511cc1cd8036)), assuming a value that we did not intend for a parameter of the function that gave this warning.

This PR responds to the deprecation.