### PR TITLE
better eigenvalue solver for modal_analysis_declarative.py

### DIFF
--- a/sfepy/examples/linear_elasticity/modal_analysis_declarative.py
+++ b/sfepy/examples/linear_elasticity/modal_analysis_declarative.py
@@ -15,7 +15,7 @@ wheelset.vtk. View the results using::
 
 The first six frequencies calculated by SfePy::
 
-  [11.287, 11.317, 34.432, 80.709, 80.901, 93.144]
+  [11.272, 11.322, 34.432, 80.711, 80.895, 93.149]
 
 The results of modal analysis performed in Ansys::
 

--- a/sfepy/examples/linear_elasticity/modal_analysis_declarative.py
+++ b/sfepy/examples/linear_elasticity/modal_analysis_declarative.py
@@ -98,9 +98,16 @@ def define(n_eigs=6, approx_order=1, density=7850., young=210e9, poisson=0.3):
         #     'which': 'sm',
         #     'eps': 1e-6,
         # }),
-        'eig': ('eig.primme', {
-            'which': 'SM',
+        #'eig': ('eig.primme', {
+        #    'which': 'SM',
+        #    'tol': 1e-8,
+        #}),
+        'eig': ('eig.scipy', {
+            'method': 'eigsh',
+            'which': 'LM',
+            'sigma': 0,
             'tol': 1e-8,
+            'maxiter': 1000,
         }),
     }
 


### PR DESCRIPTION
Hi!
I’ve noticed you added this nice modal analysis example.
I think the solver choice is not optimal for two reasons:
- primme is not builtin with scipy 
- most importantly, when using the eigsh solver for finding the lowest frequency mode, it is important to use the shift-invert sigma parameter set to 0 and to search for the largest magnitude eigenmodes (LM), something that took me a long time to find out and is essential when you want the solve to be fast. This is not documented anywhere else AFAIK and would thus be interesting for users of this example.

Hence my proposed changes.

Regards,
Florian