### PR TITLE
rename base -> basis in FE basis context

### DIFF
--- a/doc/problem_desc_file_long.rst
+++ b/doc/problem_desc_file_long.rst
@@ -53,11 +53,11 @@ Fields, long syntax::
             'region' : <region_name>,
             'approx_order' : <approx_order>,
             ['space' : <space>,]
-            ['poly_space_base' : <poly_space_base>,]
+            ['poly_space_basis' : <poly_space_basis>,]
         }
 
 see :ref:`User's Guide-Fields` for meaning of <data_type>, <shape>,
-<region_name>, <approx_order>, <space> and <>poly_space_base>.
+<region_name>, <approx_order>, <space> and <>poly_space_basis>.
 
 **Example**: scalar P1 elements in 2D on a region Omega::
 

--- a/doc/users_guide.rst
+++ b/doc/users_guide.rst
@@ -369,7 +369,7 @@ Fields correspond to FE spaces::
 
           fields = {
               <name> : (<data_type>, <shape>, <region_name>, <approx_order>,
-              [<space>, <poly_space_base>])
+              [<space>, <poly_space_basis>])
           }
 
 where
@@ -382,7 +382,7 @@ where
   * <approx_order> is the FE approximation order, e.g. 0, 1, 2, '1B' (1
     with bubble)
   * <space> is the function space
-  * <poly_space_base> is the basis of the FE (usually polynomial) space
+  * <poly_space_basis> is the basis of the FE (usually polynomial) space
 
 **Example**: scalar P1 elements in 2D on a region Omega::
 
@@ -398,7 +398,7 @@ The following approximation orders can be used:
   Optional bubble function enrichment is marked by 'B'.
 
 The implemented combinations of spaces and bases are listed below,
-the space column corresponds to <space>, the basis column to <poly_space_base>
+the space column corresponds to <space>, the basis column to <poly_space_basis>
 and region type to the field region type.
 
 .. include:: field_table.rst

--- a/sfepy/base/conf.py
+++ b/sfepy/base/conf.py
@@ -197,7 +197,7 @@ def transform_fields(adict):
         if isinstance(conf, tuple):
             c2 = tuple_to_conf(key, conf,
                                ['dtype', 'shape', 'region', 'approx_order',
-                                'space', 'poly_space_base'])
+                                'space', 'poly_space_basis'])
             if c2.dtype in dtypes:
                 c2.dtype = dtypes[c2.dtype]
             d2['field_%s__%d' % (c2.name, ii)] = c2

--- a/sfepy/discrete/common/fields.py
+++ b/sfepy/discrete/common/fields.py
@@ -87,7 +87,7 @@ class Field(Struct):
 
     @staticmethod
     def from_args(name, dtype, shape, region, approx_order=1,
-                  space='H1', poly_space_base='lagrange'):
+                  space='H1', poly_space_basis='lagrange'):
         """
         Create a Field subclass instance corresponding to a given space.
 
@@ -109,7 +109,7 @@ class Field(Struct):
             The FE approximation order, e.g. 0, 1, 2, '1B' (1 with bubble).
         space : str
             The function space name.
-        poly_space_base : str
+        poly_space_basis : str
             The name of polynomial space base.
 
         Notes
@@ -118,7 +118,7 @@ class Field(Struct):
         """
         conf = Struct(name=name, dtype=dtype, shape=shape, region=region.name,
                       approx_order=approx_order, space=space,
-                      poly_space_base=poly_space_base)
+                      poly_space_basis=poly_space_basis)
         return Field.from_conf(conf, {region.name : region})
 
     @staticmethod
@@ -141,13 +141,17 @@ class Field(Struct):
         table = Field._all
 
         space = conf.get('space', 'H1')
-        poly_space_base = conf.get('poly_space_base', 'lagrange')
+        if 'poly_space_base' in conf.to_dict(): # For backward compatibility.
+            poly_space_basis = conf.get('poly_space_base')
 
-        key = space + '_' + poly_space_base
+        else:
+            poly_space_basis = conf.get('poly_space_basis', 'lagrange')
+
+        key = space + '_' + poly_space_basis
 
         approx_order = parse_approx_order(conf.approx_order)
         ao, force_bubble, discontinuous = approx_order
-        if poly_space_base == 'constant':
+        if poly_space_basis == 'constant':
             discontinuous = False
 
         region = regions[conf.region]
@@ -180,7 +184,7 @@ class Field(Struct):
                         'An abstract Field method called!')
         aux = name.split('_')
         self.space = aux[1]
-        self.poly_space_base = aux[2]
+        self.poly_space_basis = aux[2]
 
     def clear_mappings(self, clear_all=False):
         """

--- a/sfepy/discrete/common/poly_spaces.py
+++ b/sfepy/discrete/common/poly_spaces.py
@@ -92,11 +92,11 @@ class PolySpace(Struct):
 
         self.bbox = nm.vstack((geometry.coors.min(0), geometry.coors.max(0)))
 
-    def eval_base(self, coors, diff=0, ori=None, force_axis=False,
-                  transform=None, suppress_errors=False, eps=1e-15):
+    def eval_basis(self, coors, diff=0, ori=None, force_axis=False,
+                   transform=None, suppress_errors=False, eps=1e-15):
         """
         Evaluate the basis or its first or second derivatives in points given
-        by coordinates. The real work is done in _eval_base() implemented in
+        by coordinates. The real work is done in _eval_basis() implemented in
         subclasses.
 
         Note that the second derivative code is a work-in-progress and only
@@ -148,9 +148,9 @@ class PolySpace(Struct):
                              % (self.geometry.dim, coors.shape[-1]))
 
         if (coors.ndim == 2):
-            base = self._eval_base(coors, diff=diff, ori=ori,
-                                   suppress_errors=suppress_errors,
-                                   eps=eps)
+            base = self._eval_basis(coors, diff=diff, ori=ori,
+                                    suppress_errors=suppress_errors,
+                                    eps=eps)
 
             if (base.ndim == 3) and force_axis:
                 base = base[None, ...]
@@ -168,9 +168,9 @@ class PolySpace(Struct):
                              bdim, self.n_nod), dtype=nm.float64)
 
             for ii, _coors in enumerate(coors):
-                base[ii] = self._eval_base(_coors, diff=diff, ori=ori,
-                                           suppress_errors=suppress_errors,
-                                           eps=eps)
+                base[ii] = self._eval_basis(_coors, diff=diff, ori=ori,
+                                            suppress_errors=suppress_errors,
+                                            eps=eps)
 
         if transform is not None:
             base = transform_basis(transform, base)

--- a/sfepy/discrete/dg/fields.py
+++ b/sfepy/discrete/dg/fields.py
@@ -203,8 +203,8 @@ class DGField(FEField):
         self.unravel_sol = get_unraveler(self.n_el_nod, self.n_cell)
 
         # integral
-        self.clear_qp_base()
-        self.clear_facet_qp_base()
+        self.clear_qp_basis()
+        self.clear_facet_qp_basis()
         if integral is None:
             self.integral = Integral("dg_fi", order = 2 * self.approx_order)
         else:
@@ -330,8 +330,8 @@ class DGField(FEField):
                                  len(nm.unique(cells)))[:, None]
         return coors
 
-    def clear_facet_qp_base(self):
-        """Clears facet_qp_base cache"""
+    def clear_facet_qp_basis(self):
+        """Clears facet_qp_basis cache"""
         self.facet_bf = {}
         self.facet_qp = None
         self.facet_whs = None
@@ -417,9 +417,9 @@ class DGField(FEField):
 
         return facet_qps, weights
 
-    def get_facet_base(self, derivative=False, base_only=False):
+    def get_facet_basis(self, derivative=False, basis_only=False):
         """
-        Returns values of base in facets quadrature points, data shape is a bit
+        Returns values of basis in facets quadrature points, data shape is a bit
         crazy right now:
             (number of qps, 1, n_el_facets, 1, n_el_nod)
         end for derivatine:
@@ -428,7 +428,7 @@ class DGField(FEField):
         Parameters
         ----------
         derivative: truthy or integer
-        base_only: do not return weights
+        basis_only: do not return weights
 
         Returns
         -------
@@ -462,7 +462,7 @@ class DGField(FEField):
                                   transform=self.basis_transform)
             self.facet_bf[diff] = facet_bf
 
-        if base_only:
+        if basis_only:
             return facet_bf
         else:
             return facet_bf, whs
@@ -710,8 +710,8 @@ class DGField(FEField):
             diff = 0
         unreduce_nod = int(not reduce_nod)
 
-        inner_base_vals, outer_base_vals, whs = \
-            self.get_both_facet_base_vals(state, region, derivative=derivative)
+        inner_basis_vals, outer_basis_vals, whs = \
+            self.get_both_facet_basis_vals(state, region, derivative=derivative)
         dofs = self.unravel_sol(state.data[0])
 
         n_qp = whs.shape[-1]
@@ -723,10 +723,10 @@ class DGField(FEField):
         inner_facet_vals = nm.zeros(outputs_shape)
         if unreduce_nod:
             inner_facet_vals[:] = nm.einsum('id...,idf...->ifd...',
-                                            dofs, inner_base_vals)
+                                            dofs, inner_basis_vals)
         else:
             inner_facet_vals[:] = nm.einsum('id...,id...->i...',
-                                            dofs, inner_base_vals)
+                                            dofs, inner_basis_vals)
 
         per_facet_neighbours = self.get_facet_neighbor_idx(region, state.eq_map)
 
@@ -736,12 +736,12 @@ class DGField(FEField):
                 outer_facet_vals[:, facet_n, :] = \
                     nm.einsum('id...,id...->id...',
                               dofs[per_facet_neighbours[:, facet_n, 0]],
-                              outer_base_vals[:, :, facet_n])
+                              outer_basis_vals[:, :, facet_n])
             else:
                 outer_facet_vals[:, facet_n, :] = \
                     nm.einsum('id...,id...->i...',
                               dofs[per_facet_neighbours[:, facet_n, 0]],
-                              outer_base_vals[:, :, facet_n])
+                              outer_basis_vals[:, :, facet_n])
 
         boundary_cells = nm.array(nm.where(per_facet_neighbours[:, :, 0] < 0)).T
         outer_facet_vals[boundary_cells[:, 0], boundary_cells[:, 1]] = 0.0
@@ -754,16 +754,16 @@ class DGField(FEField):
                     "outerfacets")
                 outer_facet_vals[ebc[:, 0], ebc[:, 1], :] = \
                     nm.einsum("id,id...->id...",
-                              ebc_vals, inner_base_vals[0, :, ebc[:, 1]])
+                              ebc_vals, inner_basis_vals[0, :, ebc[:, 1]])
             else:
                 #  fix flipping qp order to accomodate for
                 #  opposite facet orientation of neighbours
                 outer_facet_vals[ebc[:, 0], ebc[:, 1], :] = ebc_vals[:, ::-1]
 
-        # flip outer_facet_vals moved to get_both_facet_base_vals
+        # flip outer_facet_vals moved to get_both_facet_basis_vals
         return inner_facet_vals, outer_facet_vals, whs
 
-    def get_both_facet_base_vals(self, state, region, derivative=None):
+    def get_both_facet_basis_vals(self, state, region, derivative=None):
         """Returns values of the basis function in quadrature points on facets
         broadcasted to all cells inner to the element as well as outer ones
         along with weights for the qps broadcasted and transformed to elements.
@@ -781,8 +781,8 @@ class DGField(FEField):
 
         Returns
         -------
-        outer_facet_base_vals:
-        inner_facet_base_vals:
+        outer_facet_basis_vals:
+        inner_facet_basis_vals:
                  shape (n_cell, n_el_nod, n_el_facet, n_qp) or
                        (n_cell, n_el_nod, n_el_facet, dim, n_qp)
                  when derivative is True or 1
@@ -793,38 +793,38 @@ class DGField(FEField):
         else:
             diff = 0
 
-        facet_bf, whs = self.get_facet_base(derivative=derivative)
+        facet_bf, whs = self.get_facet_basis(derivative=derivative)
         n_qp = nm.shape(whs)[1]
         facet_vols = self.get_facet_vols(region)
         whs = facet_vols * whs[None, :, :, 0]
 
-        base_shape = (self.n_cell, self.n_el_nod, self.n_el_facets) + \
-                     (self.dim,) * diff + \
-                     (n_qp,)
-        inner_facet_base_vals = nm.zeros(base_shape)
-        outer_facet_base_vals = nm.zeros(base_shape)
+        basis_shape = (self.n_cell, self.n_el_nod, self.n_el_facets) + \
+                      (self.dim,) * diff + \
+                      (n_qp,)
+        inner_facet_basis_vals = nm.zeros(basis_shape)
+        outer_facet_basis_vals = nm.zeros(basis_shape)
 
         if derivative:
