### PR TITLE
resview.py: fix different positions of single slot plots in pv_plot()

### DIFF
--- a/sfepy/scripts/resview.py
+++ b/sfepy/scripts/resview.py
@@ -426,6 +426,7 @@ def pv_plot(filenames, options, plotter=None, step=None,
                                      use_cache=use_cache)
 
         pipe = [steps[fstep].copy()]
+        pos_bnds = pipe[0].bounds
 
         if field in fields_map:  # subregion
             mat_val = fields_map[field]
@@ -478,9 +479,8 @@ def pv_plot(filenames, options, plotter=None, step=None,
             plot_info.append('warp=%s, factor=%.2e' % (warp, factor))
 
         position = opts.get('p', 0)  # determine plotting slot
-        bnds = pipe[-1].bounds
         if 'p' in opts:
-            size = nm.array(bnds[1::2]) - nm.array(bnds[::2])
+            size = nm.array(pos_bnds[1::2]) - nm.array(pos_bnds[::2])
             pipe.append(pipe[-1].copy())
             pos1 = position % options.max_plots
             pos2 = position // options.max_plots


### PR DESCRIPTION
E.g.
```
python3 sfepy/examples/homogenization/rs_correctors.py -n

sfepy-view -2 --max-plots=2 corrs_elastic.vtk -f uc_00:wuc_00:f10%:p0 1:vw:p0 uc_01:wuc_01:f10%:p1 1:vw:p1 uc_10:wuc_10:f10%:p2 1:vw:p2 uc_11:wuc_11:f10%:p3 1:vw:p3
```
did not work correctly.