### PR TITLE
fix presolve in homogenization

### DIFF
--- a/sfepy/discrete/problem.py
+++ b/sfepy/discrete/problem.py
@@ -266,7 +266,8 @@ class Problem(Struct):
 
             if conf is None:
                 self.conf = Struct(options={}, ics={},
-                                   ebcs={}, epbcs={}, lcbcs={}, materials={})
+                                   ebcs={}, epbcs={}, lcbcs={}, materials={},
+                                   solvers={})
 
         self.equations = equations
         self.fields = fields

--- a/sfepy/examples/homogenization/homogenization_opt.py
+++ b/sfepy/examples/homogenization/homogenization_opt.py
@@ -149,6 +149,7 @@ def define(is_opt=False):
             'set_variables' : [('Pi', 'pis', 'u')],
             'class' : cb.CorrDimDim,
             'save_name' : 'corrs_le',
+            'is_linear': True,
         },
     }
 

--- a/sfepy/examples/homogenization/homogenization_opt.py
+++ b/sfepy/examples/homogenization/homogenization_opt.py
@@ -153,7 +153,7 @@ def define(is_opt=False):
     }
 
     solvers = {
-        'ls' : ('ls.scipy_direct', {}),
+        'ls' : ('ls.auto_direct', {'use_presolve' : True}),
         'newton' : ('nls.newton', {
             'i_max' : 1,
             'eps_a' : 1e-4,

--- a/sfepy/examples/homogenization/linear_homogenization.py
+++ b/sfepy/examples/homogenization/linear_homogenization.py
@@ -166,7 +166,7 @@ requirements = {
 }
 
 solvers = {
-    'ls': ('ls.scipy_direct', {}),
+    'ls': ('ls.auto_direct', {'use_presolve' : True}),
     'newton': ('nls.newton', {
         'i_max': 1,
         'eps_a': 1e-4,

--- a/sfepy/examples/homogenization/linear_homogenization_up.py
+++ b/sfepy/examples/homogenization/linear_homogenization_up.py
@@ -195,7 +195,8 @@ requirements = {
 }
 
 solvers = {
-    'ls': ('ls.auto_iterative', {}),
+    'ls': ('ls.auto_direct', {'use_presolve' : True}),
+    # 'ls': ('ls.auto_iterative', {}),
     'newton': ('nls.newton', {
         'i_max': 1,
         'eps_a': 1e2,

--- a/sfepy/examples/homogenization/nonlinear_homogenization.py
+++ b/sfepy/examples/homogenization/nonlinear_homogenization.py
@@ -224,7 +224,7 @@ requirements = {
 }
 
 solvers = {
-    'ls': ('ls.scipy_direct', {}),
+    'ls': ('ls.auto_direct', {'use_presolve' : True}),
     'newton': ('nls.newton', {
         'i_max': 1,
         'eps_a': 1e-4,

--- a/sfepy/examples/homogenization/perfusion_micro.py
+++ b/sfepy/examples/homogenization/perfusion_micro.py
@@ -659,7 +659,7 @@ for ch, val in six.iteritems(pb_def['channels']):
             })
 
 solvers = {
-    'ls': ('ls.scipy_direct', {}),
+    'ls': ('ls.auto_direct', {'use_presolve' : True}),
     'newton': ('nls.newton', {
         'i_max': 1,
     })

--- a/sfepy/examples/homogenization/perfusion_micro.py
+++ b/sfepy/examples/homogenization/perfusion_micro.py
@@ -437,6 +437,7 @@ requirements = {
         'epbcs': [],
         'save_name': 'corrs_one_YM',
         'class': cb.CorrSetBCS,
+        'is_linear': True,
     },
 }
 
@@ -453,6 +454,7 @@ for ipm in ['p', 'm']:
                 },
             'class': cb.CorrOne,
             'save_name': 'corrs_%s_gamma_%s' % (pb_def['name'], ipm),
+            'is_linear': True,
         },
     })
 
@@ -552,6 +554,7 @@ for ch, val in six.iteritems(pb_def['channels']):
                 },
             'class': cb.CorrOne,
             'save_name': 'corrs_%s_eta%s' % (pb_def['name'], ch),
+            'is_linear': True,
         },
         'corrs_pi' + ch: {
             'requires': ['pis_' + ch],

--- a/sfepy/examples/homogenization/rs_correctors.py
+++ b/sfepy/examples/homogenization/rs_correctors.py
@@ -179,7 +179,7 @@ requirements = {
 ##
 # Solvers.
 solvers = {
-    'ls' : ('ls.scipy_direct', {}),
+    'ls' : ('ls.auto_direct', {'use_presolve' : True}),
     'newton' : ('nls.newton', {
         'i_max' : 1,
         'eps_a' : 1e-8,

--- a/sfepy/examples/multi_physics/piezo_elasticity_micro.py
+++ b/sfepy/examples/multi_physics/piezo_elasticity_micro.py
@@ -283,7 +283,7 @@ def define(eps0=1e-3, filename_mesh='meshes/3d/piezo_mesh_micro.vtk'):
             'set_variables': [('Pi_u', 'pis_u', 'u')],
             'class': cb.CorrDimDim,
             'save_name': 'corrs_rs',
-            'solvers': {'ls': 'ls_i', 'nls': 'ns_ea6'},
+            'solvers': {'ls': 'ls_d', 'nls': 'ns_ea6'},
         },
     }
 

--- a/sfepy/examples/multi_physics/piezo_elasticity_micro.py
+++ b/sfepy/examples/multi_physics/piezo_elasticity_micro.py
@@ -284,6 +284,7 @@ def define(eps0=1e-3, filename_mesh='meshes/3d/piezo_mesh_micro.vtk'):
             'class': cb.CorrDimDim,
             'save_name': 'corrs_rs',
             'solvers': {'ls': 'ls_d', 'nls': 'ns_ea6'},
+            'is_linear' : True,
         },
     }
 
@@ -315,6 +316,7 @@ def define(eps0=1e-3, filename_mesh='meshes/3d/piezo_mesh_micro.vtk'):
                 'class': cb.CorrOne,
                 'save_name': 'corrs_k' + sk,
                 'solvers': {'ls': 'ls_d', 'nls': 'ns_ea0'},
+                'is_linear' : True,
             },
         })
 

--- a/sfepy/examples/multi_physics/piezo_elasticity_micro.py
+++ b/sfepy/examples/multi_physics/piezo_elasticity_micro.py
@@ -215,7 +215,7 @@ def define(eps0=1e-3, filename_mesh='meshes/3d/piezo_mesh_micro.vtk'):
     }
 
     solvers = {
-        'ls_d': ('ls.scipy_direct', {}),
+        'ls_d': ('ls.auto_direct', {'use_presolve' : True}),
         'ls_i': ('ls.scipy_iterative', {}),
         'ns_ea6': ('nls.newton', {'eps_a': 1e6, 'eps_r': 1e-3,}),
         'ns_ea0': ('nls.newton', {'eps_a': 1e0, 'eps_r': 1e-3,}),

--- a/sfepy/examples/phononic/band_gaps_conf.py
+++ b/sfepy/examples/phononic/band_gaps_conf.py
@@ -331,6 +331,7 @@ class BandGapsConf(Struct):
                 'save_name' : self.corrs_save_names['corrs_rs'],
                 'is_linear' : True,
                 'class' : cb.CorrDimDim,
+                'is_linear' : True,
             },
         }
         return requirements