-            inner_facet_base_vals[:] = facet_bf[0, :, 0, :, :, :]\
+            inner_facet_basis_vals[:] = facet_bf[0, :, 0, :, :, :]\
                                                             .swapaxes(-2, -3).T
         else:
-            inner_facet_base_vals[:] = facet_bf[:, 0, :, 0, :].T
+            inner_facet_basis_vals[:] = facet_bf[:, 0, :, 0, :].T
 
         per_facet_neighbours = self.get_facet_neighbor_idx(region, state.eq_map)
 
         # numpy prepends shape resulting from multiple
         # indexing before remaining shape
         if derivative:
-            outer_facet_base_vals[:] = \
-                inner_facet_base_vals[0, :, per_facet_neighbours[:, :, 1]]\
+            outer_facet_basis_vals[:] = \
+                inner_facet_basis_vals[0, :, per_facet_neighbours[:, :, 1]]\
                     .swapaxes(-3, -4)
         else:
-            outer_facet_base_vals[:] = \
-                inner_facet_base_vals[0, :, per_facet_neighbours[:, :, 1]]\
+            outer_facet_basis_vals[:] = \
+                inner_facet_basis_vals[0, :, per_facet_neighbours[:, :, 1]]\
                     .swapaxes(-2, -3)
 
         # fix to flip facet QPs for right integration order
-        return inner_facet_base_vals, outer_facet_base_vals[..., ::-1], whs
+        return inner_facet_basis_vals, outer_facet_basis_vals[..., ::-1], whs
 
     def clear_normals_cache(self, region=None):
         """Clears normals cache for given region or all regions.
@@ -1186,17 +1186,17 @@ class DGField(FEField):
             qp, weights = self.integral.get_qp(self.gel.name)
             coors = self.mapping.get_physical_qps(qp)
 
-            base_vals_qp = self.poly_space.eval_basis(qp)[:, 0, :]
+            basis_vals_qp = self.poly_space.eval_basis(qp)[:, 0, :]
             # this drops redundant axis that is returned by eval_basis due to
             # consistency with derivatives
 
             # left hand, so far only orthogonal basis
-            # for legendre base this can be calculated exactly
+            # for legendre basis this can be calculated exactly
             # in 1D it is: 1 / (2 * nm.arange(self.n_el_nod) + 1)
-            lhs_diag = nm.einsum("q,q...->...", weights, base_vals_qp ** 2)
+            lhs_diag = nm.einsum("q,q...->...", weights, basis_vals_qp ** 2)
 
             rhs_vec = nm.einsum("q,q...,iq...->i...",
-                                weights, base_vals_qp, fun(coors))
+                                weights, basis_vals_qp, fun(coors))
 
             vals = (rhs_vec / lhs_diag)
 
@@ -1269,16 +1269,17 @@ class DGField(FEField):
             bcoors = coors[bc2bfi[:, 1], ::-1, bc2bfi[:, 0], :]
 
             # get facet basis vals
-            base_vals_qp = self.poly_space.eval_basis(qp)[:, 0, 0, :]
+            basis_vals_qp = self.poly_space.eval_basis(qp)[:, 0, 0, :]
 
             # solve for boundary cell DOFs
             bc_val = fun(bcoors)
             # this returns singular matrix - projection on the boundary should
             # be into facet dim space
-            #lhs = nm.einsum("q,qd,qc->dc", weights, base_vals_qp, base_vals_qp)
+            #lhs = nm.einsum("q,qd,qc->dc", weights, basis_vals_qp,
+            #                basis_vals_qp)
             # inv_lhs = nm.linalg.inv(lhs)
             # rhs_vec = nm.einsum("q,q...,iq...->i...",
-            #                       weights, base_vals_qp, bc_val)
+            #                       weights, basis_vals_qp, bc_val)
 
         return nods, vals
 
@@ -1383,10 +1384,10 @@ class DGField(FEField):
         if ref_nodes is None:
             # poly_space could provide special nodes
             ref_nodes = self.get_qp('v', self.integral).vals
-        base_vals_node = self.poly_space.eval_basis(ref_nodes)[:, 0, :]
+        basis_vals_node = self.poly_space.eval_basis(ref_nodes)[:, 0, :]
         dofs = self.unravel_sol(dofs[:, 0])
 
-        nodal_vals = nm.sum(dofs * base_vals_node.T, axis=1)
+        nodal_vals = nm.sum(dofs * basis_vals_node.T, axis=1)
         nodes = self.mapping.get_physical_qps(ref_nodes)
 
         # import matplotlib.pyplot as plt

--- a/sfepy/discrete/dg/fields.py
+++ b/sfepy/discrete/dg/fields.py
@@ -1091,7 +1091,7 @@ class DGField(FEField):
 
             geo_ps = self.gel.poly_space
             ps = self.poly_space
-            bf = self.get_base('v', 0, integral, iels=iels)
+            bf = self.eval_basis('v', 0, integral, iels=iels)
 
             conn = nm.take(dconn, iels.astype(nm.int32), axis=0)
             mapping = FEMapping(coors, conn, poly_space=geo_ps)

--- a/sfepy/discrete/dg/fields.py
+++ b/sfepy/discrete/dg/fields.py
@@ -229,7 +229,7 @@ class DGField(FEField):
     def _create_interpolant(self):
         name = self.gel.name + '_DG_legendre'
         ps = PolySpace.any_from_args(name, self.gel, self.approx_order,
-                                     base=self.poly_space_basis,
+                                     basis=self.poly_space_basis,
                                      force_bubble=False)
         self.poly_space = ps
         # 'legendre_simplex' is created for '1_2'.

--- a/sfepy/discrete/dg/fields.py
+++ b/sfepy/discrete/dg/fields.py
@@ -143,7 +143,7 @@ class DGField(FEField):
     is_surface = False
 
     def __init__(self, name, dtype, shape, region, space="H1",
-                 poly_space_base="legendre", approx_order=1, integral=None):
+                 poly_space_basis="legendre", approx_order=1, integral=None):
         """
         Creates DGField, with Legendre polyspace and default integral
         corresponding to 2 * approx_order.
@@ -163,7 +163,7 @@ class DGField(FEField):
         space : string
             default "H1"
 
-        poly_space_base : PolySpace
+        poly_space_basis : PolySpace
             optionally force polyspace
 
         approx_order : 0 for FVM, default 1
@@ -191,7 +191,7 @@ class DGField(FEField):
 
         # approximation space
         self.space = space
-        self.poly_space_base = poly_space_base
+        self.poly_space_basis = poly_space_basis
         self.force_bubble = False
         self._create_interpolant()
 
@@ -229,7 +229,7 @@ class DGField(FEField):
     def _create_interpolant(self):
         name = self.gel.name + '_DG_legendre'
         ps = PolySpace.any_from_args(name, self.gel, self.approx_order,
-                                     base=self.poly_space_base,
+                                     base=self.poly_space_basis,
                                      force_bubble=False)
         self.poly_space = ps
         # 'legendre_simplex' is created for '1_2'.

--- a/sfepy/discrete/dg/fields.py
+++ b/sfepy/discrete/dg/fields.py
@@ -458,8 +458,8 @@ class DGField(FEField):
 
             for i in range(self.n_el_facets):
                 facet_bf[..., i, :, :] = \
-                    ps.eval_base(qps[..., i, :], diff=diff,
-                                 transform=self.basis_transform)
+                    ps.eval_basis(qps[..., i, :], diff=diff,
+                                  transform=self.basis_transform)
             self.facet_bf[diff] = facet_bf
 
         if base_only:
@@ -1186,8 +1186,8 @@ class DGField(FEField):
             qp, weights = self.integral.get_qp(self.gel.name)
             coors = self.mapping.get_physical_qps(qp)
 
-            base_vals_qp = self.poly_space.eval_base(qp)[:, 0, :]
-            # this drops redundant axis that is returned by eval_base due to
+            base_vals_qp = self.poly_space.eval_basis(qp)[:, 0, :]
+            # this drops redundant axis that is returned by eval_basis due to
             # consistency with derivatives
 
             # left hand, so far only orthogonal basis
@@ -1269,7 +1269,7 @@ class DGField(FEField):
             bcoors = coors[bc2bfi[:, 1], ::-1, bc2bfi[:, 0], :]
 
             # get facet basis vals
-            base_vals_qp = self.poly_space.eval_base(qp)[:, 0, 0, :]
+            base_vals_qp = self.poly_space.eval_basis(qp)[:, 0, 0, :]
 
             # solve for boundary cell DOFs
             bc_val = fun(bcoors)
@@ -1383,7 +1383,7 @@ class DGField(FEField):
         if ref_nodes is None:
             # poly_space could provide special nodes
             ref_nodes = self.get_qp('v', self.integral).vals
-        base_vals_node = self.poly_space.eval_base(ref_nodes)[:, 0, :]
+        base_vals_node = self.poly_space.eval_basis(ref_nodes)[:, 0, :]
         dofs = self.unravel_sol(dofs[:, 0])
 
         nodal_vals = nm.sum(dofs * base_vals_node.T, axis=1)

--- a/sfepy/discrete/dg/poly_spaces.py
+++ b/sfepy/discrete/dg/poly_spaces.py
@@ -71,7 +71,6 @@ def get_n_el_nod(order, dim, extended=False):
 
     .. math::
         N_p =  \frac{(n + 1) \cdot (n + 2) \cdot ... \cdot (n + d)}{d!}
-    
 
     where `n` is the order and `d` the dimension.
     When extended is True
@@ -127,8 +126,8 @@ class LegendrePolySpace(PolySpace):
         self.coefM = None
         self.expoM = None
 
-    def _eval_base(self, coors, diff=0, ori=None,
-                   suppress_errors=False, eps=1e-15):
+    def _eval_basis(self, coors, diff=0, ori=None,
+                    suppress_errors=False, eps=1e-15):
         """Calls _combine_polyvals or _combine_polyvals_diff to build
         multidimensional basis implemented in subclasses to get basis for
         different geometries expects coors to be in shape
@@ -193,7 +192,7 @@ class LegendrePolySpace(PolySpace):
         is written as a linear  combination of d basis functions
         :math:`f_i, i=0, ..., n-1` (the coefficients being stored
         in list-of-values).
-        
+
         Defining
 
         .. math ::
@@ -206,7 +205,7 @@ class LegendrePolySpace(PolySpace):
         coordinates in the element's parameter space), then val-coef-matrix
         denotes the n x n matrix F and val-exp-matrix denotes the n x 3 matrix P
         where n is number of basis functions as calculated by ``get_n_el_nod``.
-        
+
         Expects matrices to be saved in atributes coefM and expoM!
 
         .. [1] Remacle, J.-F., Chevaugeon, N., Marchandise, E., & Geuzaine, C.
@@ -228,7 +227,8 @@ class LegendrePolySpace(PolySpace):
 
     @abstractmethod
     def _combine_polyvals(self, coors, polyvals, idx):
-        """Combines Legendre or Jacobi polynomials to get muldidimensional
+        """
+        Combines Legendre or Jacobi polynomials to get muldidimensional
         basis values according to element topolgy
 
         Parameters
@@ -236,9 +236,10 @@ class LegendrePolySpace(PolySpace):
         coors : array_like
             coordinates of evaluation points
         polyvals : array_like
-            values of legendre polynomials precomputed in _eval_base
+            values of legendre polynomials precomputed in _eval_basis
         idx : tuple
-            function index, for tensor-product correspond to orders of polynomials in variables
+            function index, for tensor-product correspond to orders of
+            polynomials in variables
 
         Returns
         -------
@@ -255,7 +256,7 @@ class LegendrePolySpace(PolySpace):
         coors : array_like
             coordinates of evaluation points
         polyvals : array_like
-            values of legendre polynomials precomputed in _eval_base
+            values of legendre polynomials precomputed in _eval_basis
         der : int
             derivative variable
         idx : tuple
@@ -371,7 +372,7 @@ class LegendrePolySpace(PolySpace):
             Parameters
             ----------
             x :
-                
+
 
             Returns
             -------
@@ -400,7 +401,7 @@ class LegendrePolySpace(PolySpace):
         coors : array_like
         beta : float
         alpha : float
-            
+
 
         Returns
         -------

--- a/sfepy/discrete/evaluate.py
+++ b/sfepy/discrete/evaluate.py
@@ -382,7 +382,7 @@ def eval_in_els_and_qp(expression, iels, coors,
 
     for field in six.itervalues(fields):
         field.clear_mappings(clear_all=True)
-        field.clear_qp_base()
+        field.clear_qp_basis()
 
     aux = create_evaluable(expression, fields, materials,
                            variables.itervalues(), Integrals([integral]),

--- a/sfepy/discrete/fem/fields_base.py
+++ b/sfepy/discrete/fem/fields_base.py
@@ -93,7 +93,7 @@ def eval_nodal_coors(coors, mesh_coors, region, poly_space, geom_poly_space,
         qp_coors = poly_space.node_coors
 
     ##
-    # Evaluate geometry interpolation base functions in (extra) nodes.
+    # Evaluate geometry interpolation basis functions in (extra) nodes.
     bf = geom_poly_space.eval_basis(qp_coors)
     bf = bf[:, 0, :].copy()
 
@@ -239,10 +239,10 @@ class FEField(Field):
 
     Field shape information:
 
-    - ``shape`` - the shape of the base functions in a point
+    - ``shape`` - the shape of the basis functions in a point
     - ``n_components`` - the number of DOFs per FE node
     - ``val_shape`` - the shape of field value (the product of DOFs and
-      base functions) in a point
+      basis functions) in a point
     """
 
     def __init__(self, name, dtype, shape, region, approx_order=1):
