### PR TITLE
include spaces when joining cflags, configure_cppflags, configure_cflags

### DIFF
--- a/sfepy/config.py
+++ b/sfepy/config.py
@@ -40,7 +40,7 @@ def compose_system_compile_flags(is_posix: bool) -> list:
     cflags, configure_cppflags, configure_cflags = sysconfig.get_config_vars(
         'CFLAGS', 'CONFIGURE_CPPFLAGS', 'CONFIGURE_CFLAGS')
 
-    return (cflags + configure_cppflags + configure_cflags).split()
+    return (cflags + ' ' + configure_cppflags + ' ' + configure_cflags).split()
 
 
 class Config(object):


### PR DESCRIPTION
Otherwise builds can fail when all variables are being used and don't contain extra spaces.

e.g.:
```
    Change Dir: /home/stuekero/wheels/SfePy/test/sfepy-2023.2/_cmake_test_compile/build/CMakeFiles/CMakeTmp                                                                                                                                             
                                                                                                                                                                                                                                                        
    Run Build Command(s):/home/stuekero/wheels/SfePy/test/venv/lib/python3.10/site-packages/ninja/data/bin/ninja cmTC_73db5 && [1/2] Building C object CMakeFiles/cmTC_73db5.dir/testCCompiler.c.o                                                      
    FAILED: CMakeFiles/cmTC_73db5.dir/testCCompiler.c.o                                                                                                                                                                                                 
    /cvmfs/soft.computecanada.ca/easybuild/software/2020/Core/gcccore/9.3.0/bin/cc   -g -O2 -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -O2 -ftree-vectorize -march=core-avx2 -fno-math-errno -fPIC -O2 -ftree-vectorize -march=core
-avx2 -fno-math-errno -fPIC-I/cvmfs/soft.computecanada.ca/easybuild/software/2020/Core/libffi/3.3/include-O2 -ftree-vectorize -march=core-avx2 -fno-math-errno -fPIC -o CMakeFiles/cmTC_73db5.dir/testCCompiler.c.o -c /home/stuekero/wheels/SfePy/test/
sfepy-2023.2/_cmake_test_compile/build/CMakeFiles/CMakeTmp/testCCompiler.c                                                                                                                                                                              
    cc: error: unrecognized command line option ‘-fPIC-I/cvmfs/soft.computecanada.ca/easybuild/software/2020/Core/libffi/3.3/include-O2’                                                                                                                
    ninja: build stopped: subcommand failed.
```
