### PR TITLE
fix ccontres.pyx: replace floating-point divisin by integer division

### DIFF
--- a/sfepy/mechanics/extmods/ccontres.pyx
+++ b/sfepy/mechanics/extmods/ccontres.pyx
@@ -166,7 +166,7 @@ def evaluate_contact_constraints(
 
     n = elementID.shape[0]
     nsd = X.shape[1]
-    ngp = GPs.shape[0] / n
+    ngp = GPs.shape[0] // n
     nsn = ISN.shape[0]
     nes = ISN.shape[1]
     nen = IEN.shape[1]


### PR DESCRIPTION
This PR fix the following compilation error:

```
Error compiling Cython file:
------------------------------------------------------------
...

    cdef int n, nsd, ngp, nsn, nes, nen

    n = elementID.shape[0]
    nsd = X.shape[1]
    ngp = GPs.shape[0] / n
                      ^
------------------------------------------------------------
```

cmake version 3.22.1
Cython version 0.29.28
gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