@@ -258,7 +258,7 @@ class FEField(Field):
         shape : int/tuple/str
             The field shape: 1 or (1,) or 'scalar', space dimension (2, or (2,)
             or 3 or (3,)) or 'vector', or a tuple. The field shape determines
-            the shape of the FE base functions and is related to the number of
+            the shape of the FE basis functions and is related to the number of
             components of variables and to the DOF per node count, depending
             on the field kind.
         region : Region
@@ -287,10 +287,10 @@ class FEField(Field):
         self.extra_data = {}
         self.ori = None
         self._create_interpolant()
-        self._setup_global_base()
+        self._setup_global_basis()
         self.setup_coors()
         self.clear_mappings(clear_all=True)
-        self.clear_qp_base()
+        self.clear_qp_basis()
         self.basis_transform = None
         self.econn0 = None
         self.unused_dofs = None
@@ -344,9 +344,9 @@ class FEField(Field):
         """
         return self.force_bubble or (self.approx_order > 1)
 
-    def _setup_global_base(self):
+    def _setup_global_basis(self):
         """
-        Setup global DOF/base functions, their indices and connectivity of the
+        Setup global DOF/basis functions, their indices and connectivity of the
         field. Called methods implemented in subclasses.
         """
         self._setup_facet_orientations()
@@ -606,9 +606,9 @@ class FEField(Field):
 
         return dofs
 
-    def clear_qp_base(self):
+    def clear_qp_basis(self):
         """
-        Remove cached quadrature points and base functions.
+        Remove cached quadrature points and basis functions.
         """
         self.qp_coors = {}
         self.bf = {}
@@ -722,7 +722,7 @@ class FEField(Field):
         return vec.ravel()
 
     def eval_basis(self, key, derivative, integral, iels=None,
-                   from_geometry=False, base_only=True):
+                   from_geometry=False, basis_only=True):
         qp = self.get_qp(key, integral)
 
         if from_geometry:
@@ -743,7 +743,7 @@ class FEField(Field):
         if iels is not None and bf.ndim == 4:
             bf = bf[iels]
 
-        if base_only:
+        if basis_only:
             return bf
 
         else:
@@ -1220,9 +1220,9 @@ class FEField(Field):
         """
         Create a new reference mapping.
 
-        Compute jacobians, element volumes and base function derivatives
+        Compute jacobians, element volumes and basis function derivatives
         for Volume-type geometries (volume mappings), and jacobians,
-        normals and base function derivatives for Surface-type
+        normals and basis function derivatives for Surface-type
         geometries (surface mappings).
 
         Notes

--- a/sfepy/discrete/fem/fields_base.py
+++ b/sfepy/discrete/fem/fields_base.py
@@ -310,10 +310,10 @@ class FEField(Field):
 
     def _create_interpolant(self):
         name = '%s_%s_%s_%d%s' % (self.gel.name, self.space,
-                                  self.poly_space_base, self.approx_order,
+                                  self.poly_space_basis, self.approx_order,
                                   'B' * self.force_bubble)
         ps = PolySpace.any_from_args(name, self.gel, self.approx_order,
-                                     base=self.poly_space_base,
+                                     base=self.poly_space_basis,
                                      force_bubble=self.force_bubble)
         self.poly_space = ps
 

--- a/sfepy/discrete/fem/fields_base.py
+++ b/sfepy/discrete/fem/fields_base.py
@@ -313,7 +313,7 @@ class FEField(Field):
                                   self.poly_space_basis, self.approx_order,
                                   'B' * self.force_bubble)
         ps = PolySpace.any_from_args(name, self.gel, self.approx_order,
-                                     base=self.poly_space_basis,
+                                     basis=self.poly_space_basis,
                                      force_bubble=self.force_bubble)
         self.poly_space = ps
 

