### PR TITLE
Rename integration

### DIFF
--- a/sfepy/discrete/common/fields.py
+++ b/sfepy/discrete/common/fields.py
@@ -439,14 +439,14 @@ class Field(Struct):
             valsi = vals.copy()
             evaluate_in_rc(vals, ref_coors, cells, status,
                            nm.ascontiguousarray(source_vals.real),
-                           self.get_econn('volume', self.region), cmode, ctx)
+                           self.get_econn('cell', self.region), cmode, ctx)
             evaluate_in_rc(valsi, ref_coors, cells, status,
                            nm.ascontiguousarray(source_vals.imag),
-                           self.get_econn('volume', self.region), cmode, ctx)
+                           self.get_econn('cell', self.region), cmode, ctx)
             vals = vals + valsi * 1j
         else:
             evaluate_in_rc(vals, ref_coors, cells, status, source_vals,
-                           self.get_econn('volume', self.region), cmode, ctx)
+                           self.get_econn('cell', self.region), cmode, ctx)
 
         output('interpolation: %f s' % timer.stop(),verbose=verbose)
 

--- a/sfepy/discrete/common/region.py
+++ b/sfepy/discrete/common/region.py
@@ -251,6 +251,9 @@ class Region(Struct):
     def set_kind(self, kind):
         if kind == self.kind: return
 
+        if self.__facet_kinds[self.tdim]['facet'] == kind:
+            kind = 'facet'
+
         self.kind = kind
         if 'facet' in kind:
             self.true_kind = self.__facet_kinds[self.tdim][kind]
@@ -594,7 +597,7 @@ class Region(Struct):
         to facets are returned if the region itself contains no cells. Obeys
         parent region, if given.
         """
-        if self.cells.shape[0] == 0:
+        if self.kind != 'cell':
             if true_cells_only:
                 msg = 'region %s has not true cells! (has kind: %s)' \
                       % (self.name, self.kind)

--- a/sfepy/discrete/dg/fields.py
+++ b/sfepy/discrete/dg/fields.py
@@ -933,7 +933,7 @@ class DGField(FEField):
 
         return vols_out
 
-    def get_data_shape(self, integral, integration='volume', region_name=None):
+    def get_data_shape(self, integral, integration='cell', region_name=None):
         """Returns data shape
         (n_nod, n_qp, self.gel.dim, self.n_el_nod)
 
@@ -950,7 +950,7 @@ class DGField(FEField):
         data_shape : tuple
         """
 
-        if integration in ('volume',):
+        if integration in ('cell',):
             # from FEField.get_data_shape()
             _, weights = integral.get_qp(self.gel.name)
             n_qp = weights.shape[0]
@@ -988,7 +988,7 @@ class DGField(FEField):
 
         ct = conn_type.type if isinstance(conn_type, Struct) else conn_type
 
-        if ct == 'volume':
+        if ct == 'cell':
             if region.name == self.region.name:
                 conn = self.econn
             else:
@@ -1098,7 +1098,7 @@ class DGField(FEField):
         coors = domain.get_mesh_coors(actual=True)
         dconn = domain.get_conn()
         # from FEField
-        if integration == 'volume':
+        if region.kind == 'cell':
             qp = self.get_qp('v', integral)
             # qp = self.integral.get_qp(self.gel.name)
             iels = region.get_cells()
@@ -1114,7 +1114,7 @@ class DGField(FEField):
                                       transform=self.basis_transform)
         else:
             raise ValueError('unsupported integration geometry type: %s'
-                             % integration)
+                             % region.kind)
 
         if out is not None:
             # Store the integral used.

--- a/sfepy/discrete/dg/fields.py
+++ b/sfepy/discrete/dg/fields.py
@@ -963,8 +963,7 @@ class DGField(FEField):
 
         return data_shape
 
-    def get_econn(self, conn_type, region, trace_region=None,
-                  integration=None):
+    def get_econn(self, conn_type, region, trace_region=None):
         """Getter for econn
 
         Parameters
@@ -972,10 +971,7 @@ class DGField(FEField):
         conn_type : string or Struct
             'volume' is only supported
         region : sfepy.discrete.common.region.Region
-
         trace_region : ignored
-             (Default value = None)
-        integration : ignored
              (Default value = None)
 
         Returns

--- a/sfepy/discrete/equations.py
+++ b/sfepy/discrete/equations.py
@@ -394,7 +394,7 @@ class Equations(Container):
             is_surface = rvar.is_surface or cvar.is_surface
 
             dct = info.dc_type.type
