### PR TITLE
Restrict Cython version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "ninja",
     "setuptools>=46.4",
     "wheel",
-	"Cython>=0.29.30",
+	"Cython>=0.29.30,<3.0",
     "matplotlib",
     "meshio",
     "numpy==1.20.*; python_version <= '3.9'", # meshio undeclared constraint.


### PR DESCRIPTION
Cython 3.0 came out this week. It changed the default language level, and hence broke our build. This should be better understood, but until then this PR provides a stopgap measure.