--- a/sfepy/discrete/fem/fields_base.py
+++ b/sfepy/discrete/fem/fields_base.py
@@ -94,7 +94,7 @@ def eval_nodal_coors(coors, mesh_coors, region, poly_space, geom_poly_space,
 
     ##
     # Evaluate geometry interpolation base functions in (extra) nodes.
-    bf = geom_poly_space.eval_base(qp_coors)
+    bf = geom_poly_space.eval_basis(qp_coors)
     bf = bf[:, 0, :].copy()
 
     ##
@@ -736,8 +736,8 @@ class FEField(Field):
 
         if bf_key not in self.bf:
             ori = self.ori
-            self.bf[bf_key] = ps.eval_base(qp.vals, diff=derivative, ori=ori,
-                                           transform=self.basis_transform)
+            self.bf[bf_key] = ps.eval_basis(qp.vals, diff=derivative, ori=ori,
+                                            transform=self.basis_transform)
 
         bf = self.bf[bf_key]
         if iels is not None and bf.ndim == 4:
@@ -758,7 +758,7 @@ class FEField(Field):
             qp = self.get_qp(sd.face_type, integral)
 
             ps_s = self.gel.surface_facet.poly_space
-            bf_s = ps_s.eval_base(qp.vals)
+            bf_s = ps_s.eval_basis(qp.vals)
 
             coors, faces = gel.coors, gel.get_surface_entities()
 
@@ -775,7 +775,7 @@ class FEField(Field):
             qp = self.get_qp(face_type, integral)
 
             ps_s = self.gel.surface_facet[bkey].poly_space
-            bf_s = ps_s.eval_base(qp.vals)
+            bf_s = ps_s.eval_basis(qp.vals)
 
             coors, faces = gel.coors, gel.get_surface_entities()
 
@@ -1321,7 +1321,7 @@ class FEField(Field):
 
                         fc_map[fc_map == -bkey] = ikey
 
-                    abf = ps.eval_base(qp.vals, transform=transform)
+                    abf = ps.eval_basis(qp.vals, transform=transform)
                     bf = nm.zeros((nfc, nqp, 1, max(bkeys)), dtype=nm.float64)
                     for ifc, efc in enumerate(self.efaces):
                         bkey = efc_map[ifc]
@@ -1338,7 +1338,7 @@ class FEField(Field):
                     self.create_bqp(region.name, integral)
                     qp = self.qp_coors[(integral.order, esd.bkey)]
 
-                    abf = ps.eval_base(qp.vals[0], transform=transform)
+                    abf = ps.eval_basis(qp.vals[0], transform=transform)
                     bf = abf[..., self.efaces[0]]
 
                     indx = self.gel.get_surface_entities()[0]
@@ -1347,7 +1347,7 @@ class FEField(Field):
                     mapping.set_basis_indices(indx)
 
                     if integration == 'facet_extra':
-                        se_bf_bg = geo_ps.eval_base(qp.vals, diff=True)
+                        se_bf_bg = geo_ps.eval_basis(qp.vals, diff=True)
                         se_bf_bg = se_bf_bg[sd.fis[:, 1]]
                         se_ebf_bg = self.eval_basis(esd.bkey, 1, integral)
                         se_ebf_bg = se_ebf_bg[sd.fis[:, 1]]
@@ -1362,7 +1362,7 @@ class FEField(Field):
             else:
                 # Do not use BQP for surface fields.
                 qp = self.get_qp(sd.face_type, integral)
-                bf = ps.eval_base(qp.vals, transform=transform)
+                bf = ps.eval_basis(qp.vals, transform=transform)
 
                 out = mapping.get_mapping(qp.vals, qp.weights, bf,
                                           is_face=True)

--- a/sfepy/discrete/fem/fields_base.py
+++ b/sfepy/discrete/fem/fields_base.py
@@ -694,7 +694,7 @@ class FEField(Field):
         """
         Set local element basis transformation.
 
-        The basis transformation is applied in :func:`FEField.get_base()` and
+        The basis transformation is applied in :func:`FEField.eval_basis()` and
         :func:`FEField.create_mapping()`.
 
         Parameters
@@ -721,8 +721,8 @@ class FEField(Field):
 
         return vec.ravel()
 
-    def get_base(self, key, derivative, integral, iels=None,
-                 from_geometry=False, base_only=True):
+    def eval_basis(self, key, derivative, integral, iels=None,
+                   from_geometry=False, base_only=True):
         qp = self.get_qp(key, integral)
 
         if from_geometry:
@@ -1075,7 +1075,7 @@ class FEField(Field):
         """
         integral = Integral('i', order=self.approx_order)
 
-        bf = self.get_base('v', False, integral)
+        bf = self.eval_basis('v', False, integral)
         bf = bf[:, 0, :].copy()
 
         data_qp = nm.dot(bf, dofs[self.econn])
@@ -1242,7 +1242,7 @@ class FEField(Field):
 
         if region.kind == 'cell':
             qp = self.get_qp('v', integral)
-            bf = self.get_base('v', 0, integral, iels=iels)
+            bf = self.eval_basis('v', 0, integral, iels=iels)
 
             dconn = domain.get_conn(tdim=region.tdim, cells=iels)
             mapping = FEMapping(coors, dconn, poly_space=geo_ps)
@@ -1349,7 +1349,7 @@ class FEField(Field):
                     if integration == 'facet_extra':
                         se_bf_bg = geo_ps.eval_base(qp.vals, diff=True)
                         se_bf_bg = se_bf_bg[sd.fis[:, 1]]
-                        se_ebf_bg = self.get_base(esd.bkey, 1, integral)
+                        se_ebf_bg = self.eval_basis(esd.bkey, 1, integral)
                         se_ebf_bg = se_ebf_bg[sd.fis[:, 1]]
                         remap = prepare_remap(cells, cells.max() + 1)
                         se_conn = dconn[remap[sd.fis[:, 0]], :]

--- a/sfepy/discrete/fem/fields_l2.py
+++ b/sfepy/discrete/fem/fields_l2.py
@@ -156,8 +156,8 @@ class L2ConstantVolumeField(Field):
         """
         return nm.zeros(1, dtype=nm.int32)
 
-    def get_base(self, key, derivative, integral, iels=None,
-                 from_geometry=False, base_only=True):
+    def eval_basis(self, key, derivative, integral, iels=None,
+                   from_geometry=False, base_only=True):
         qp_coors, qp_weights = integral.get_qp(self.gel.name)
         ps = self.poly_space
         bf = ps.eval_base(qp_coors)

--- a/sfepy/discrete/fem/fields_l2.py
+++ b/sfepy/discrete/fem/fields_l2.py
@@ -160,7 +160,7 @@ class L2ConstantVolumeField(Field):
                    from_geometry=False, base_only=True):
         qp_coors, qp_weights = integral.get_qp(self.gel.name)
         ps = self.poly_space
-        bf = ps.eval_base(qp_coors)
+        bf = ps.eval_basis(qp_coors)
         if key[0] == 'b': # BQP
             num = 6 if self.gel.n_vertex == 4 else 4
             bf = nm.tile(bf, (num, 1, 1, 1))
@@ -182,7 +182,7 @@ class L2ConstantVolumeField(Field):
             geo_ps = self.gel.poly_space
             dconn = domain.get_conn(tdim=region.tdim, cells=iels)
             qp_coors, qp_weights = integral.get_qp(self.gel.name)
-            bf = ps.eval_base(qp_coors)
+            bf = ps.eval_basis(qp_coors)
 
         elif integration in ('facet', 'facet_extra'):
             if self.is_surface:
@@ -199,7 +199,7 @@ class L2ConstantVolumeField(Field):
             sd = domain.surface_groups[region.name]
             dconn = sd.get_connectivity()
             qp_coors, qp_weights = integral.get_qp(gel.name)
-            bf = ps.eval_base(qp_coors)
+            bf = ps.eval_basis(qp_coors)
 
         mapping = FEMapping(coors, dconn, poly_space=geo_ps)
         out = mapping.get_mapping(qp_coors, qp_weights, bf, poly_space=ps,

--- a/sfepy/discrete/fem/fields_l2.py
+++ b/sfepy/discrete/fem/fields_l2.py
@@ -63,7 +63,7 @@ class L2ConstantVolumeField(Field):
         name = '%s_%s_%s_%d' % (self.gel.name, self.space,
                                 self.poly_space_basis, self.approx_order)
         ps = PolySpace.any_from_args(name, self.gel, self.approx_order,
-                                     base='lagrange')
+                                     basis='lagrange')
         self.poly_space = ps
 
     def setup_extra_data(self, info):
@@ -192,7 +192,7 @@ class L2ConstantVolumeField(Field):
             else:
                 gel = self.gel.surface_facet
                 ps = PolySpace.any_from_args('aux', gel, self.approx_order,
-                                             base='lagrange')
+                                             basis='lagrange')
 
             geo_ps = gel.poly_space
             domain.create_surface_group(region)

--- a/sfepy/discrete/fem/fields_l2.py
+++ b/sfepy/discrete/fem/fields_l2.py
@@ -61,7 +61,7 @@ class L2ConstantVolumeField(Field):
 
     def _create_interpolant(self):
         name = '%s_%s_%s_%d' % (self.gel.name, self.space,
-                                self.poly_space_base, self.approx_order)
+                                self.poly_space_basis, self.approx_order)
         ps = PolySpace.any_from_args(name, self.gel, self.approx_order,
                                      base='lagrange')
         self.poly_space = ps

--- a/sfepy/discrete/fem/fields_nodal.py
+++ b/sfepy/discrete/fem/fields_nodal.py
@@ -315,7 +315,7 @@ class H1NodalMixin(H1Mixin, GlobalNodalLikeBasis):
         integral = Integral('i', coors=coors, weights=nm.ones_like(coors[:, 0]))
 
         rcfield.clear_qp_base()
-        bf = rcfield.get_base('v', False, integral)
+        bf = rcfield.eval_basis('v', False, integral)
 
         if gel.name == '2_4':
             fsubs = subs

--- a/sfepy/discrete/fem/fields_nodal.py
+++ b/sfepy/discrete/fem/fields_nodal.py
@@ -418,7 +418,7 @@ class H1NodalVolumeField(H1NodalMixin, FEField):
 
             coors = self.poly_space.node_coors
 
-            bf = self.gel.poly_space.eval_base(coors)
+            bf = self.gel.poly_space.eval_basis(coors)
             bf = bf[:,0,:].copy()
 
             conn = self.econn[:, :self.gel.n_vertex]

--- a/sfepy/discrete/fem/fields_nodal.py
+++ b/sfepy/discrete/fem/fields_nodal.py
@@ -314,7 +314,7 @@ class H1NodalMixin(H1Mixin, GlobalNodalLikeBasis):
         coors = fcoors[rffield.econn[0]]
         integral = Integral('i', coors=coors, weights=nm.ones_like(coors[:, 0]))
 
-        rcfield.clear_qp_base()
+        rcfield.clear_qp_basis()
         bf = rcfield.eval_basis('v', False, integral)
 
         if gel.name == '2_4':
@@ -406,7 +406,7 @@ class H1NodalVolumeField(H1NodalMixin, FEField):
     def interp_v_vals_to_n_vals(self, vec):
         """
         Interpolate a function defined by vertex DOF values using the FE
-        geometry base (P1 or Q1) into the extra nodes, i.e. define the
+        geometry basis (P1 or Q1) into the extra nodes, i.e. define the
         extra DOF values.
         """
         if not self.node_desc.has_extra_nodes():
@@ -478,9 +478,9 @@ class H1DiscontinuousField(H1NodalMixin, FEField):
     """
     family_name = 'volume_H1_lagrange_discontinuous'
 
-    def _setup_global_base(self):
+    def _setup_global_basis(self):
         """
-        Setup global DOF/base function indices and connectivity of the field.
+        Setup global DOF/basis function indices and connectivity of the field.
         """
         self._setup_facet_orientations()
 
@@ -546,7 +546,7 @@ class H1NodalSurfaceField(H1NodalMixin, FEField):
     def interp_v_vals_to_n_vals(self, vec):
         """
         Interpolate a function defined by vertex DOF values using the FE
-        surface geometry base (P1 or Q1) into the extra nodes, i.e. define the
+        surface geometry basis (P1 or Q1) into the extra nodes, i.e. define the
         extra DOF values.
         """
         if not self.node_desc.has_extra_nodes():

--- a/sfepy/discrete/fem/linearizer.py
+++ b/sfepy/discrete/fem/linearizer.py
@@ -22,7 +22,7 @@ def get_eval_dofs(dofs, dof_conn, ps, ori=None):
         else:
             eori = None
 
-        bf = ps.eval_base(rx, ori=eori, force_axis=True)[...,0,:]
+        bf = ps.eval_basis(rx, ori=eori, force_axis=True)[...,0,:]
         rvals = dot_sequences(bf, edofs)
 
         return rvals
@@ -38,7 +38,7 @@ def get_eval_coors(coors, conn, ps):
         ecoors = coors[conn[iels]]
         aux = ecoors.transpose((0, 2, 1))
 
-        bf = ps.eval_base(rx).squeeze()
+        bf = ps.eval_basis(rx).squeeze()
         phys_coors = nm.dot(aux, bf.T).transpose((0, 2, 1))
         return phys_coors
 

--- a/sfepy/discrete/fem/mappings.py
+++ b/sfepy/discrete/fem/mappings.py
@@ -193,11 +193,11 @@ class FEMapping(Mapping):
             poly_space = {}
             for k, v in gel.items():
                 poly_space[k] = PolySpace.any_from_args(None, v, order,
-                                                        base='lagrange',
+                                                        basis='lagrange',
                                                         force_bubble=False)
         elif poly_space is None:
             poly_space = PolySpace.any_from_args(None, gel, order,
-                                                 base='lagrange',
+                                                 basis='lagrange',
                                                  force_bubble=False)
 
         self.poly_space = poly_space

--- a/sfepy/discrete/fem/mappings.py
+++ b/sfepy/discrete/fem/mappings.py
@@ -217,10 +217,10 @@ class FEMapping(Mapping):
         Evaluate basis functions or their gradients in given coordinates.
         """
         if isinstance(self.poly_space, dict):
-            bf = {k: v.eval_base(coors[k], diff=diff)
+            bf = {k: v.eval_basis(coors[k], diff=diff)
                   for k, v in self.poly_space.items()}
         else:
-            bf = self.poly_space.eval_base(coors, diff=diff)
+            bf = self.poly_space.eval_basis(coors, diff=diff)
 
         indices = self.indices
         if indices is not None:
@@ -332,8 +332,8 @@ class FEMapping(Mapping):
             raise ValueError('zero basis function gradient!')
 
         if not is_face:
-            ebf_g = poly_space.eval_base(qp_coors, diff=True, ori=ori,
-                                         force_axis=True, transform=transform)
+            ebf_g = poly_space.eval_basis(qp_coors, diff=True, ori=ori,
+                                          force_axis=True, transform=transform)
             size = ebf_g.nbytes * self.n_el
             site_config = Config()
             raise_if_too_large(size, site_config.refmap_memory_factor())

--- a/sfepy/discrete/fem/mappings.py
+++ b/sfepy/discrete/fem/mappings.py
@@ -212,10 +212,9 @@ class FEMapping(Mapping):
         else:
             return self.poly_space.geometry
 
-    def get_base(self, coors, diff=False, grad_axes=None):
+    def eval_basis(self, coors, diff=False, grad_axes=None):
         """
-        Get basis functions or their gradient evaluated in given
-        coordinates.
+        Evaluate basis functions or their gradients in given coordinates.
         """
         if isinstance(self.poly_space, dict):
             bf = {k: v.eval_base(coors[k], diff=diff)
@@ -262,7 +261,7 @@ class FEMapping(Mapping):
             The physical quadrature points ordered element by element,
             i.e. with shape (n_el, n_qp, dim).
         """
-        bf = self.get_base(qp_coors)
+        bf = self.eval_basis(qp_coors)
         if isinstance(bf, dict):
             sh = self.conn.shape
             nqp = max(v.shape[0] for v in bf.values())
@@ -324,10 +323,10 @@ class FEMapping(Mapping):
         poly_space = get_default(poly_space, self.poly_space)
 
         if fc_bf_map is not None:
-            bf_g = self.get_base(qp_coors, diff=True, grad_axes=fc_bf_map[1])
+            bf_g = self.eval_basis(qp_coors, diff=True, grad_axes=fc_bf_map[1])
             bf_g = nm.ascontiguousarray(bf_g[fc_bf_map[0]])
         else:
-            bf_g = self.get_base(qp_coors, diff=True)
+            bf_g = self.eval_basis(qp_coors, diff=True)
 
         if nm.allclose(bf_g, 0.0) and self.dim > 1:
             raise ValueError('zero basis function gradient!')

--- a/sfepy/discrete/fem/poly_spaces.py
+++ b/sfepy/discrete/fem/poly_spaces.py
@@ -278,13 +278,13 @@ class LagrangePolySpace(FEPolySpace):
         See :func:`PolySpace.eval_basis()`.
         """
         if diff == 2:
-            base = self._eval_hessian(coors)
+            basis = self._eval_hessian(coors)
 
         else:
-            base = self.eval_ctx.evaluate(coors, diff=diff,
-                                          eps=eps,
-                                          check_errors=not suppress_errors)
-        return base
+            basis = self.eval_ctx.evaluate(coors, diff=diff,
+                                           eps=eps,
+                                           check_errors=not suppress_errors)
+        return basis
 
 class LagrangeSimplexPolySpace(LagrangePolySpace):
     """Lagrange polynomial space on a simplex domain."""
@@ -600,7 +600,7 @@ class LagrangeTensorProductPolySpace(LagrangePolySpace):
         ev = self.ps1d.eval_basis
 
         if diff:
-            base = nm.ones((coors.shape[0], dim, self.n_nod), dtype=nm.float64)
+            basis = nm.ones((coors.shape[0], dim, self.n_nod), dtype=nm.float64)
 
             for ii in range(dim):
                 self.ps1d.nodes = self.nodes[:,2*ii:2*ii+2].copy()
@@ -608,30 +608,30 @@ class LagrangeTensorProductPolySpace(LagrangePolySpace):
 
                 for iv in range(dim):
                     if ii == iv:
-                        base[:,iv:iv+1,:] *= ev(coors[:,ii:ii+1].copy(),
-                                                diff=True,
-                                                suppress_errors=suppress_errors,
-                                                eps=eps)
+                        basis[:,iv:iv+1,:] *= ev(coors[:,ii:ii+1].copy(),
+                                                 diff=True,
+                                                 suppress_errors=suppress_errors,
+                                                 eps=eps)
 
                     else:
-                        base[:,iv:iv+1,:] *= ev(coors[:,ii:ii+1].copy(),
-                                                diff=False,
-                                                suppress_errors=suppress_errors,
-                                                eps=eps)
+                        basis[:,iv:iv+1,:] *= ev(coors[:,ii:ii+1].copy(),
+                                                 diff=False,
+                                                 suppress_errors=suppress_errors,
+                                                 eps=eps)
 
         else:
-            base = nm.ones((coors.shape[0], 1, self.n_nod), dtype=nm.float64)
+            basis = nm.ones((coors.shape[0], 1, self.n_nod), dtype=nm.float64)
 
             for ii in range(dim):
                 self.ps1d.nodes = self.nodes[:,2*ii:2*ii+2].copy()
                 self.ps1d.n_nod = self.n_nod
 
-                base *= ev(coors[:,ii:ii+1].copy(),
-                           diff=diff,
-                           suppress_errors=suppress_errors,
-                           eps=eps)
+                basis *= ev(coors[:,ii:ii+1].copy(),
+                            diff=diff,
+                            suppress_errors=suppress_errors,
+                            eps=eps)
 
-        return base
+        return basis
 
     def _eval_hessian(self, coors):
         """
@@ -728,35 +728,35 @@ class LagrangeWedgePolySpace(FEPolySpace):
                     suppress_errors=False, eps=1e-15):
 
         nd = self.geometry.dim if diff else 1
