### PR TITLE
Remove setuptools limitation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
-    "setuptools>=46.4,<60.0",
+    "setuptools>=46.4",
     "wheel",
 	"Cython>=0.29.30",
     "matplotlib",


### PR DESCRIPTION
As discussed [on the mailing list](https://mail.python.org/archives/list/sfepy@python.org/thread/5F5NTE2BSGMPQ7FVCFH5AQWJC7YU7XSH/): allows us to get the most recent bug fixes in setuptools, as long as numpy.distutils is working - which is expected to be for a while.

Work on replacing numpy.distutils is in early stages, and is hoped to remove the deprecation danger.