-            if not (dct in ('volume', 'scalar', 'custom') or is_surface
+            if not (dct in ('cell', 'custom') or is_surface
                     or info.trace_region is not None or any_dof_conn):
                 continue
 

--- a/sfepy/discrete/fem/fields_base.py
+++ b/sfepy/discrete/fem/fields_base.py
@@ -1222,8 +1222,7 @@ class VolumeField(FEField):
 
         return self.surface_data[region.name]
 
-    def get_econn(self, conn_type, region, trace_region=None, integration=None,
-                  local=False):
+    def get_econn(self, conn_type, region, trace_region=None, local=False):
         """
         Get extended connectivity of the given type in the given region.
         """
@@ -1404,8 +1403,7 @@ class SurfaceField(FEField):
         """
         return 0, None, None
 
-    def get_econn(self, conn_type, region, trace_region=None,
-                  integration=None):
+    def get_econn(self, conn_type, region, trace_region=None, local=False):
         """
         Get extended connectivity of the given type in the given region.
         """

--- a/sfepy/discrete/fem/fields_base.py
+++ b/sfepy/discrete/fem/fields_base.py
@@ -418,7 +418,7 @@ class FEField(Field):
         ----------
         integral : Integral instance
             The integral describing used numerical quadrature.
-        integration : str
+        integration : 'cell', 'facet', 'facet_extra', 'point' or 'custom'
             The term integration mode.
         region_name : str
             The name of the region of the integral.
@@ -432,6 +432,15 @@ class FEField(Field):
 
         Notes
         -----
+        Integration modes:
+        - 'cell': integration over cells/elements
+        - 'facet': integration over cell facets (faces, edges)
+        - 'facet_extra': same as 'facet' but also the normal derivatives
+          are evaluated
+        - 'point': point integration
+        - 'custom': user defined integration
+
+        Dimensions:
         - `n_el`, `n_fa` = number of elements/facets
         - `n_qp` = number of quadrature points per element/facet
         - `dim` = spatial dimension

--- a/sfepy/discrete/iga/fields.py
+++ b/sfepy/discrete/iga/fields.py
@@ -106,7 +106,7 @@ class IGField(Field):
 
         nconn = self.nurbs.conn
 
-        if ct == 'volume':
+        if ct == 'cell':
             if region.name == self.region.name:
                 conn = nconn
 
@@ -114,7 +114,7 @@ class IGField(Field):
                 cells = region.get_cells(true_cells_only=True)
                 conn = nm.take(nconn, cells.astype(nm.int32), axis=0)
 
-        elif ct == 'surface':
+        elif ct == 'facet':
             fis = region.get_facet_indices()
             tdim = region.kind_tdim
             facets = self._get_facets(tdim)
@@ -135,7 +135,7 @@ class IGField(Field):
 
         return conn
 
-    def get_data_shape(self, integral, integration='volume', region_name=None):
+    def get_data_shape(self, integral, integration='cell', region_name=None):
         """
         Get element data dimensions.
 
@@ -143,8 +143,8 @@ class IGField(Field):
         ----------
         integral : Integral instance
             The integral describing used numerical quadrature.
-        integration : 'volume'
-            The term integration type. Only 'volume' type is implemented.
+        integration : 'cell'
+            The term integration type. Only 'cell' type is implemented.
         region_name : str
             The name of the region of the integral.
 
@@ -183,11 +183,11 @@ class IGField(Field):
                              % region.name)
 
         if idim == region.tdim: # Cells.
-            rconn = self.get_econn('volume', region)
+            rconn = self.get_econn('cell', region)
             dofs = nm.unique(rconn)
 
         else: # Facets.
-            rconn = self.get_econn('surface', region)
+            rconn = self.get_econn('facet', region)
             dofs = nm.unique(nm.concatenate(rconn))
 
         if not merge:
@@ -248,7 +248,7 @@ class IGField(Field):
     def setup_extra_data(self, geometry, info):
         dct = info.dc_type.type
 
-        if dct != 'volume':
+        if dct != 'cell':
             raise ValueError('unknown dof connectivity type! (%s)' % dct)
 
     def create_mapping(self, region, integral, integration):

--- a/sfepy/discrete/iga/fields.py
+++ b/sfepy/discrete/iga/fields.py
@@ -97,8 +97,7 @@ class IGField(Field):
         """
         return (self.nurbs.degrees > 1).any()
 
-    def get_econn(self, conn_type, region, trace_region=None, integration=None,
-                  local=False):
+    def get_econn(self, conn_type, region, trace_region=None, local=False):
         """
         Get DOF connectivity of the given type in the given region.
         """

--- a/sfepy/discrete/projections.py
+++ b/sfepy/discrete/projections.py
@@ -181,7 +181,7 @@ def project_to_facets(region, fun, dpn, field):
     n_dof = len(nods)
 
     # Region facet connectivity.
-    lconn = field.get_econn('surface', region, local=True)
+    lconn = field.get_econn('facet', region, local=True)
 
     # Cell and face(cell) ids for each facet.
     fis = region.get_facet_indices()

--- a/sfepy/discrete/variables.py
+++ b/sfepy/discrete/variables.py
@@ -1595,7 +1595,7 @@ class FieldVariable(Variable):
 
             self.initial_condition[eq] = nm.ravel(vv)
 
-    def get_data_shape(self, integral, integration='volume', region_name=None):
+    def get_data_shape(self, integral, integration='cell', region_name=None):
         """
         Get element data dimensions for given approximation.
 
@@ -1603,8 +1603,8 @@ class FieldVariable(Variable):
         ----------
         integral : Integral instance
             The integral describing used numerical quadrature.
-        integration : 'volume', 'surface', 'surface_extra', 'point' or 'custom'
-            The term integration type.
+        integration : 'cell', 'facet', 'facet_extra', 'point' or 'custom'
+            The term extra integration mode.
         region_name : str
             The name of the region of the integral.
 
@@ -1671,9 +1671,9 @@ class FieldVariable(Variable):
             The integral defining quadrature points in which the
             evaluation occurs. If None, the first order volume integral
             is created. Must not be None for surface integrations.
-        integration : 'volume', 'surface', 'surface_extra', or 'point'
+        integration : 'cell', 'facet', 'facet_extra', or 'point'
             The term integration type. If None, it is derived from
