### PR TITLE
Fix broken examples

### DIFF
--- a/sfepy/discrete/common/domain.py
+++ b/sfepy/discrete/common/domain.py
@@ -237,6 +237,8 @@ class Domain(Struct):
         region = visit_stack(self._region_stack, region_op,
                              region_leaf(self, self.regions, select,
                                          functions, tdim))
+        region.field_dim = tdim
+
         return region
 
     def create_region(self, name, select, kind='cell', parent=None,

--- a/sfepy/discrete/fem/fields_base.py
+++ b/sfepy/discrete/fem/fields_base.py
@@ -241,7 +241,9 @@ class FEField(Field):
         -----
         Assumes one cell type for the whole region!
         """
-        shape = parse_shape(shape, region.cmesh.tdim)
+        field_dim = region.field_dim if hasattr(region, 'field_dim')\
+            else region.domain.shape.dim
+        shape = parse_shape(shape, field_dim)
         Struct.__init__(self, name=name, dtype=dtype, shape=shape,
                         region=region)
         self.domain = self.region.domain
@@ -525,7 +527,7 @@ class FEField(Field):
         """
         region = self.domain.regions[region_name]
         shape = region.shape
-        dim = region.cmesh.tdim
+        dim = region.field_dim if hasattr(region, 'field_dim') else region.dim
 
         if integration is None:
             integration == region.kind

--- a/sfepy/examples/homogenization/nonlinear_homogenization.py
+++ b/sfepy/examples/homogenization/nonlinear_homogenization.py
@@ -74,8 +74,8 @@ def def_mat(ts, mode, coors, term, pb):
     state_u.set_data(
         pb.domain.get_mesh_coors(actual=True) - pb.domain.get_mesh_coors())
     state_u.field.clear_mappings()
-    family_data = pb.family_data(state_u, term.region,
-                                 term.integral, term.act_integration)
+    family_data = pb.family_data(state_u, term.region, term.integral,
+                                 term.geometry_types['u'])
 
     if len(state_u.field.mappings0) == 0:
         state_u.field.save_mappings()

--- a/sfepy/examples/homogenization/nonlinear_homogenization.py
+++ b/sfepy/examples/homogenization/nonlinear_homogenization.py
@@ -75,7 +75,7 @@ def def_mat(ts, mode, coors, term, pb):
         pb.domain.get_mesh_coors(actual=True) - pb.domain.get_mesh_coors())
     state_u.field.clear_mappings()
     family_data = pb.family_data(state_u, term.region, term.integral,
-                                 term.geometry_types['u'])
+                                 list(term.geometry_types.values())[0])
 
     if len(state_u.field.mappings0) == 0:
         state_u.field.save_mappings()

--- a/sfepy/examples/homogenization/nonlinear_hyperelastic_mM.py
+++ b/sfepy/examples/homogenization/nonlinear_hyperelastic_mM.py
@@ -80,8 +80,8 @@ def get_homog_mat(ts, coors, mode, term=None, problem=None, **kwargs):
     update_var = problem.conf.options.mesh_update_variables[0]
     state_u = problem.equations.variables[update_var]
     state_u.field.clear_mappings()
-    family_data = problem.family_data(state_u, term.region,
-                                      term.integral, term.act_integration)
+    family_data = problem.family_data(state_u, term.region, term.integral,
+                                      term.geometry_types['u'])
 
     mtx_f = family_data.mtx_f.reshape((coors.shape[0],)
                                       + family_data.mtx_f.shape[-2:])

--- a/sfepy/terms/terms.py
+++ b/sfepy/terms/terms.py
@@ -1115,7 +1115,8 @@ class Term(Struct):
         from sfepy.base.base import output
         from sfepy.mechanics.tensors import dim2sym
 
-        dim = self.region.tdim
+        dim = self.region.field_dim if hasattr(self.region, 'field_dim')\
+            else self.region.dim
         sym = dim2sym(dim)
 
         def _parse_scalar_shape(sh):


### PR DESCRIPTION
Introducing the new attribute `field_dim` in `Region` class fixes the issue #1035. But, in my opinion, this is not a clean solution. It would required a deeper revision of `dim`, `tdim` attributes of regions, fields, domains, etc.