-        base = nm.empty((coors.shape[0], nd, self.n_nod), nm.float64)
+        basis = nm.empty((coors.shape[0], nd, self.n_nod), nm.float64)
 
         for qp1 in nm.unique(coors[:, 2]):
             idxs = coors[:, 2] == qp1
             coors2 = coors[idxs, :2]
-            base2 = self.ps[0]._eval_basis(coors2, False, ori,
-                                           suppress_errors, eps)
+            basis2 = self.ps[0]._eval_basis(coors2, False, ori,
+                                            suppress_errors, eps)
             coors1 = coors[idxs, 2][:, None]
-            base1 = self.ps[1]._eval_basis(coors1, False, ori,
-                                           suppress_errors, eps)
+            basis1 = self.ps[1]._eval_basis(coors1, False, ori,
+                                            suppress_errors, eps)
 
             if diff:
-                base2d = self.ps[0]._eval_basis(coors2, True, ori,
-                                                suppress_errors, eps)
-                base1d = self.ps[1]._eval_basis(coors1, True, ori,
-                                                suppress_errors, eps)
-                base_r = base2d[:, 0, None, :] * base1[:, 0, :, None]
-                base_s = base2d[:, 1, None, :] * base1[:, 0, :, None]
-                base_t = base2[:, 0, None, :] * base1d[:, 0, :, None]
+                basis2d = self.ps[0]._eval_basis(coors2, True, ori,
+                                                 suppress_errors, eps)
+                basis1d = self.ps[1]._eval_basis(coors1, True, ori,
+                                                 suppress_errors, eps)
+                basis_r = basis2d[:, 0, None, :] * basis1[:, 0, :, None]
+                basis_s = basis2d[:, 1, None, :] * basis1[:, 0, :, None]
+                basis_t = basis2[:, 0, None, :] * basis1d[:, 0, :, None]
 
-                base[idxs, 0] = base_r.reshape((-1, self.n_nod))
-                base[idxs, 1] = base_s.reshape((-1, self.n_nod))
-                base[idxs, 2] = base_t.reshape((-1, self.n_nod))
+                basis[idxs, 0] = basis_r.reshape((-1, self.n_nod))
+                basis[idxs, 1] = basis_s.reshape((-1, self.n_nod))
+                basis[idxs, 2] = basis_t.reshape((-1, self.n_nod))
 
             else:
-                base_ = base2[:, 0, None, :] * base1[:, 0, :, None]
-                base[idxs] = base_.reshape(-1, 1, self.n_nod)
+                basis_ = basis2[:, 0, None, :] * basis1[:, 0, :, None]
+                basis[idxs] = basis_.reshape(-1, 1, self.n_nod)
 
-        return base
+        return basis
 
 class SerendipityTensorProductPolySpace(FEPolySpace):
     """
@@ -878,21 +878,21 @@ class SerendipityTensorProductPolySpace(FEPolySpace):
         else:
             bdim = 1
 
-        base = nm.empty((coors.shape[0], bdim, self.n_nod), dtype=nm.float64)
+        basis = nm.empty((coors.shape[0], bdim, self.n_nod), dtype=nm.float64)
 
         if diff == 0:
             for ib, bf in enumerate(self._bfs):
-                base[:, 0, ib] = bf(*coors.T)
+                basis[:, 0, ib] = bf(*coors.T)
 
         elif diff == 1:
             for ib, bfg in enumerate(self._bfgs):
                 for ig in range(dim):
-                    base[:, ig, ib] = bfg[ig](*coors.T)
+                    basis[:, ig, ib] = bfg[ig](*coors.T)
 
         else:
             raise NotImplementedError
 
-        return base
+        return basis
 
 class LobattoTensorProductPolySpace(FEPolySpace):
     """
@@ -1051,16 +1051,16 @@ class LobattoTensorProductPolySpace(FEPolySpace):
         from .extmods.lobatto_bases import eval_lobatto_tensor_product as ev
         c_min, c_max = self.bbox[:, 0]
 
-        base = ev(coors, self.nodes, c_min, c_max, self.order, diff)
+        basis = ev(coors, self.nodes, c_min, c_max, self.order, diff)
 
         if ori is not None:
-            ebase = nm.tile(base, (ori.shape[0], 1, 1, 1))
+            ebasis = nm.tile(basis, (ori.shape[0], 1, 1, 1))
 
             if self.edge_indx.shape[0]:
                 # Orient edge functions.
                 ie, ii = nm.where(ori[:, self.edge_indx] == 1)
                 ii = self.edge_indx[ii]
-                ebase[ie, :, :, ii] *= -1.0
+                ebasis[ie, :, :, ii] *= -1.0
 
             if self.face_indx.shape[0]:
                 # Orient face functions.
@@ -1069,25 +1069,25 @@ class LobattoTensorProductPolySpace(FEPolySpace):
                 # ... normal axis order
                 ie, ii = nm.where((fori == 1) | (fori == 2))
                 ii = self.face_indx[ii]
-                ebase[ie, :, :, ii] *= -1.0
+                ebasis[ie, :, :, ii] *= -1.0
 
                 # ... swapped axis order
-                sbase = ev(coors, self.sfnodes, c_min, c_max, self.order, diff)
-                sbase = insert_strided_axis(sbase, 0, ori.shape[0])
+                sbasis = ev(coors, self.sfnodes, c_min, c_max, self.order, diff)
+                sbasis = insert_strided_axis(sbasis, 0, ori.shape[0])
 
                 # ...overwrite with swapped axes basis.
                 ie, ii = nm.where(fori >= 4)
                 ii2 = self.face_indx[ii]
-                ebase[ie, :, :, ii2] = sbase[ie, :, :, ii]
+                ebasis[ie, :, :, ii2] = sbasis[ie, :, :, ii]
 
                 # ...deal with orientation.
                 ie, ii = nm.where((fori == 5) | (fori == 6))
                 ii = self.face_indx[ii]
-                ebase[ie, :, :, ii] *= -1.0
+                ebasis[ie, :, :, ii] *= -1.0
 
-            base = ebase
+            basis = ebasis
 
-        return base
+        return basis
 
 class BernsteinSimplexPolySpace(FEPolySpace):
     """
@@ -1138,9 +1138,9 @@ class BernsteinSimplexPolySpace(FEPolySpace):
         else:
             bdim = 1
 
-        base = nm.ones((coors.shape[0], bdim, self.n_nod), dtype=nm.float64)
+        basis = nm.ones((coors.shape[0], bdim, self.n_nod), dtype=nm.float64)
         if dim == 0:
-            return base
+            return basis
 
         bcoors = self._get_barycentric(coors)
 
@@ -1150,7 +1150,7 @@ class BernsteinSimplexPolySpace(FEPolySpace):
             for ii, node in enumerate(self.nodes):
                 coef = of / nm.prod(fs[node])
                 val = coef * nm.prod(nm.power(bcoors, node), axis=1)
-                base[:, 0, ii] = val
+                basis[:, 0, ii] = val
 
         else:
             for ii, node in enumerate(self.nodes):
@@ -1171,9 +1171,9 @@ class BernsteinSimplexPolySpace(FEPolySpace):
 
                         dval += val
 
-                    base[:, ider, ii] = dval
+                    basis[:, ider, ii] = dval
 
-        return base
+        return basis
 
 class BernsteinTensorProductPolySpace(FEPolySpace):
     """
@@ -1212,7 +1212,7 @@ class BernsteinTensorProductPolySpace(FEPolySpace):
         else:
             bdim = 1
 
-        base = nm.ones((coors.shape[0], bdim, self.n_nod), dtype=nm.float64)
+        basis = nm.ones((coors.shape[0], bdim, self.n_nod), dtype=nm.float64)
         degree = self.order
         n_efuns_max = degree + 1
 
@@ -1224,18 +1224,18 @@ class BernsteinTensorProductPolySpace(FEPolySpace):
 
             if not diff:
                 for ii, ni in enumerate(self.nodes.T):
-                    base[iq, 0, :] *= B[ii, ni]
+                    basis[iq, 0, :] *= B[ii, ni]
 
             else:
                 for ii, ni in enumerate(self.nodes.T):
                     for iv in range(bdim):
                         if ii == iv:
-                            base[iq, iv, :] *= dB_dxi[ii, ni]
+                            basis[iq, iv, :] *= dB_dxi[ii, ni]
 
                         else:
-                            base[iq, iv, :] *= B[ii, ni]
+                            basis[iq, iv, :] *= B[ii, ni]
 
-        return base
+        return basis
 
 def get_lgl_nodes(p):
     """

--- a/sfepy/discrete/fem/poly_spaces.py
+++ b/sfepy/discrete/fem/poly_spaces.py
@@ -272,10 +272,10 @@ class LagrangePolySpace(FEPolySpace):
 
         return ctx
 
-    def _eval_base(self, coors, diff=0, ori=None,
-                   suppress_errors=False, eps=1e-15):
+    def _eval_basis(self, coors, diff=0, ori=None,
+                    suppress_errors=False, eps=1e-15):
         """
-        See :func:`PolySpace.eval_base()`.
+        See :func:`PolySpace.eval_basis()`.
         """
         if diff == 2:
             base = self._eval_hessian(coors)
@@ -592,12 +592,12 @@ class LagrangeTensorProductPolySpace(LagrangePolySpace):
 
         return nodes, nts, node_coors
 
-    def _eval_base_debug(self, coors, diff=False, ori=None,
-                         suppress_errors=False, eps=1e-15):
-        """Python version of eval_base()."""
+    def _eval_basis_debug(self, coors, diff=False, ori=None,
+                          suppress_errors=False, eps=1e-15):
+        """Python version of eval_basis()."""
         dim = self.geometry.dim
 
-        ev = self.ps1d.eval_base
+        ev = self.ps1d.eval_basis
 
         if diff:
             base = nm.ones((coors.shape[0], dim, self.n_nod), dtype=nm.float64)
@@ -637,7 +637,7 @@ class LagrangeTensorProductPolySpace(LagrangePolySpace):
         """
         Evaluate the second derivatives of the basis.
         """
-        evh = self.ps1d.eval_base
+        evh = self.ps1d.eval_basis
 
         dim = self.geometry.dim
         bfgg = nm.zeros((coors.shape[0], dim, dim, self.n_nod),
@@ -724,8 +724,8 @@ class LagrangeWedgePolySpace(FEPolySpace):
         self.n_nod = n_nod
         self.eval_ctx = None
 
-    def _eval_base(self, coors, diff=False, ori=None,
-                   suppress_errors=False, eps=1e-15):
+    def _eval_basis(self, coors, diff=False, ori=None,
+                    suppress_errors=False, eps=1e-15):
 
         nd = self.geometry.dim if diff else 1
         base = nm.empty((coors.shape[0], nd, self.n_nod), nm.float64)
@@ -733,17 +733,17 @@ class LagrangeWedgePolySpace(FEPolySpace):
         for qp1 in nm.unique(coors[:, 2]):
             idxs = coors[:, 2] == qp1
             coors2 = coors[idxs, :2]
-            base2 = self.ps[0]._eval_base(coors2, False, ori,
-                                          suppress_errors, eps)
+            base2 = self.ps[0]._eval_basis(coors2, False, ori,
+                                           suppress_errors, eps)
             coors1 = coors[idxs, 2][:, None]
-            base1 = self.ps[1]._eval_base(coors1, False, ori,
-                                          suppress_errors, eps)
+            base1 = self.ps[1]._eval_basis(coors1, False, ori,
+                                           suppress_errors, eps)
 
             if diff:
-                base2d = self.ps[0]._eval_base(coors2, True, ori,
-                                               suppress_errors, eps)
-                base1d = self.ps[1]._eval_base(coors1, True, ori,
-                                               suppress_errors, eps)
+                base2d = self.ps[0]._eval_basis(coors2, True, ori,
+                                                suppress_errors, eps)
+                base1d = self.ps[1]._eval_basis(coors1, True, ori,
+                                                suppress_errors, eps)
                 base_r = base2d[:, 0, None, :] * base1[:, 0, :, None]
                 base_s = base2d[:, 1, None, :] * base1[:, 0, :, None]
                 base_t = base2[:, 0, None, :] * base1d[:, 0, :, None]
@@ -866,10 +866,10 @@ class SerendipityTensorProductPolySpace(FEPolySpace):
 
         return nodes, nts, nm.ascontiguousarray(node_coors)
 
-    def _eval_base(self, coors, diff=0, ori=None,
-                   suppress_errors=False, eps=1e-15):
+    def _eval_basis(self, coors, diff=0, ori=None,
+                    suppress_errors=False, eps=1e-15):
         """