-            `integral`.
+            the region kind.
         step : int, default 0
             The time step (0 means current, -1 previous, ...).
         time_derivative : None or 'dt'
@@ -1716,7 +1716,7 @@ class FieldVariable(Variable):
             integral = Integral('aux_1', 1)
 
         if integration is None:
-            integration = 'volume' if region.can_cells else 'surface'
+            integration = region.kind
 
         geo, _, key = field.get_mapping(region, integral, integration,
                                         return_key=True)
@@ -1727,10 +1727,9 @@ class FieldVariable(Variable):
 
         else:
             vec = self(step=step, derivative=time_derivative, dt=dt)
-            ct = integration
-            if integration == 'surface_extra':
-                ct = 'volume'
-            conn = field.get_econn(ct, region, trace_region, integration)
+
+            ct = 'cell' if integration == 'facet_extra' else integration
+            conn = field.get_econn(ct, region, trace_region)
 
             shape = self.get_data_shape(integral, integration, region.name)
 

--- a/sfepy/discrete/variables.py
+++ b/sfepy/discrete/variables.py
@@ -1604,7 +1604,7 @@ class FieldVariable(Variable):
         integral : Integral instance
             The integral describing used numerical quadrature.
         integration : 'cell', 'facet', 'facet_extra', 'point' or 'custom'
-            The term extra integration mode.
+            The term integration mode.
         region_name : str
             The name of the region of the integral.
 

--- a/sfepy/terms/terms_adj_navier_stokes.py
+++ b/sfepy/terms/terms_adj_navier_stokes.py
@@ -139,7 +139,7 @@ class SUPGCAdjStabilizationTerm(Term):
 
         val_u = self.get(parameter, 'val')
         grad_u = self.get(parameter, 'grad').transpose((0, 1, 3, 2)).copy()
-        conn = state.field.get_connectivity(self.region, self.integration)
+        conn = state.field.get_connectivity(self.region, self.act_integration)
 
         fmode = diff_var is not None
 
@@ -173,7 +173,8 @@ class SUPGPAdj1StabilizationTerm(Term):
         vg_w, _ = self.get_mapping(state)
 
         grad_p = self.get(parameter, 'grad')
-        conn_w = state.field.get_connectivity(self.region, self.integration)
+        conn_w = state.field.get_connectivity(self.region,
+                                              self.act_integration)
 
         fmode = diff_var is not None
 
@@ -209,7 +210,8 @@ class SUPGPAdj2StabilizationTerm(Term):
         vg_u, _ = self.get_mapping(parameter)
 
         grad_u = self.get(parameter, 'grad').transpose((0, 1, 3, 2)).copy()
-        conn_r = state.field.get_connectivity(self.region, self.integration)
+        conn_r = state.field.get_connectivity(self.region,
+                                              self.act_integration)
 
         fmode = diff_var is not None
 
@@ -433,7 +435,7 @@ class NSOFSurfMinDPressTerm(Term):
     arg_types = ('material_1', 'material_2', 'parameter')
     arg_shapes = {'material_1' : 1, 'material_2' : 1,
                   'parameter' : 1}
-    integration = 'surface'
+    integration = 'facet'
 
     function = staticmethod(terms.d_of_nsSurfMinDPress)
 

--- a/sfepy/terms/terms_basic.py
+++ b/sfepy/terms/terms_basic.py
@@ -61,7 +61,7 @@ class IntegrateTerm(Term):
     arg_types = ('opt_material', 'parameter')
     arg_shapes = [{'opt_material' : '1, 1', 'parameter' : 'N'},
                   {'opt_material' : None}]
-    integration = 'by_region'
+    integration = ('cell', 'facet')
 
     @staticmethod
     def function(out, val_qp, vg, fmode):
@@ -126,7 +126,7 @@ class IntegrateOperatorTerm(Term):
     arg_types = ('opt_material', 'virtual')
     arg_shapes = [{'opt_material' : '1, 1', 'virtual' : (1, None)},
                   {'opt_material' : None}]
-    integration = 'by_region'
+    integration = ('cell', 'facet')
 
     @staticmethod
     def function(out, material, bf, geo):
@@ -161,7 +161,7 @@ class VolumeTerm(Term):
     name = 'ev_volume'
     arg_types = ('parameter',)
     arg_shapes = [{'parameter' : 'N'}]
-    integration = 'by_region'
+    integration = ('cell', 'facet')
 
     @staticmethod
     def function(out, geo):
@@ -198,7 +198,7 @@ class VolumeSurfaceTerm(Term):
     name = 'ev_volume_surface'
     arg_types = ('parameter',)
     arg_shapes = {'parameter' : 'N'}
-    integration = 'surface'
+    integration = 'facet'
 
     function = staticmethod(terms.d_volume_surface)
 
@@ -234,7 +234,7 @@ class SurfaceMomentTerm(Term):
     name = 'ev_surface_moment'
     arg_types = ('material', 'parameter')
     arg_shapes = {'material' : '.: D', 'parameter' : 'N'}
-    integration = 'surface'
+    integration = 'facet'
 
     function = staticmethod(terms.di_surface_moment)
 
@@ -278,7 +278,7 @@ class IntegrateMatTerm(Term):
     name = 'ev_integrate_mat'
     arg_types = ('material', 'parameter')
     arg_shapes = [{'material' : 'N, N', 'parameter' : 'N'}]