--- a/sfepy/examples/phononic/band_gaps_conf.py
+++ b/sfepy/examples/phononic/band_gaps_conf.py
@@ -105,7 +105,7 @@ class BandGapsConf(Struct):
 
     def define_solvers(self):
         solvers = {
-            'ls_d' : ('ls.scipy_direct', {}),
+            'ls_d' : ('ls.auto_direct', {'use_presolve' : True}),
             'ls_i' : ('ls.scipy_iterative', {
                 'method' : 'cg',
                 'i_max'      : 1000,

--- a/sfepy/homogenization/coefs_base.py
+++ b/sfepy/homogenization/coefs_base.py
@@ -72,22 +72,7 @@ class MiniAppBase(Struct):
         problem.init_solvers()
 
         if self.is_linear:
-            output('linear problem, trying to presolve...')
-            timer = Timer(start=True)
-
-            ev = problem.get_evaluator()
-
-            state = problem.create_state()
-            try:
-                mtx_a = ev.eval_tangent_matrix(state(), is_full=True)
-            except ValueError:
-                output('matrix evaluation failed, giving up...')
-                raise
-
             problem.set_linear(True)
-            problem.try_presolve(mtx_a)
-
-            output('...done in %.2f s' % timer.stop())
 
         else:
             problem.set_linear(False)

--- a/sfepy/homogenization/coefs_base.py
+++ b/sfepy/homogenization/coefs_base.py
@@ -70,12 +70,17 @@ class MiniAppBase(Struct):
 
         problem.set_conf_solvers(problem.conf.solvers, opts)
         problem.init_solvers()
+        problem.set_linear(self.is_linear)
 
         if self.is_linear:
-            problem.set_linear(True)
+            set_presolve = True
+            for v in problem.conf.solvers.values():
+                if v.kind.startswith('ls.') and hasattr(v, 'use_presolve'):
+                    set_presolve = False
 
-        else:
-            problem.set_linear(False)
+            ls_conf = problem.get_solver().nls.lin_solver.conf
+            if set_presolve and hasattr(ls_conf, 'use_presolve'):
+                ls_conf.use_presolve = True
 
     def _get_volume(self, volume):
         if isinstance(volume, dict):


### PR DESCRIPTION
Hi @vlukes, I have removed presolving from the MiniAppBase, as it is done in Problem.solve() anyway. Further optimizations are possible, e.g. trying the presolve only if a direct solver is selected.

What do you say to replacing the iterative solvers?