### PR TITLE
Return last vec from elastodynamic solvers

### DIFF
--- a/sfepy/solvers/ts_solvers.py
+++ b/sfepy/solvers/ts_solvers.py
@@ -498,6 +498,8 @@ class ElastodynamicsBaseTS(TimeSteppingSolver):
             ts.advance()
 
             vec = vect
+            
+        return vec
 
 class VelocityVerletTS(ElastodynamicsBaseTS):
     """


### PR DESCRIPTION
Currently, using pb.solve() with an elastodynamic solver (e.g. NewmarkTS) results in an exception at the end of the run:
```
...
 File "[redacted]\sfepy\discrete\problem.py", line 1471, in solve
    variables.set_state(vec, self.active_only)
... (cutting out the non-important backtrace)
File "[redacted]\sfepy\discrete\variables.py", line 555, in check_vec_size
    if vec.size != n_dof:
AttributeError: 'NoneType' object has no attribute 'size'
```
This is because the base class' `__call__` does not return the last vec as `solve()` expects and other solvers do. 

This PR: return last solution from `ElastodynamicsBaseTS.__call__()`.