-    integration = 'by_region'
+    integration = ('cell', 'facet')
 
     @staticmethod
     def function(out, mat, geo, fmode):

--- a/sfepy/terms/terms_biot.py
+++ b/sfepy/terms/terms_biot.py
@@ -141,7 +141,7 @@ class BiotStressTerm(CauchyStressTerm):
     name = 'ev_biot_stress'
     arg_types = ('material', 'parameter')
     arg_shapes = {'material' : 'S, 1', 'parameter' : 1}
-    integration = 'volume'
+    integration = 'cell'
 
     @staticmethod
     def function(out, val_qp, mat, vg, fmode):

--- a/sfepy/terms/terms_constraints.py
+++ b/sfepy/terms/terms_constraints.py
@@ -34,7 +34,7 @@ class NonPenetrationTerm(Term):
                    'virtual/div' : (1, None), 'state/div' : 'D'},
                   {'opt_material' : None}]
     modes = ('grad', 'div')
-    integration = 'surface'
+    integration = 'facet'
 
     @staticmethod
     def function(out, val_qp, ebf, bf, mat, sg, diff_var, mode):
@@ -117,7 +117,7 @@ class NonPenetrationPenaltyTerm(Term):
     arg_types = ('material', 'virtual', 'state')
     arg_shapes = {'material' : '1, 1',
                   'virtual' : ('D', 'state'), 'state' : 'D'}
-    integration = 'surface'
+    integration = 'facet'
 
     @staticmethod
     def function(out, val_qp, ebf, mat, sg, diff_var):

--- a/sfepy/terms/terms_contact.py
+++ b/sfepy/terms/terms_contact.py
@@ -96,7 +96,7 @@ class ContactTerm(Term):
     arg_types = ('material', 'virtual', 'state')
     arg_shapes = {'material' : '.: 1',
                   'virtual' : ('D', 'state'), 'state' : 'D'}
-    integration = 'surface'
+    integration = 'facet'
 
     def __init__(self, *args, **kwargs):
         Term.__init__(self, *args, **kwargs)

--- a/sfepy/terms/terms_dg.py
+++ b/sfepy/terms/terms_dg.py
@@ -149,7 +149,7 @@ class AdvectionDGFluxTerm(DGTerm):
                    'state'           : 1
                    },
                   {'opt_material': None}]
-    integration = 'volume'
+    integration = 'cell'
     symbolic = {'expression': 'div(a*p)*w',
                 'map' : {'p': 'state', 'a': 'material', 'v': 'virtual'}
                 }
@@ -292,7 +292,7 @@ class DiffusionDGFluxTerm(DGTerm):
                    'virtual/avg_virtual': (1, None),
                    'state/avg_virtual' : 1,
                    }]
-    integration = 'volume'
+    integration = 'cell'
     modes = ('avg_state', 'avg_virtual')
 
     def get_fargs(self, diff_tensor, test, state,
@@ -611,7 +611,7 @@ class NonlinearHyperbolicDGFluxTerm(DGTerm):
                    'state'         : 1
                    },
                   {'opt_material': None}]
-    integration = 'volume'
+    integration = 'cell'
     symbolic = {'expression': 'div(f(p))*w',
                 'map'       : {'p': 'state', 'v': 'virtual', 'f': 'function'}
                 }

--- a/sfepy/terms/terms_diffusion.py
+++ b/sfepy/terms/terms_diffusion.py
@@ -297,8 +297,7 @@ class DiffusionVelocityTerm( Term ):
     name = 'ev_diffusion_velocity'
     arg_types = ('material', 'parameter')
     arg_shapes = {'material' : 'D, D', 'parameter' : 1}
-    integration = 'by_region'
-    surface_integration = 'surface_extra'
+    integration = ('cell', 'facet_extra')
 
     @staticmethod
     def function(out, grad, mat, vg, fmode):
@@ -350,7 +349,7 @@ class SurfaceFluxTerm(Term):
     name = 'ev_surface_flux'
     arg_types = ('material', 'parameter')
     arg_shapes = {'material' : 'D, D', 'parameter' : 1}
-    integration = 'surface_extra'
+    integration = 'facet_extra'
 
     function = staticmethod(terms.d_surface_flux)
 
@@ -389,7 +388,7 @@ class SurfaceFluxOperatorTerm(Term):
     arg_shapes = [{'opt_material' : 'D, D', 'virtual' : (1, 'state'),
                    'state' : 1},
                   {'opt_material' : None}]
