### PR TITLE
scipy.eigsh: set linear solver

### DIFF
--- a/sfepy/examples/linear_elasticity/modal_analysis_declarative.py
+++ b/sfepy/examples/linear_elasticity/modal_analysis_declarative.py
@@ -107,7 +107,10 @@ def define(n_eigs=6, approx_order=1, density=7850., young=210e9, poisson=0.3):
             'which': 'LM',
             'sigma': 0,
             'tol': 1e-8,
-            'linear_solver': 'cholesky',
+            'linear_solver': 'splu',
+            # 'cholesky' solver is usually faster, but
+            # scikit-sparse package is reuired
+            # 'linear_solver': 'cholesky',
             'maxiter': 1000,
         }),
     }

--- a/sfepy/examples/linear_elasticity/modal_analysis_declarative.py
+++ b/sfepy/examples/linear_elasticity/modal_analysis_declarative.py
@@ -107,10 +107,10 @@ def define(n_eigs=6, approx_order=1, density=7850., young=210e9, poisson=0.3):
             'which': 'LM',
             'sigma': 0,
             'tol': 1e-8,
-            'linear_solver': 'splu',
+            'linear_solver': ('ls.mumps', {}),
             # 'cholesky' solver is usually faster, but
-            # scikit-sparse package is reuired
-            # 'linear_solver': 'cholesky',
+            # scikit-sparse package is required
+            # 'linear_solver': ('cholesky', {}),
             'maxiter': 1000,
         }),
     }

--- a/sfepy/examples/linear_elasticity/modal_analysis_declarative.py
+++ b/sfepy/examples/linear_elasticity/modal_analysis_declarative.py
@@ -107,10 +107,11 @@ def define(n_eigs=6, approx_order=1, density=7850., young=210e9, poisson=0.3):
             'which': 'LM',
             'sigma': 0,
             'tol': 1e-8,
-            'linear_solver': ('ls.mumps', {}),
-            # 'cholesky' solver is usually faster, but
-            # scikit-sparse package is required
-            # 'linear_solver': ('cholesky', {}),
+            'linear_solver': ('ls.scipy_superlu', {}),
+            # 'linear_solver': ('ls.cholesky', {}),
+            # 'linear_solver': ('ls.mumps', {}),
+            # 'ls.cholesky' and 'ls.mumps' linear solvers are much faster,
+            # but scikit-sparse package and MUMPS library are required
             'maxiter': 1000,
         }),
     }

--- a/sfepy/examples/linear_elasticity/modal_analysis_declarative.py
+++ b/sfepy/examples/linear_elasticity/modal_analysis_declarative.py
@@ -107,6 +107,7 @@ def define(n_eigs=6, approx_order=1, density=7850., young=210e9, poisson=0.3):
             'which': 'LM',
             'sigma': 0,
             'tol': 1e-8,
+            'linear_solver': 'cholesky',
             'maxiter': 1000,
         }),
     }

--- a/sfepy/solvers/eigen.py
+++ b/sfepy/solvers/eigen.py
@@ -76,8 +76,9 @@ class ScipyEigenvalueSolver(EigenvalueSolver):
             see :func:`scipy.sparse.linalg.eigs()`
             or :func:`scipy.sparse.linalg.eigsh()`. For dense problmes,
             only 'LM' and 'SM' can be used"""),
-        ('linear_solver', "{'cholesky', 'splu'}", None, False,
-         """The method used to construct a inverse linear operator. If None, the
+        ('linear_solver', "({'ls.cholesky', 'ls.mumps', ...}, ls_conf)",
+         None, False,
+         """The method used to construct an inverse linear operator. If None, the
             eigenvalue solver will solve the linear system internally."""),
         ('*', '*', None, False,
          'Additional parameters supported by the method.'),
@@ -125,8 +126,9 @@ class ScipyEigenvalueSolver(EigenvalueSolver):
                         ls_solvers[k] = v
 
                 fake_mtx_a = sps.csc_matrix(mtx_a.shape)
-                ls_conf = Struct(use_presolve=True)
-                ls = ls_solvers[conf.linear_solver](ls_conf)
+                solver_name, solver_conf = conf.linear_solver
+                ls_conf = Struct(use_presolve=True, **solver_conf)
+                ls = ls_solvers[solver_name](ls_conf)
                 ls.mtx = mtx_a
                 ls.presolve(mtx_a)
                 matvec = ls.__call__


### PR DESCRIPTION
Setting up a linear solver for matrix factorization can rapidly speed up the computation of eigenvalues:

- eigsh from Scipy : 2648s
- Octave: 214s
- Matlab: 224s
- **eigsh + cholesky: 62s**

See discussion under #1105.