-        See :func:`PolySpace.eval_base()`.
+        See :func:`PolySpace.eval_basis()`.
         """
         dim = self.geometry.dim
         if diff:
@@ -1043,10 +1043,10 @@ class LobattoTensorProductPolySpace(FEPolySpace):
 
         return anodes
 
-    def _eval_base(self, coors, diff=False, ori=None,
-                   suppress_errors=False, eps=1e-15):
+    def _eval_basis(self, coors, diff=False, ori=None,
+                    suppress_errors=False, eps=1e-15):
         """
-        See PolySpace.eval_base().
+        See PolySpace.eval_basis().
         """
         from .extmods.lobatto_bases import eval_lobatto_tensor_product as ev
         c_min, c_max = self.bbox[:, 0]
@@ -1120,10 +1120,10 @@ class BernsteinSimplexPolySpace(FEPolySpace):
         bcoors[:, 1:] = coors
         return bcoors
 
-    def _eval_base(self, coors, diff=False, ori=None,
-                   suppress_errors=False, eps=1e-15):
+    def _eval_basis(self, coors, diff=False, ori=None,
+                    suppress_errors=False, eps=1e-15):
         """
-        See PolySpace.eval_base().
+        See PolySpace.eval_basis().
         """
         from scipy.special import factorial
 
@@ -1198,10 +1198,10 @@ class BernsteinTensorProductPolySpace(FEPolySpace):
 
         return nodes, nts, node_coors
 
-    def _eval_base(self, coors, diff=False, ori=None,
-                   suppress_errors=False, eps=1e-15):
+    def _eval_basis(self, coors, diff=False, ori=None,
+                    suppress_errors=False, eps=1e-15):
         """
-        See PolySpace.eval_base().
+        See PolySpace.eval_basis().
         """
         from sfepy.discrete.iga.extmods.igac import eval_bernstein_basis as ev
 
@@ -1316,10 +1316,10 @@ class SEMTensorProductPolySpace(FEPolySpace):
 
         return nodes, nts, node_coors, node_weights, node_coors1d, weights1d
 
-    def _eval_base(self, coors, diff=0, ori=None,
-                   suppress_errors=False, eps=1e-15):
+    def _eval_basis(self, coors, diff=0, ori=None,
+                    suppress_errors=False, eps=1e-15):
         """
-        See :func:`PolySpace.eval_base()`.
+        See :func:`PolySpace.eval_basis()`.
         """
         dim = self.geometry.dim
         bdim = dim if diff else 1

--- a/sfepy/discrete/structural/fields.py
+++ b/sfepy/discrete/structural/fields.py
@@ -14,7 +14,7 @@ class Shell10XField(H1NodalMixin, FEField):
 
     def _create_interpolant(self):
         name = '%s_%s_%s_%d' % (self.gel.name, self.space,
-                                  self.poly_space_base, self.approx_order)
+                                self.poly_space_basis, self.approx_order)
         ps = PolySpace.any_from_args(name, self.gel, self.approx_order,
                                      base='lagrange', force_bubble=False)
         self.poly_space = ps

--- a/sfepy/discrete/structural/fields.py
+++ b/sfepy/discrete/structural/fields.py
@@ -16,7 +16,7 @@ class Shell10XField(H1NodalMixin, FEField):
         name = '%s_%s_%s_%d' % (self.gel.name, self.space,
                                 self.poly_space_basis, self.approx_order)
         ps = PolySpace.any_from_args(name, self.gel, self.approx_order,
-                                     base='lagrange', force_bubble=False)
+                                     basis='lagrange', force_bubble=False)
         self.poly_space = ps
 
     def create_mapping(self, region, integral, integration,

--- a/sfepy/examples/diffusion/laplace_iga_interactive.py
+++ b/sfepy/examples/diffusion/laplace_iga_interactive.py
@@ -233,7 +233,7 @@ def main():
     order_increase *= int(order_increase>0)
     field = Field.from_args('fu', nm.float64, 'scalar', omega,
                             approx_order='iga', space='H1',
-                            poly_space_base='iga')
+                            poly_space_basis='iga')
 
     # Variables
     u = FieldVariable('u', 'unknown', field) # unknown function

--- a/sfepy/examples/linear_elasticity/shell10x_cantilever_interactive.py
+++ b/sfepy/examples/linear_elasticity/shell10x_cantilever_interactive.py
@@ -137,7 +137,7 @@ def solve_problem(shape, dims, young, poisson, force, transform=None):
     gamma2 = domain.regions['Gamma2']
 
     field = Field.from_args('fu', nm.float64, 6, omega, approx_order=1,
-                            poly_space_base='shell10x')
+                            poly_space_basis='shell10x')
     u = FieldVariable('u', 'unknown', field)
     v = FieldVariable('v', 'test', field, primary_var_name='u')
 

--- a/sfepy/linalg/geometry.py
+++ b/sfepy/linalg/geometry.py
@@ -212,7 +212,7 @@ def flag_points_in_polygon2d(polygon, coors):
                              ~flag[aux], flag[aux])
     return flag
 
-def inverse_element_mapping(coors, e_coors, eval_base, ref_coors,
+def inverse_element_mapping(coors, e_coors, eval_basis, ref_coors,
                             suppress_errors=False):
     """
     Given spatial element coordinates, find the inverse mapping for
@@ -237,14 +237,14 @@ def inverse_element_mapping(coors, e_coors, eval_base, ref_coors,
 
     else: # Tensor-product and other.
         def residual(xi):
-            bf = eval_base(xi[nm.newaxis,:].copy(),
-                           suppress_errors=suppress_errors).squeeze()
+            bf = eval_basis(xi[nm.newaxis,:].copy(),
+                            suppress_errors=suppress_errors).squeeze()
             res = coors - nm.dot(bf, e_coors)
             return res.squeeze()
 
         def matrix(xi):
-            bfg = eval_base(xi[nm.newaxis,:].copy(), diff=True,
-                            suppress_errors=suppress_errors).squeeze()
+            bfg = eval_basis(xi[nm.newaxis,:].copy(), diff=True,
+                             suppress_errors=suppress_errors).squeeze()
             mtx = - nm.dot(bfg, e_coors)
             return mtx
 

--- a/sfepy/mechanics/membranes.py
+++ b/sfepy/mechanics/membranes.py
@@ -163,7 +163,7 @@ def describe_geometry(field, region, integral):
 
     qp = integral.get_qp(gel.name)
     ps = PolySpace.any_from_args(None, gel, field.approx_order)
-    membrane_geo = vm.get_mapping(qp[0], qp[1], ps.eval_base(qp[0]),
+    membrane_geo = vm.get_mapping(qp[0], qp[1], ps.eval_basis(qp[0]),
                                   poly_space=ps)
 
     return mtx_t, membrane_geo

--- a/sfepy/mechanics/shell10x.py
+++ b/sfepy/mechanics/shell10x.py
@@ -190,8 +190,8 @@ def get_mapping_data(ebs, rops, ps, coors_loc, qp_coors, qp_weights,
     n_el = coors_loc.shape[0]
     n_qp = qp_weights.shape[0]
 
-    bfu = ps.eval_base(qp_coors[:, :2].copy())
-    bfgu = ps.eval_base(qp_coors[:, :2].copy(), diff=True)
+    bfu = ps.eval_basis(qp_coors[:, :2].copy())
+    bfgu = ps.eval_basis(qp_coors[:, :2].copy(), diff=True)
 
     nh = ebs[..., -1, :]
 

--- a/sfepy/scripts/plot_condition_numbers.py
+++ b/sfepy/scripts/plot_condition_numbers.py
@@ -87,7 +87,7 @@ def main():
 
         field = Field.from_args('fu', nm.float64, n_c, omega,
                                 approx_order=order,
-                                space='H1', poly_space_base=options.basis)
+                                space='H1', poly_space_basis=options.basis)
 
         quad_order = 2 * field.approx_order
         output('quadrature order:', quad_order)

--- a/sfepy/scripts/save_basis.py
+++ b/sfepy/scripts/save_basis.py
@@ -171,9 +171,9 @@ def main():
 
         gel = GeometryElement(options.geometry)
         gps = PolySpace.any_from_args(None, gel, 1,
-                                      base=options.basis)
+                                      basis=options.basis)
         ps = PolySpace.any_from_args(None, gel, options.max_order,
-                                     base=options.basis)
+                                     basis=options.basis)
 
         n_digit, _format = get_print_info(ps.n_nod, fill='0')
         name_template = os.path.join(output_dir, 'bf_%s.vtk' % _format)

--- a/sfepy/scripts/save_basis.py
+++ b/sfepy/scripts/save_basis.py
@@ -73,7 +73,7 @@ def save_basis_on_mesh(mesh, options, output_dir, lin,
     omega = domain.create_region('Omega', 'all')
     field = Field.from_args('f', nm.float64, shape=1, region=omega,
                             approx_order=options.max_order,
-                            poly_space_base=options.basis)
+                            poly_space_basis=options.basis)
     var = FieldVariable('u', 'unknown', field)
 
     if options.plot_dofs:

--- a/sfepy/scripts/save_basis.py
+++ b/sfepy/scripts/save_basis.py
@@ -182,17 +182,17 @@ def main():
 
             def eval_dofs(iels, rx):
                 if options.derivative == 0:
-                    bf = ps.eval_base(rx).squeeze()
+                    bf = ps.eval_basis(rx).squeeze()
                     rvals = bf[None, :, ip:ip+1]
 
                 else:
-                    bfg = ps.eval_base(rx, diff=True)
+                    bfg = ps.eval_basis(rx, diff=True)
                     rvals = bfg[None, ..., ip]
 
                 return rvals
 
             def eval_coors(iels, rx):
-                bf = gps.eval_base(rx).squeeze()
+                bf = gps.eval_basis(rx).squeeze()
                 coors = nm.dot(bf, gel.coors)[None, ...]
                 return coors
 