-    integration = 'surface_extra'
+    integration = 'facet_extra'
     function = terms.dw_surface_flux
 
     def get_fargs(self, mat, virtual, state,
@@ -404,7 +403,7 @@ class SurfaceFluxOperatorTerm(Term):
             mat[..., :, :] = nm.eye(dim, dtype=nm.float64)
 
         if diff_var is None:
-            grad = self.get(state, 'grad', integration='surface_extra')
+            grad = self.get(state, 'grad', integration='facet_extra')
             fmode = 0
 
         else:

--- a/sfepy/terms/terms_dot.py
+++ b/sfepy/terms/terms_dot.py
@@ -33,29 +33,29 @@ class DotProductTerm(Term):
     arg_types = (('opt_material', 'virtual', 'state'),
                  ('opt_material', 'parameter_1', 'parameter_2'))
     arg_shapes_dict = {
-        'volume': [{'opt_material' : '1, 1', 'virtual' : (1, 'state'),
-                    'state' : 1, 'parameter_1' : 1, 'parameter_2' : 1},
-                   {'opt_material' : None},
-                   {'opt_material' : '1, 1', 'virtual' : ('D', 'state'),
-                    'state' : 'D', 'parameter_1' : 'D', 'parameter_2' : 'D'},
-                   {'opt_material' : 'D, D'},
-                   {'opt_material' : None}],
-        'surface': [{'opt_material' : '1, 1', 'virtual' : (1, 'state'),
-                     'state' : 1, 'parameter_1' : 1, 'parameter_2' : 1},
-                    {'opt_material' : None},
-                    {'opt_material' : '1, 1', 'virtual' : (1, None),
-                    'state' : 'D'},
-                    {'opt_material' : None},
-                    {'opt_material' : '1, 1', 'virtual' : ('D', None),
-                    'state' : 1},
-                    {'opt_material' : None},
-                    {'opt_material' : '1, 1', 'virtual' : ('D', 'state'),
-                    'state' : 'D', 'parameter_1' : 'D', 'parameter_2' : 'D'},
-                    {'opt_material' : 'D, D'},
-                    {'opt_material' : None}]
+        'cell': [{'opt_material' : '1, 1', 'virtual' : (1, 'state'),
+                  'state' : 1, 'parameter_1' : 1, 'parameter_2' : 1},
+                 {'opt_material' : None},
+                 {'opt_material' : '1, 1', 'virtual' : ('D', 'state'),
+                  'state' : 'D', 'parameter_1' : 'D', 'parameter_2' : 'D'},
+                 {'opt_material' : 'D, D'},
+                 {'opt_material' : None}],
+        'facet': [{'opt_material' : '1, 1', 'virtual' : (1, 'state'),
+                   'state' : 1, 'parameter_1' : 1, 'parameter_2' : 1},
+                  {'opt_material' : None},
+                  {'opt_material' : '1, 1', 'virtual' : (1, None),
+                   'state' : 'D'},
+                  {'opt_material' : None},
+                  {'opt_material' : '1, 1', 'virtual' : ('D', None),
+                   'state' : 1},
+                  {'opt_material' : None},
+                  {'opt_material' : '1, 1', 'virtual' : ('D', 'state'),
+                   'state' : 'D', 'parameter_1' : 'D', 'parameter_2' : 'D'},
+                  {'opt_material' : 'D, D'},
+                  {'opt_material' : None}]
     }
     modes = ('weak', 'eval')
-    integration = 'by_region'
+    integration = ('cell', 'facet')
 
     @staticmethod
     def dw_dot(out, mat, val_qp, vgeo, sgeo, fun, fmode):
@@ -111,7 +111,7 @@ class DotProductTerm(Term):
                 fmode = 1
 
             if state.n_components > 1:
-                if ((self.integration == 'volume')
+                if ((self.act_integration == 'cell')
                     or (virtual.n_components > 1)):
                     fun = terms.dw_volume_dot_vector
 
@@ -119,7 +119,7 @@ class DotProductTerm(Term):
                     fun = terms.dw_surface_s_v_dot_n
 
             else:
-                if ((self.integration == 'volume')
+                if ((self.act_integration == 'cell')
                     or (virtual.n_components == 1)):
                     fun = terms.dw_volume_dot_scalar
 
@@ -172,7 +172,7 @@ class BCNewtonTerm(DotProductTerm):
     arg_shapes = {'material_1' : '1, 1', 'material_2' : '1, 1',
                   'virtual' : (1, 'state'), 'state' : 1}
     mode = 'weak'
-    integration = 'surface'
+    integration = 'facet'
     arg_shapes_dict = None
 
     def get_fargs(self, alpha, p_outer, virtual, state,

--- a/sfepy/terms/terms_elastic.py
+++ b/sfepy/terms/terms_elastic.py
@@ -403,8 +403,7 @@ class CauchyStrainTerm(Term):
     name = 'ev_cauchy_strain'
     arg_types = ('parameter',)
     arg_shapes = {'parameter' : 'D'}
-    integration = 'by_region'
-    surface_integration = 'surface_extra'
+    integration = ('cell', 'facet_extra')
 
     @staticmethod
     def function(out, strain, vg, fmode):
@@ -459,8 +458,7 @@ class CauchyStressTerm(Term):
     name = 'ev_cauchy_stress'
     arg_types = ('material', 'parameter')
     arg_shapes = {'material' : 'S, S', 'parameter' : 'D'}
-    integration = 'by_region'
-    surface_integration = 'surface_extra'
+    integration = ('cell', 'facet_extra')
 
     @staticmethod
     def function(out, coef, strain, mat, vg, fmode):
@@ -754,7 +752,7 @@ class ElasticWaveTerm(Term):
         gmat = _build_wave_strain_op(kappa, ebf)
 
         if diff_var is None:
-            econn = state.field.get_econn('volume', self.region)
+            econn = state.field.get_econn('cell', self.region)
             adc = create_adof_conn(nm.arange(state.n_dof, dtype=nm.int32),
                                    econn, n_c, 0)
             vals = state()[adc]
@@ -826,7 +824,7 @@ class ElasticWaveCauchyTerm(Term):
 
         if diff_var is None:
             avar = evar if self.mode == 'ge' else gvar
-            econn = avar.field.get_econn('volume', self.region)
+            econn = avar.field.get_econn('cell', self.region)
             adc = create_adof_conn(nm.arange(avar.n_dof, dtype=nm.int32),
                                    econn, n_c, 0)
             vals = avar()[adc]

--- a/sfepy/terms/terms_hyperelastic_tl.py
+++ b/sfepy/terms/terms_hyperelastic_tl.py
@@ -732,7 +732,7 @@ class SurfaceFluxTLTerm(HyperElasticSurfaceTLBase):
     arg_shapes = {'material_1' : 'D, D', 'material_2' : '1, 1',
                   'parameter_1' : 1, 'parameter_2' : 'D'}
     family_data_names = ['det_f', 'inv_f']
-    integration = 'surface_extra'
+    integration = 'facet_extra'
 
     function = staticmethod(terms.d_tl_surface_flux)
 
@@ -782,7 +782,7 @@ class SurfaceTractionTLTerm(HyperElasticSurfaceTLBase):
                    'state' : 'D'},
                   {'opt_material' : None}]
     family_data_names = ['det_f', 'inv_f']
-    integration = 'surface_extra'
+    integration = 'facet_extra'
 
     function = staticmethod(terms.dw_tl_surface_traction)
 
@@ -831,7 +831,7 @@ class VolumeSurfaceTLTerm(HyperElasticSurfaceTLBase):
     arg_types = ('parameter',)
     arg_shapes = {'parameter' : 'D'}
     family_data_names = ['det_f', 'inv_f']
-    integration = 'surface_extra'
+    integration = 'facet_extra'
 
     function = staticmethod(terms.d_tl_volume_surface)
 

--- a/sfepy/terms/terms_membrane.py
+++ b/sfepy/terms/terms_membrane.py
@@ -94,7 +94,7 @@ class TLMembraneTerm(Term):
                   'material_h0' : '1, 1',
                   'virtual' : ('D', 'state'), 'state' : 'D'}
     geometries = ['3_4', '3_8']
-    integration = 'surface'
+    integration = 'facet'
 
     @staticmethod
     def function(out, fun, *args):

--- a/sfepy/terms/terms_multilinear.py
+++ b/sfepy/terms/terms_multilinear.py
@@ -229,7 +229,7 @@ class ExpressionArg(Struct):
 
     def get_bf(self, expr_cache):
         ag, _ = self.term.get_mapping(self.arg)
-        if self.term.integration == 'surface_extra':
+        if self.term.integration == 'facet_extra':
             sd = self.arg.field.surface_data[self.term.region.name]
             _bf = self.arg.field.get_base(sd.bkey, 0, self.term.integral)
             bf = _bf[sd.fis[:, 1], ...]
@@ -366,7 +366,7 @@ class ExpressionBuilder(Struct):
             self.add_bfg(iin, ein, arg.name)
 
         else:
-            cell_dep = arg.term.integration == 'surface_extra'
+            cell_dep = arg.term.integration == 'facet_extra'
             self.add_bf(iin, ein, arg.name, cell_dependent=cell_dep)
 
         out_letters = iin
@@ -398,7 +398,7 @@ class ExpressionBuilder(Struct):
             self.add_bfg(iin, ein, arg.name)
 
         else:
-            cell_dep = arg.term.integration == 'surface_extra'
+            cell_dep = arg.term.integration == 'facet_extra'
             self.add_bf(iin, ein, arg.name, cell_dependent=cell_dep)
 
         out_letters = iin
@@ -1189,7 +1189,7 @@ class EIntegrateOperatorTerm(ETermBase):
     arg_types = ('opt_material', 'virtual')
     arg_shapes = [{'opt_material' : '1, 1', 'virtual' : (1, None)},
                   {'opt_material' : None}]
-    integration = 'by_region'
+    integration = ('cell', 'facet')
 
     def get_function(self, mat, virtual, mode=None, term_mode=None,
                      diff_var=None, **kwargs):
@@ -1271,7 +1271,7 @@ class EDotTerm(ETermBase):
                   {'opt_material' : 'D, D'},
                   {'opt_material' : None}]
     modes = ('weak', 'eval')
