### PR TITLE
Fix some deprecations on NumPy 1.25 and newer setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -205,6 +205,7 @@ def setup_package():
         'scipy',
         'sympy',
         'tables',
+        'packaging',
     ]
 
     setup(

--- a/sfepy/discrete/fem/domain.py
+++ b/sfepy/discrete/fem/domain.py
@@ -134,7 +134,7 @@ class FEDomain(Domain):
                                 ori.roots, ori.vecs,
                                 ori.swap_from, ori.swap_to)
 
-                if nm.alltrue(flag == 0):
+                if nm.all(flag == 0):
                     if itry > 0: output('...corrected')
                     itry = -1
                     break

--- a/sfepy/discrete/fem/meshio.py
+++ b/sfepy/discrete/fem/meshio.py
@@ -1,7 +1,7 @@
 import sys
 from copy import copy
 from io import StringIO
-from pkg_resources import parse_version
+from packaging import version
 import numpy as nm
 
 from sfepy.base.base import (complex_types, dict_from_keys_init,
@@ -455,7 +455,7 @@ class MeshioLibIO(MeshIO):
          cell_sets) = self._create_out_data(mesh, out,
                                             format=self.file_format)
 
-        if parse_version(meshiolib.__version__) >= parse_version('4.0.3') and\
+        if version.parse(meshiolib.__version__) >= version.parse('4.0.3') and\
            ('-ascii' in self.file_format or '-binary' in self.file_format):
             self.file_format, ab_str = self.file_format.split('-')
             kwargs['binary'] = True if 'binary' in ab_str else False

--- a/sfepy/linalg/utils.py
+++ b/sfepy/linalg/utils.py
@@ -66,9 +66,9 @@ def dets_fast(a):
     out : array
         The output array with shape (m,): out[i] = det(a[i, :, :]).
     """
-    from pkg_resources import parse_version
+    from packaging import version
 
-    if parse_version(nm.__version__) >= parse_version('1.8'):
+    if version.parse(nm.__version__) >= version.parse('1.8'):
         return nm.linalg.det(a)
 
     else:


### PR DESCRIPTION
* replace `alltrue` with `all`
* replace `pkg_resources` with `packaging` 