--- a/sfepy/terms/terms_dg.py
+++ b/sfepy/terms/terms_dg.py
@@ -36,7 +36,7 @@ class DGTerm(Term):
     Abstract base class for DG terms, provides alternative call_function and
     eval_real methods to accommodate returning iels and vals.
     """
-    poly_space_base = "legendre"
+    poly_space_basis = "legendre"
     def call_function(self, out, fargs):
         try:
             out, status = self.function(out, *fargs)

--- a/sfepy/terms/terms_dg.py
+++ b/sfepy/terms/terms_dg.py
@@ -181,7 +181,7 @@ class AdvectionDGFluxTerm(DGTerm):
             active_cells, active_facets = nm.where(nbrhd_idx[:, :, 0] >= 0)
             active_nrbhs = nbrhd_idx[active_cells, active_facets, 0]
 
-            in_fc_b, out_fc_b, whs = field.get_both_facet_base_vals(state, region)
+            in_fc_b, out_fc_b, whs = field.get_both_facet_basis_vals(state, region)
 
             # TODO broadcast advelo to facets
             #  - maybe somehow get values of advelo at them?
@@ -220,11 +220,11 @@ class AdvectionDGFluxTerm(DGTerm):
             # get maximal wave speeds at facets
             C = nm.abs(nm.einsum("ifk,ik->if", fc_n, advelo))
 
-            facet_base_vals = field.get_facet_base(base_only=True)
+            facet_basis_vals = field.get_facet_basis(basis_only=True)
             in_fc_v, out_fc_v, weights = field.get_both_facet_state_vals(state,
                                                                          region)
-            # get sane facet base shape
-            fc_b = facet_base_vals[:, 0, :, 0, :].T
+            # get sane facet basis shape
+            fc_b = facet_basis_vals[:, 0, :, 0, :].T
             # (n_el_nod, n_el_facet, n_qp)
 
             fc_v_avg = (in_fc_v + out_fc_v)/2.
@@ -350,42 +350,42 @@ class DiffusionDGFluxTerm(DGTerm):
         active_cells, active_facets = nm.where(nbrhd_idx[:, :, 0] >= 0)
         active_nrbhs = nbrhd_idx[active_cells, active_facets, 0]
 
-        inner_facet_base, outer_facet_base, whs = \
-            field.get_both_facet_base_vals(state, region, derivative=False)
+        inner_facet_basis, outer_facet_basis, whs = \
+            field.get_both_facet_basis_vals(state, region, derivative=False)
 
-        inner_facet_base_d, outer_facet_base_d, _ = \
-            field.get_both_facet_base_vals(state, region, derivative=True)
+        inner_facet_basis_d, outer_facet_basis_d, _ = \
+            field.get_both_facet_basis_vals(state, region, derivative=True)
 
         if self.mode == 'avg_state':
             # content of diagonal
             inner_vals = nm.einsum("nkl, nbfkq, nfk, ndfq, nfq->ndb",
                                    D,
-                                   inner_facet_base_d / 2,  # state
+                                   inner_facet_basis_d / 2,  # state
                                    fc_n,
-                                   inner_facet_base,  # test
+                                   inner_facet_basis,  # test
                                    whs)
             outer_vals = nm.einsum(
                 "ikl, ibkq, ik, idq, iq->idb",
                 D[active_cells],
-                outer_facet_base_d[active_cells, :, active_facets] / 2,  # state
+                outer_facet_basis_d[active_cells, :, active_facets] / 2,  # state
                 fc_n[active_cells, active_facets],
-                inner_facet_base[active_cells, :, active_facets],  # test
+                inner_facet_basis[active_cells, :, active_facets],  # test
                 whs[active_cells, active_facets])
 
         elif self.mode == 'avg_virtual':
             # content of diagonal
             inner_vals = nm.einsum("nkl, ndfkq, nfk, nbfq, nfq->ndb",
                                    D,
-                                   inner_facet_base_d / 2,  # test
+                                   inner_facet_basis_d / 2,  # test
                                    fc_n,
-                                   inner_facet_base,  # state
+                                   inner_facet_basis,  # state
                                    whs)
 
             outer_vals = nm.einsum("ikl, idkq, ik, ibq, iq->idb",
                    D[active_cells],
-                   inner_facet_base_d[active_cells, :, active_facets] / 2,  # test
+                   inner_facet_basis_d[active_cells, :, active_facets] / 2,  # test
                    fc_n[active_cells, active_facets],
-                   - outer_facet_base[active_cells, :, active_facets],  # state
+                   - outer_facet_basis[active_cells, :, active_facets],  # state
                    whs[active_cells, active_facets])
 
         iels = self._get_nbrhd_dof_indexes(active_cells, active_nrbhs, field)
@@ -400,11 +400,11 @@ class DiffusionDGFluxTerm(DGTerm):
     def _function_residual(self, out, state, diff_var, field, region, D):
         fc_n = field.get_cell_normals_per_facet(region)
 
-        # get base values
-        inner_facet_base, outer_facet_base, _ = \
-            field.get_both_facet_base_vals(state, region, derivative=False)
-        inner_facet_base_d, outer_facet_base_d, _ = \
-            field.get_both_facet_base_vals(state, region, derivative=True)
+        # get basis values
+        inner_facet_basis, outer_facet_basis, _ = \
+            field.get_both_facet_basis_vals(state, region, derivative=False)
+        inner_facet_basis_d, outer_facet_basis_d, _ = \
+            field.get_both_facet_basis_vals(state, region, derivative=True)
 
         # get state values
         inner_facet_state_d, outer_facet_state_d, _ = \
@@ -417,19 +417,19 @@ class DiffusionDGFluxTerm(DGTerm):
                                     D, inner_facet_state_d) +
                           nm.einsum("ikl,ifkq                ->ifkq",
                                     D,   outer_facet_state_d)) / 2.
-            # outer_facet_base is in DG zero - hence the jump is inner value
-            jmpBase = inner_facet_base
+            # outer_facet_basis is in DG zero - hence the jump is inner value
+            jmpBasis = inner_facet_basis
 
             cell_fluxes = nm.einsum("ifkq ,     ifk,  idfq,    ifq -> id",
-                             avgDdState, fc_n, jmpBase, weights)
+                             avgDdState, fc_n, jmpBasis, weights)
 
         elif self.mode == 'avg_virtual':
-            avgDdbase = (nm.einsum("ikl,idfkq->idfkq",
-                                   D, inner_facet_base_d)) / 2.
+            avgDdbasis = (nm.einsum("ikl,idfkq->idfkq",
+                                   D, inner_facet_basis_d)) / 2.
 
             jmpState = inner_facet_state - outer_facet_state
             cell_fluxes = nm.einsum("idfkq, ifk, ifq , ifq -> id",
-                             avgDdbase, fc_n, jmpState, weights)
+                             avgDdbasis, fc_n, jmpState, weights)
 
         out[:] = 0.0
         n_el_nod = field.n_el_nod
@@ -491,8 +491,8 @@ class DiffusionInteriorPenaltyTerm(DGTerm):
 
         approx_order = field.approx_order
 
-        inner_facet_base, outer_facet_base, whs = \
-            field.get_both_facet_base_vals(state, region, derivative=False)
+        inner_facet_basis, outer_facet_basis, whs = \
+            field.get_both_facet_basis_vals(state, region, derivative=False)
         facet_vols = nm.sum(whs, axis=-1)
 
         # nu characterizes diffusion tensor, so far we use diagonal average
@@ -508,14 +508,14 @@ class DiffusionInteriorPenaltyTerm(DGTerm):
 
             inner = nm.einsum("nf, ndfq, nbfq, nfq -> ndb",
                                sigma,
-                               inner_facet_base,  # test
-                               inner_facet_base,  # state
+                               inner_facet_basis,  # test
+                               inner_facet_basis,  # state
                                whs)
 
             outer = nm.einsum("i, idq, ibq, iq -> idb",
                                sigma[active_cells, active_facets],
-                               inner_facet_base[active_cells, :, active_facets],  # test
-                               - outer_facet_base[active_cells, :, active_facets],  # state
+                               inner_facet_basis[active_cells, :, active_facets],  # test
+                               - outer_facet_basis[active_cells, :, active_facets],  # state
                                whs[active_cells, active_facets])
 
             vals = nm.vstack((inner, outer))
@@ -530,16 +530,16 @@ class DiffusionInteriorPenaltyTerm(DGTerm):
                 field.get_both_facet_state_vals(state, region,
                                                 derivative=False
                                                 )
-            inner_facet_base, outer_facet_base, _ = \
-                field.get_both_facet_base_vals(state, region,
+            inner_facet_basis, outer_facet_basis, _ = \
+                field.get_both_facet_basis_vals(state, region,
                                                derivative=False
                                                )
             jmp_state = inner_facet_state - outer_facet_state
-            jmp_base = inner_facet_base  # - outer_facet_base
+            jmp_basis = inner_facet_basis  # - outer_facet_basis
 
-            n_el_nod = nm.shape(inner_facet_base)[1]
+            n_el_nod = nm.shape(inner_facet_basis)[1]
             cell_penalty = nm.einsum("nf,nfq,ndfq,nfq->nd",
-                                     sigma, jmp_state, jmp_base, whs)
+                                     sigma, jmp_state, jmp_basis, whs)
 
             out[:] = 0.0
             for i in range(n_el_nod):
@@ -647,10 +647,10 @@ class NonlinearHyperbolicDGFluxTerm(DGTerm):
             return None
 
         fc_n = field.get_cell_normals_per_facet(region)
-        facet_base_vals = field.get_facet_base(base_only=True)
+        facet_basis_vals = field.get_facet_basis(basis_only=True)
         in_fc_v, out_fc_v, weights = field.get_both_facet_state_vals(state, region)
 
-        fc_b = facet_base_vals[:, 0, :, 0, :].T  # (n_el_nod, n_el_facet, n_qp)
+        fc_b = facet_basis_vals[:, 0, :, 0, :].T  # (n_el_nod, n_el_facet, n_qp)
 
         n_el_nod = field.n_el_nod
 

--- a/sfepy/terms/terms_diffusion.py
+++ b/sfepy/terms/terms_diffusion.py
@@ -396,7 +396,7 @@ class SurfaceFluxOperatorTerm(Term):
         sg, _ = self.get_mapping(state)
         sd = state.field.extra_data[f'sd_{self.region.name}']
         self.get_mapping(virtual) # Creates BQP for the basis.
-        bf = virtual.field.get_base(sd.bkey, 0, self.integral)
+        bf = virtual.field.eval_basis(sd.bkey, 0, self.integral)
 
         if mat is None:
             _, n_qp, dim, _, _ = self.get_data_shape(state)

--- a/sfepy/terms/terms_hyperelastic_tl.py
+++ b/sfepy/terms/terms_hyperelastic_tl.py
@@ -793,7 +793,7 @@ class SurfaceTractionTLTerm(HyperElasticSurfaceTLBase):
                   mode=None, term_mode=None, diff_var=None, **kwargs):
         sg, _ = self.get_mapping(virtual)
         sd = virtual.field.extra_data[f'sd_{self.region.name}']
-        bf = virtual.field.get_base(sd.bkey, 0, self.integral)
+        bf = virtual.field.eval_basis(sd.bkey, 0, self.integral)
 
         name = state.name
         fd = self.get_family_data(state, self.region, self.integral,
@@ -842,7 +842,7 @@ class VolumeSurfaceTLTerm(HyperElasticSurfaceTLBase):
                   mode=None, term_mode=None, diff_var=None, **kwargs):
         sg, _ = self.get_mapping(parameter)
         sd = parameter.field.extra_data[f'sd_{self.region.name}']
-        bf = parameter.field.get_base(sd.bkey, 0, self.integral)
+        bf = parameter.field.eval_basis(sd.bkey, 0, self.integral)
 
         name = parameter.name
         fd = self.get_family_data(parameter, self.region, self.integral,

--- a/sfepy/terms/terms_multilinear.py
+++ b/sfepy/terms/terms_multilinear.py
@@ -244,7 +244,7 @@ class ExpressionArg(Struct):
 
             else:
                 sd = self.arg.field.extra_data[f'sd_{self.term.region.name}']
-                _bf = self.arg.field.get_base(sd.bkey, 0, self.term.integral)
+                _bf = self.arg.field.eval_basis(sd.bkey, 0, self.term.integral)
                 bf = _bf[sd.fis[:, 1], ...]
                 cell_dependent = True
 

--- a/sfepy/terms/terms_shells.py
+++ b/sfepy/terms/terms_shells.py
@@ -122,7 +122,7 @@ class Shell10XTerm(Term):
                   'virtual' : (6, 'state'), 'state' : 6}
     geometries = ['3_2_4']
     integration = 'custom'
-    poly_space_base = 'shell10x'
+    poly_space_basis = 'shell10x'
 
     def set_integral(self, integral):
         """

--- a/sfepy/tests/test_fem.py
+++ b/sfepy/tests/test_fem.py
@@ -236,7 +236,7 @@ def test_base_functions_values(gels):
         dim = ps.geometry.dim
         coors = nm.r_[ps.geometry.coors, [[0.2] * dim]]
 
-        bf = ps.eval_base(coors, diff=diff)
+        bf = ps.eval_basis(coors, diff=diff)
         _ok = nm.allclose(val, bf, rtol=0.0, atol=1e-14)
 
         if not diff:
@@ -263,7 +263,7 @@ def test_base_functions_delta(gels):
             ps = PolySpace.any_from_args('aux', gel, order,
                                          base='lagrange',
                                          force_bubble=False)
-            bf = ps.eval_base(ps.node_coors)
+            bf = ps.eval_basis(ps.node_coors)
             _ok = nm.allclose(nm.eye(ps.n_nod),
                               bf.squeeze(),
                               rtol=0.0, atol=(order + 1) * 1e-14)

--- a/sfepy/tests/test_fem.py
+++ b/sfepy/tests/test_fem.py
@@ -215,9 +215,9 @@ def gels():
 
     return gels
 
-def test_base_functions_values(gels):
+def test_basis_functions_values(gels):
     """
-    Compare base function values and their gradients with correct
+    Compare basis function values and their gradients with correct
     data. Also test that sum of values over all element nodes gives one.
     """
     from sfepy.base.base import ordered_iteritems
@@ -231,7 +231,7 @@ def test_base_functions_values(gels):
         force_bubble = key[6:7] == 'B'
 
         ps = PolySpace.any_from_args('aux', gel, order,
-                                     base='lagrange',
+                                     basis='lagrange',
                                      force_bubble=force_bubble)
         dim = ps.geometry.dim
         coors = nm.r_[ps.geometry.coors, [[0.2] * dim]]
@@ -249,9 +249,9 @@ def test_base_functions_values(gels):
 
     assert ok
 
-def test_base_functions_delta(gels):
+def test_basis_functions_delta(gels):
     r"""
-    Test :math:`\delta` property of base functions evaluated in the
+    Test :math:`\delta` property of basis functions evaluated in the
     reference element nodes.
     """
     from sfepy.base.base import ordered_iteritems