-    integration = 'by_region'
+    integration = ('cell', 'facet')
 
     def get_function(self, mat, virtual, state, mode=None, term_mode=None,
                      diff_var=None, **kwargs):
@@ -1352,7 +1352,7 @@ class ENonPenetrationPenaltyTerm(ETermBase):
     arg_types = ('material', 'virtual', 'state')
     arg_shapes = {'material' : '1, 1',
                   'virtual' : ('D', 'state'), 'state' : 'D'}
-    integration = 'surface'
+    integration = 'facet'
 
     def get_function(self, mat, virtual, state, mode=None, term_mode=None,
                      diff_var=None, **kwargs):
@@ -1755,7 +1755,7 @@ class ELinearTractionTerm(ETermBase):
                   {'opt_material': None}, {'opt_material': '1, 1'},
                   {'opt_material': 'D, 1'}, {'opt_material': 'D, D'}]
     modes = ('weak', 'eval')
-    integration = 'surface'
+    integration = 'facet'
 
     def get_function(self, traction, vvar, mode=None, term_mode=None,
                      diff_var=None, **kwargs):
@@ -1819,7 +1819,7 @@ class SurfaceFluxOperatorTerm(ETermBase):
                    'virtual/grad_virtual' : (1, None),
                    'state/grad_virtual' : 1,
                    'parameter_1': 1, 'parameter_2': 1}]
