### PR TITLE
JAX-based hyperelastic terms proof of concept

### DIFF
--- a/sfepy/terms/terms_jax.py
+++ b/sfepy/terms/terms_jax.py
@@ -260,3 +260,132 @@ class MassADTerm(Term):
     def function(out, fun, fargs):
         out[:] = np.asarray(fun(*fargs).reshape(out.shape))
         return 0
+
+def _get_Eq(gu):
+    return 0.5 * (gu + gu.T + gu.T @ gu)
+
+def _get_E(bfg, cu):
+    gu = cu @ bfg.transpose((0, 2, 1)) # This does DBD.
+    val = jax.vmap(_get_Eq, in_axes=[0])(gu)
+    return val
+
+_get_dEv = jax.jacobian(_get_E, -1)
+
+def get_neohook_strain_energy(mu, C):
+    # (*) 0.5 *
+    dim = C.shape[-1]
+    trc  = jnp.trace(C)
+    if dim == 2:
+        trc += 1.0 # Plane strain.
+
+    W = mu * (jnp.linalg.det(C)**(-1.0/3.0) * trc - 3.0)
+    return W
+
+_get_neohook_stress_2pk = jax.grad(get_neohook_strain_energy, -1)
+
+def get_neohook_stress_2pk(mu, gu):
+    eye = np.eye(gu.shape[-1])
+    F = gu + eye
+    # (*) 2 *
+    S = _get_neohook_stress_2pk(mu, F.T @ F)
+    return S
+
+# This is very slow, worsens with problem size w.r.t. dw_tl_neohook and order 2
+# is out of memory.
+# @jax.jit
+def ceval_neohook0(mu, vbfg, ubfg, det, cu):
+    gu = cu @ ubfg.transpose((0, 2, 1)) # This does DBD.
+    stress = jax.vmap(get_neohook_stress_2pk, in_axes=[None, 0])(mu, gu)
+    dEv = _get_dEv(vbfg, cu) * det[..., None, None]
+    val = jnp.sum(stress[..., None, None] * dEv, axis=[0, 1, 2])
+    return val
+
+def get_neohook_strain_energy_f(mu, F):
+    dim = F.shape[-1]
+    trf = jnp.trace(F.T @ F)
+    if dim == 2:
+        trf += 1.0 # Plane strain
+
+    W = 0.5 * mu * (jnp.linalg.det(F)**(-2.0/3.0) * trf - 3.0)
+    return W
+
+_get_neohook_stress_1pk = jax.grad(get_neohook_strain_energy_f, -1)
+
+def get_neohook_stress_1pk(mu, gu):
+    eye = np.eye(gu.shape[-1])
+    F = gu + eye
+    S = _get_neohook_stress_1pk(mu, F)
+    return S
+
+# This is slow, improves with problem size w.r.t. sfepy and order 2 works, with
+# refine about 5x slower than sfepy.
+@jax.jit
+def ceval_neohook(mu, vbfg, ubfg, det, cu):
+    gu = cu @ ubfg.transpose((0, 2, 1)) # This does DBD.
+    stress = jax.vmap(get_neohook_stress_1pk, in_axes=[None, 0])(mu, gu)
+    vbfgd = vbfg * det
+    val = jnp.sum(stress @ vbfgd, axis=0)
+    return val
+
+eval_neohook = jax.jit(jax.vmap(ceval_neohook,
+                                in_axes=[None, 0, 0, 0, 0]))
+eval_jac_neohook = jax.jit(jax.vmap(jax.jacobian(ceval_neohook, -1),
+                                    in_axes=[None, 0, 0, 0, 0]))
+eval_mu_neohook = jax.jit(jax.vmap(jax.jacobian(ceval_neohook, 0),
+                                   in_axes=[None, 0, 0, 0, 0]))
+
+class NeoHookeanTLADTerm(Term):
+    r"""
+    Homogeneous Hyperelastic neo-Hookean term differentiable w.r.t. the
+    material parameter. Effective stress :math:`S_{ij} = \mu
+    J^{-\frac{2}{3}}(\delta_{ij} - \frac{1}{3}C_{kk}C_{ij}^{-1})`.
+
+    :Definition:
+
+    .. math::
+        \int_{\Omega} S_{ij}(\ul{u}) \delta E_{ij}(\ul{u};\ul{v})
+
+    :Arguments:
+        - material : :math:`\mu`
+        - virtual  : :math:`\ul{v}`
+        - state    : :math:`\ul{u}`
+    """
+    name = 'dw_tl_he_neohook_ad'
+    arg_types = ('material', 'virtual', 'state')
+    arg_shapes = {'material' : '1, 1', 'virtual' : ('D', 'state'),
+                  'state' : 'D'}
+    modes = ('weak',)
+    diff_info = {'material' : 1}
+    geometries = ['2_3', '2_4', '3_4', '3_8']
+
+    def get_fargs(self, material, virtual, state,
+                  mode=None, term_mode=None, diff_var=None, **kwargs):
+        vgmap, _ = self.get_mapping(virtual)
+        sgmap, _ = self.get_mapping(state)
+
+        vecu = state().reshape((-1, vgmap.dim))
+        econn = state.field.get_econn(self.integration, self.region)
+        # Transpose is required to have sfepy order (DBD).
+        cu = vecu[econn].transpose((0, 2, 1))
+
+        mu = material[0, 0, 0, 0]
+        if diff_var is None:
+            fun = eval_neohook
+
+        elif diff_var == state.name:
+            fun = eval_jac_neohook
+
+        elif diff_var == 'material':
+            fun = eval_mu_neohook
+
+        else:
+            raise ValueError
+
+        fargs = [mu, vgmap.bfg, sgmap.bfg, vgmap.det, cu]
+        fargs = [jax.device_put(val) for val in fargs]
+        return fun, fargs
+
+    @staticmethod
+    def function(out, fun, fargs):
+        out[:] = np.asarray(fun(*fargs).reshape(out.shape))
+        return 0

--- a/sfepy/tests/test_term_call_modes.py
+++ b/sfepy/tests/test_term_call_modes.py
@@ -11,7 +11,8 @@ filename_meshes = [data_dir + '/meshes/elements/%s_2.mesh' % geom
                    for geom in ['1_2', '2_3', '2_4', '3_4', '3_8', '3_2_4']]
 
 not_tested_terms = ['dw_ns_dot_grad_s',
-                    'dw_lin_spring', 'dw_lin_truss', 'ev_lin_truss_force']
+                    'dw_lin_spring', 'dw_lin_truss', 'ev_lin_truss_force',
+                    'dw_tl_he_ogden_ad']
 
 
 def make_term_args(arg_shapes, arg_kinds, arg_types, ats_mode, domain,


### PR DESCRIPTION
Even though the Ogden term in the matrix mode cannot be used for constant displacements (see the docstring),
one can use the new terms to verify the standard terms (cc @heczis). The derivatives w.r.t. material parameters work too, so use for in parameter  identification algorithms is possible.