@@ -261,7 +261,7 @@ def test_base_functions_delta(gels):
     for key, gel in ordered_iteritems(gels):
         for order in range(11):
             ps = PolySpace.any_from_args('aux', gel, order,
-                                         base='lagrange',
+                                         basis='lagrange',
                                          force_bubble=False)
             bf = ps.eval_basis(ps.node_coors)
             _ok = nm.allclose(nm.eye(ps.n_nod),

--- a/sfepy/tests/test_poly_spaces.py
+++ b/sfepy/tests/test_poly_spaces.py
@@ -93,13 +93,13 @@ def _gen_common_data(orders, gels):
                                      'lobatto', 'sem']])]
              + [ii for ii in combine([['2_3', '3_4'],
                                       ['lagrange', 'bernstein']])])
-    for geom, poly_space_base in bases:
+    for geom, poly_space_basis in bases:
         order = orders[geom]
-        if (geom == '3_8') and (poly_space_base == 'serendipity'):
+        if (geom == '3_8') and (poly_space_basis == 'serendipity'):
             order = 2
 
         tst.report('geometry: %s, base: %s, order: %d'
-                   % (geom, poly_space_base, order))
+                   % (geom, poly_space_basis, order))
 
         integral = Integral('i', order=order)
 
@@ -151,7 +151,7 @@ def _gen_common_data(orders, gels):
             region = domain.create_region('Facet', rsels[geom], 'facet')
             field = Field.from_args('f', nm.float64, shape=1,
                                     region=omega, approx_order=order,
-                                    poly_space_base=poly_space_base)
+                                    poly_space_basis=poly_space_basis)
             fis = region.get_facet_indices()
             conn = mesh.cmesh.get_conn_as_graph(region.dim,
                                                 region.dim - 1)
@@ -177,7 +177,7 @@ def _gen_common_data(orders, gels):
                                                  cache=cache)
             assert_((rstatus == 0).all() and (cstatus == 0).all())
 
-            yield (geom, poly_space_base, qp_weights, mesh, im, ir, ic,
+            yield (geom, poly_space_basis, qp_weights, mesh, im, ir, ic,
                    field, ps, rrc, rcells[0], crc, ccells[0],
                    vec, edofs, fdofs)
 
@@ -207,21 +207,21 @@ def test_partition_of_unity(gels):
                                  ['lagrange', 'bernstein']])]
     )
 
-    for geom, poly_space_base in bases:
+    for geom, poly_space_basis in bases:
         max_order = orders[geom]
         for order in range(max_order + 1):
-            if (poly_space_base == 'serendipity') and not (0 < order < 4):
+            if (poly_space_basis == 'serendipity') and not (0 < order < 4):
                 continue
-            if (poly_space_base == 'sem') and not (0 < order):
+            if (poly_space_basis == 'sem') and not (0 < order):
                 continue
             tst.report('geometry: %s, base: %s, order: %d'
-                       % (geom, poly_space_base, order))
+                       % (geom, poly_space_basis, order))
 
             integral = Integral('i', order=2 * order)
             coors, _ = integral.get_qp(geom)
 
             ps = PolySpace.any_from_args('ps', gels[geom], order,
-                                         base=poly_space_base)
+                                         base=poly_space_basis)
             vals = ps.eval_basis(coors)
             _ok = nm.allclose(vals.sum(axis=-1), 1, atol=1e-14, rtol=0.0)
             tst.report('partition of unity:', _ok)
@@ -236,11 +236,11 @@ def test_continuity(gels):
 
     bads = []
     bad_families = set()
-    for (geom, poly_space_base, qp_weights, mesh, im, ir, ic,
+    for (geom, poly_space_basis, qp_weights, mesh, im, ir, ic,
          field, ps, rrc, rcell, crc, ccell, vec,
          edofs, fdofs) in _gen_common_data(orders, gels):
 
-        if poly_space_base in ('lagrange', 'serendipity', 'bernstein', 'sem'):
+        if poly_space_basis in ('lagrange', 'serendipity', 'bernstein', 'sem'):
             rbf = ps.eval_basis(rrc)
             cbf = ps.eval_basis(crc)
 
@@ -264,8 +264,8 @@ def test_continuity(gels):
             _ok = nm.allclose(rvals, cvals, atol=1e-14, rtol=0.0)
             res[1, ii] = _ok
             if not _ok:
-                bads.append([geom, poly_space_base, im, ir, ic, ip])
-                bad_families.add((geom, poly_space_base))
+                bads.append([geom, poly_space_basis, im, ir, ic, ip])
+                bad_families.add((geom, poly_space_basis))
 
             ok = ok and _ok
 
@@ -288,7 +288,7 @@ def test_gradients(gels):
 
     bads = []
     bad_families = set()
-    for (geom, poly_space_base, qp_weights, mesh, im, ir, ic,
+    for (geom, poly_space_basis, qp_weights, mesh, im, ir, ic,
          field, ps, rrc, rcell, crc, ccell, vec,
          edofs, fdofs) in _gen_common_data(orders, gels):
         gel = gels[geom]
@@ -336,8 +336,8 @@ def test_gradients(gels):
 
             res[1, ii] = _ok
             if not _ok:
-                bads.append([geom, poly_space_base, im, ir, ic, ip])
-                bad_families.add((geom, poly_space_base))
+                bads.append([geom, poly_space_basis, im, ir, ic, ip])
+                bad_families.add((geom, poly_space_basis))
 
             ok = ok and _ok
 
@@ -364,15 +364,15 @@ def test_hessians(gels):
     bases = ([ii for ii in combine([['2_3', '2_4', '3_4', '3_8'],
                                     ['lagrange']])])
 
-    for geom, poly_space_base in bases:
-        tst.report('geometry: %s, base: %s' % (geom, poly_space_base))
+    for geom, poly_space_basis in bases:
+        tst.report('geometry: %s, base: %s' % (geom, poly_space_basis))
         order = orders[geom]
 
         integral = Integral('i', order=order)
         coors, _ = integral.get_qp(geom)
 
         ps = PolySpace.any_from_args('ps', gels[geom], order,
-                                     base=poly_space_base)
+                                     base=poly_space_basis)
 
         dim = coors.shape[1]
         h1 = nm.zeros((coors.shape[0], dim, dim, ps.n_nod), nm.float64)

--- a/sfepy/tests/test_poly_spaces.py
+++ b/sfepy/tests/test_poly_spaces.py
@@ -221,7 +221,7 @@ def test_partition_of_unity(gels):
             coors, _ = integral.get_qp(geom)
 
             ps = PolySpace.any_from_args('ps', gels[geom], order,
-                                         base=poly_space_basis)
+                                         basis=poly_space_basis)
             vals = ps.eval_basis(coors)
             _ok = nm.allclose(vals.sum(axis=-1), 1, atol=1e-14, rtol=0.0)
             tst.report('partition of unity:', _ok)
@@ -372,7 +372,7 @@ def test_hessians(gels):
         coors, _ = integral.get_qp(geom)
 
         ps = PolySpace.any_from_args('ps', gels[geom], order,
-                                     base=poly_space_basis)
+                                     basis=poly_space_basis)
 
         dim = coors.shape[1]
         h1 = nm.zeros((coors.shape[0], dim, dim, ps.n_nod), nm.float64)

--- a/sfepy/tests/test_poly_spaces.py
+++ b/sfepy/tests/test_poly_spaces.py
@@ -222,7 +222,7 @@ def test_partition_of_unity(gels):
 
             ps = PolySpace.any_from_args('ps', gels[geom], order,
                                          base=poly_space_base)
-            vals = ps.eval_base(coors)
+            vals = ps.eval_basis(coors)
             _ok = nm.allclose(vals.sum(axis=-1), 1, atol=1e-14, rtol=0.0)
             tst.report('partition of unity:', _ok)
             ok = ok and _ok
@@ -241,12 +241,12 @@ def test_continuity(gels):
          edofs, fdofs) in _gen_common_data(orders, gels):
 
         if poly_space_base in ('lagrange', 'serendipity', 'bernstein', 'sem'):
-            rbf = ps.eval_base(rrc)
-            cbf = ps.eval_base(crc)
+            rbf = ps.eval_basis(rrc)
+            cbf = ps.eval_basis(crc)
 
         else:
-            rbf = ps.eval_base(rrc, ori=field.ori[:1])
-            cbf = ps.eval_base(crc, ori=field.ori[1:])
+            rbf = ps.eval_basis(rrc, ori=field.ori[:1])
+            cbf = ps.eval_basis(crc, ori=field.ori[1:])
 
         dofs = nm.r_[edofs, fdofs]
 
@@ -381,14 +381,14 @@ def test_hessians(gels):
             cc = coors.copy()
 
             cc[:, ir] -= eps
-            aux0 = ps.eval_base(cc, diff=1)
+            aux0 = ps.eval_basis(cc, diff=1)
 
             cc[:, ir] += 2 * eps
-            aux1 = ps.eval_base(cc, diff=1)
+            aux1 = ps.eval_basis(cc, diff=1)
 
             h1[:, :, ir, :] = 0.5 * (aux1 - aux0) / eps
 
-        h2 = ps.eval_base(coors, diff=2)
+        h2 = ps.eval_basis(coors, diff=2)
 
         _ok = nm.allclose(h1, h2, rtol=0, atol=50*eps)
         tst.report('hessians: error: %.2e ok: %s'

--- a/sfepy/tests/test_projections.py
+++ b/sfepy/tests/test_projections.py
@@ -104,7 +104,7 @@ def test_projection_iga_fem():
 
     ig_omega = ig_domain.create_region('Omega', 'all')
     ig_field = Field.from_args('iga', nm.float64, 1, ig_omega,
-                               approx_order='iga', poly_space_base='iga')
+                               approx_order='iga', poly_space_basis='iga')
     ig_u = FieldVariable('ig_u', 'parameter', ig_field,
                          primary_var_name='(set-to-None)')
 

--- a/sfepy/tests/test_ref_coors.py
+++ b/sfepy/tests/test_ref_coors.py
@@ -89,7 +89,7 @@ def test_ref_coors_iga():
     omega = domain.create_region('Omega', 'all')
 
     field = Field.from_args('iga', nm.float64, 'scalar', omega,
-                            approx_order='iga', poly_space_base='iga')
+                            approx_order='iga', poly_space_basis='iga')
 
     mcoors = field.nurbs.cps
     conn = field.get_econn('cell', field.region)

--- a/sfepy/tests/test_term_call_modes.py
+++ b/sfepy/tests/test_term_call_modes.py
@@ -17,7 +17,7 @@ not_tested_terms = ['dw_ns_dot_grad_s',
 
 
 def make_term_args(arg_shapes, arg_kinds, arg_types, ats_mode, domain,
-                   material_value=None, poly_space_base=None):
+                   material_value=None, poly_space_basis=None):
     from sfepy.base.base import basestr
     from sfepy.discrete import FieldVariable, Material, Variables, Materials
     from sfepy.discrete.fem import Field
@@ -83,7 +83,7 @@ def make_term_args(arg_shapes, arg_kinds, arg_types, ats_mode, domain,
             shape = _parse_scalar_shape(sh[0] if isinstance(sh, tuple) else sh)
             field = Field.from_args('f%d' % ii, nm.float64, shape, omega,
                                     approx_order=1,
-                                    poly_space_base=poly_space_base)
+                                    poly_space_basis=poly_space_basis)
 
             if arg_kind == 'virtual_variable':
                 if sh[1] is not None:
@@ -221,7 +221,7 @@ def _test_single_term(data, term_cls, domain, rname):
     else:
         integral = data.integral
 
-    poly_space_base = getattr(term_cls, 'poly_space_base', 'lagrange')
+    poly_space_basis = getattr(term_cls, 'poly_space_basis', 'lagrange')
 
     prev_shapes = {}
     for _arg_shapes in arg_shapes_list:
@@ -252,7 +252,7 @@ def _test_single_term(data, term_cls, domain, rname):
                 material_value = 1.0
             aux = make_term_args(arg_shapes, arg_kinds, ats, mode, domain,
                                  material_value=material_value,
-                                 poly_space_base=poly_space_base)
+                                 poly_space_basis=poly_space_basis)
             args, str_args, materials, variables = aux
 
             tst.report('args:', str_args)


### PR DESCRIPTION
Hey @vlukes, I did some renaming to more logical/correct names:

- `FEMapping.get_base()` -> `.eval_basis()` - self-contained
- `.get_base()` -> `.eval_basis()` of Field subclasses - mostly self-contained except use in some terms
- `PolySpace.eval_base()` -> `.eval_basis()` - many places

Originally, that's where I wanted to stop, but in the end essentially all `base` occurrences  of basis function meaning have been replaced on Python level.