-    integration = 'surface_extra'
+    integration = 'facet_extra'
     modes = ('grad_state', 'grad_virtual', 'eval')
 
     def get_function(self, mat, var1, var2, mode=None, term_mode=None,

--- a/sfepy/terms/terms_navier_stokes.py
+++ b/sfepy/terms/terms_navier_stokes.py
@@ -333,8 +333,7 @@ class GradTerm(Term):
     arg_types = ('opt_material', 'parameter')
     arg_shapes = [{'opt_material': '1, 1', 'parameter': 'N'},
                   {'opt_material': None}]
-    integration = 'by_region'
-    surface_integration = 'surface_extra'
+    integration = ('cell', 'facet_extra')
 
     @staticmethod
     def function(out, mat, grad, vg, fmode):
@@ -352,7 +351,7 @@ class GradTerm(Term):
                   mode=None, term_mode=None, diff_var=None, **kwargs):
         vg, _ = self.get_mapping(parameter)
 
-        grad = self.get(parameter, 'grad', integration=self.integration)
+        grad = self.get(parameter, 'grad', integration=self.act_integration)
 
         fmode = {'eval' : 0, 'el_avg' : 1, 'qp' : 2}.get(mode, 1)
 
@@ -386,8 +385,7 @@ class DivTerm(Term):
     arg_types = ('opt_material', 'parameter')
     arg_shapes = [{'opt_material': '1, 1', 'parameter': 'D'},
                   {'opt_material': None}]
-    integration = 'by_region'
-    surface_integration = 'surface_extra'
+    integration = ('cell', 'facet_extra')
 
     @staticmethod
     def function(out, mat, div, vg, fmode):
@@ -405,7 +403,7 @@ class DivTerm(Term):
                   mode=None, term_mode=None, diff_var=None, **kwargs):
         vg, _ = self.get_mapping(parameter)
 
-        div = self.get(parameter, 'div', integration=self.integration)
+        div = self.get(parameter, 'div', integration=self.act_integration)
 
         fmode = {'eval' : 0, 'el_avg' : 1, 'qp' : 2}.get(mode, 1)
 
@@ -499,7 +497,7 @@ class StokesWaveTerm(Term):
         kebf = insert_strided_axis(aux, 0, n_el)
 
         if diff_var is None:
-            econn = state.field.get_econn('volume', self.region)
+            econn = state.field.get_econn('cell', self.region)
             adc = create_adof_conn(nm.arange(state.n_dof, dtype=nm.int32),
                                    econn, n_c, 0)
             vals = state()[adc]
@@ -567,7 +565,7 @@ class StokesWaveDivTerm(Term):
 
         if diff_var is None:
             avar = dvar if self.mode == 'kd' else kvar
-            econn = avar.field.get_econn('volume', self.region)
+            econn = avar.field.get_econn('cell', self.region)
             adc = create_adof_conn(nm.arange(avar.n_dof, dtype=nm.int32),
                                    econn, n_c, 0)
             vals = avar()[adc]
@@ -677,7 +675,7 @@ class PSPGCStabilizationTerm(Term):
         vvg, _ = self.get_mapping(state)
 
         val_qp = self.get(parameter, 'val')
-        conn = state.field.get_connectivity(self.region, self.integration)
+        conn = state.field.get_connectivity(self.region, self.act_integration)
 
         if diff_var is None:
             fmode = 0
@@ -757,7 +755,8 @@ class SUPGCStabilizationTerm(Term):
         vg, _ = self.get_mapping(virtual)
 
         val_qp = self.get(parameter, 'val')
-        conn = virtual.field.get_connectivity(self.region, self.integration)
+        conn = virtual.field.get_connectivity(self.region,
+                                              self.act_integration)
 
         if diff_var is None:
             fmode = 0

--- a/sfepy/terms/terms_sensitivity.py
+++ b/sfepy/terms/terms_sensitivity.py
@@ -356,12 +356,12 @@ class ESDLinearTractionTerm(ETermBase):
                   {'opt_material': None}, {'opt_material': '1, 1'},
                   {'opt_material': 'D, D'}]
     modes = ('weak', 'eval')
-    integration = 'surface'
+    integration = 'facet'
 
     def get_function(self, traction, vvar, par_mv, mode=None, term_mode=None,
                      diff_var=None, **kwargs):
         sg, _ = self.get_mapping(vvar)
-        grad_mv = self.get(par_mv, 'grad', integration='surface_extra')
+        grad_mv = self.get(par_mv, 'grad', integration='facet_extra')
         div_mv = nm.trace(grad_mv, axis1=2, axis2=3)[..., None, None]
 
         _, n_qp, dim, _ = grad_mv.shape

--- a/sfepy/terms/terms_shells.py
+++ b/sfepy/terms/terms_shells.py
@@ -164,7 +164,7 @@ class Shell10XTerm(Term):
 
         # Displacements of element nodes.
         vec_u = vu()
-        econn = vu.field.get_econn('volume', self.region)
+        econn = vu.field.get_econn('cell', self.region)
         adc = create_adof_conn(nm.arange(vu.n_dof, dtype=nm.int32), econn, 6, 0)
         el_u = vec_u[adc]
 

--- a/sfepy/terms/terms_surface.py
+++ b/sfepy/terms/terms_surface.py
@@ -42,7 +42,7 @@ class LinearTractionTerm(Term):
                   {'opt_material' : 'D, 1'}, {'opt_material' : '1, 1'},
                   {'opt_material' : 'D, D'}, {'opt_material' : None}]
     modes = ('weak', 'eval')
-    integration = 'surface'
+    integration = 'facet'
 
     @staticmethod
     def d_fun(out, traction, val, sg):
@@ -127,7 +127,7 @@ class SDLinearTractionTerm(Term):
                    'parameter_mv': 'D'}, {'opt_material': '1, 1'},
                   {'opt_material': 'D, 1'}, {'opt_material': 'D, D'},
                   {'opt_material': None}]
-    integration = 'surface'
+    integration = 'facet'
 
     @staticmethod
     def d_fun(out, traction, val, grad_mv, div_mv, sg):
@@ -170,8 +170,8 @@ class SDLinearTractionTerm(Term):
         sg, _ = self.get_mapping(par_u)
 
         val = self.get(par_u, 'val')
-        grad_mv = self.get(par_mv, 'grad', integration='surface_extra')
-        div_mv = self.get(par_mv, 'div', integration='surface_extra')
+        grad_mv = self.get(par_mv, 'grad', integration='facet_extra')
+        div_mv = self.get(par_mv, 'div', integration='facet_extra')
 
         return traction, val, grad_mv, div_mv, sg
 
@@ -238,7 +238,7 @@ class ContactPlaneTerm(Term):
                   'material_a' : '.: D', 'material_b' : '.: N, D',
                   'virtual' : ('D', 'state'), 'state' : 'D'}
     geometries = ['3_4', '3_8']
-    integration = 'surface'
+    integration = 'facet'
 
     def __init__(self, *args, **kwargs):
         Term.__init__(self, *args, **kwargs)
@@ -389,7 +389,7 @@ class ContactSphereTerm(ContactPlaneTerm):
                   'material_r' : '.: 1',
                   'virtual' : ('D', 'state'), 'state' : 'D'}
     geometries = ['3_4', '3_8']
-    integration = 'surface'
+    integration = 'facet'
 
     def __init__(self, *args, **kwargs):
         Term.__init__(self, *args, **kwargs)
@@ -498,7 +498,7 @@ class SufaceNormalDotTerm(Term):
                  ('material', 'parameter'))
     arg_shapes = {'material' : 'D, 1', 'virtual' : (1, None), 'parameter' : 1}
     modes = ('weak', 'eval')
-    integration = 'surface'
+    integration = 'facet'
 
     @staticmethod
     def dw_fun(out, material, bf, sg):
@@ -558,7 +558,7 @@ class SDSufaceIntegrateTerm(Term):
     name = 'ev_sd_surface_integrate'
     arg_types = ('parameter', 'parameter_mv')
     arg_shapes = {'parameter': 1, 'parameter_mv': 'D'}
-    integration = 'surface'
+    integration = 'facet'
 
     @staticmethod
     def function(out, val_p, div_v, sg):
@@ -570,7 +570,7 @@ class SDSufaceIntegrateTerm(Term):
         sg, _ = self.get_mapping(par)
 
         val_p = self.get(par, 'val')
-        div_v = self.get(par_v, 'div', integration='surface_extra')
+        div_v = self.get(par_v, 'div', integration='facet_extra')
         return val_p, div_v, sg
 
     def get_eval_shape(self, par, par_v,
@@ -599,7 +599,7 @@ class SurfaceJumpTerm(Term):
     arg_shapes = [{'opt_material' : '1, 1', 'virtual' : (1, None),
                    'state_1' : 1, 'state_2' : 1},
                   {'opt_material' : None}]
-    integration = 'surface'
+    integration = 'facet'
 
     @staticmethod
     def function(out, jump, mul, bf1, bf2, sg, fmode):

--- a/sfepy/tests/test_ref_coors.py
+++ b/sfepy/tests/test_ref_coors.py
@@ -92,7 +92,7 @@ def test_ref_coors_iga():
                             approx_order='iga', poly_space_base='iga')
 
     mcoors = field.nurbs.cps
-    conn = field.get_econn('volume', field.region)
+    conn = field.get_econn('cell', field.region)
 
     bbox = domain.eval_mesh.get_bounding_box()
     ray = nm.linspace(bbox[0, 0], bbox[1, 0], 11)

--- a/sfepy/tests/test_term_call_modes.py
+++ b/sfepy/tests/test_term_call_modes.py
@@ -323,12 +323,15 @@ def test_term_call_modes(data):
                or (term_cls.name == "dw_ns_dot_grad_s"):
                 continue
 
-            if term_cls.integration == 'by_region':
-                rnames = ['Omega', 'Gamma']
-            else:
-                vint = ('volume', 'point', 'custom')
-                rnames = ['Omega'] if term_cls.integration in vint\
-                    else ['Gamma']
+            rnames = []
+            if ('cell' in term_cls.integration or
+                'point' in term_cls.integration or
+                'custom' in term_cls.integration):
+                rnames.append('Omega')
+
+            if ('facet' in term_cls.integration or
+                'facet_extra' in term_cls.integration):
+                rnames.append('Gamma')
 
             for rname in rnames:
                 tst.report('<-- %s.%s ...' % (term_cls.name, rname))


### PR DESCRIPTION
Done in this PR:
- integration modes `volume`, `surface` replaced by `cell`, `facet` names
- `surface_extra` changed to `facet_extra`
- region.kind is forced to be either `cell` or `facet`
