### PR TITLE
update installation docs to recommend miniforge

### DIFF
--- a/doc/developer_guide.rst
+++ b/doc/developer_guide.rst
@@ -149,9 +149,8 @@ should look there.
 Exploring the Code
 ------------------
 
-It is convenient to install IPython (see also :ref:`using-ipython`) to have the
-tab completion available. Moreover, all SfePy classes can be easily examined by
-printing them::
+It is convenient to install IPython to have the tab completion available.
+Moreover, all SfePy classes can be easily examined by printing them::
 
     In [1]: from sfepy.discrete.fem import Mesh
 

--- a/doc/downloads.rst
+++ b/doc/downloads.rst
@@ -8,10 +8,8 @@ See :ref:`introduction_installation` for additional information.
 Pre-built  packages
 -------------------
 
-- `Pre-built *SfePy* packages`_ for `Anaconda`_ Python distribution are
-  available from `conda-forge`_ channel for all supported platforms. (See
-  :ref:`multi_platform_distributions_notes` for further details.)
-
+- `Pre-built *SfePy* packages`_ for the `miniforge`_  distribution are
+  available from `conda-forge`_ channel for all supported platforms.
 - Experimental docker image: `<https://github.com/sfepy/sfepy-docker>`_.
 
 Git repository

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -28,7 +28,7 @@
    There is also a preliminary support for the isogeometric analysis,
    outlined in :ref:`isogeometric_analysis`.
 
-   The easiest way to install SfePy is to use `Anaconda`_ or `pip`_, see
+   The easiest way to install SfePy is to use `pip`_ or `conda`_, see
    :ref:`introduction_installation`.
 
    **License:** :doc:`BSD <license>`

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -158,7 +158,7 @@ Other dependencies/suggestions:
 
 - Mesh generation tools use `pexpect` and `gmsh` or `tetgen`.
 - `IPython`_ is recommended over the regular Python shell to fluently follow
-  some parts of primer/tutorial (see :ref:`using-ipython`).
+  some parts of primer/tutorial.
 - `MUMPS`_ library for using MUMPS linear direct solver
   (real and complex arithmetic, parallel factorization)
 
@@ -280,51 +280,6 @@ to turn on bound checks in the low level C functions, and recompile the code::
     python setup.py build_ext --inplace
 
 Then re-run your code and report the output to the `SfePy mailing list`_.
-
-.. _using-ipython:
-
-Using IPython
--------------
-
-We generally recommend to use (a customized) `IPython`_ interactive shell over
-the regular Python interpreter when following :doc:`tutorial` or
-:doc:`primer` (or even for any regular interactive work with *SfePy*).
-
-Install `IPython`_ (as a generic part of your selected distribution) and then
-customize it to your choice.
-
-Depending on your IPython usage, you can customize your `default` profile or
-create a *SfePy* specific new one as follows:
-
-#. Create a new *SfePy* profile::
-
-     ipython profile create sfepy
-
-#. Open the ``~/.ipython/profile_sfepy/ipython_config.py`` file in a text
-   editor and add/edit after the ``c = get_config()`` line:
-
-   .. sourcecode:: python
-
-      exec_lines = [
-          'import numpy as nm',
-          'import matplotlib as mpl',
-          'mpl.use("WXAgg")',
-      #
-      # Add your preferred SfePy customization here...
-      #
-      ]
-
-      c.InteractiveShellApp.exec_lines = exec_lines
-      c.TerminalIPythonApp.gui = 'wx'
-      c.TerminalInteractiveShell.colors = 'Linux' # NoColor, Linux, or LightBG
-
-   Please note, that generally it is not recommended to use `star` (*)
-   imports here.
-
-#. Run the customized IPython shell::
-
-     ipython --profile=sfepy
-
 
 .. _multi_platform_distributions_notes:
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -37,9 +37,12 @@ The released versions of SfePy can be installed as follows.
 - Using `conda`_:
 
   #. Install `miniforge`_. The miniforge distribution contains the minimal
-     installers for `Conda`_ and `Mamba`_ specific to `conda-forge`_. If you
-     have a ``.condarc`` file in your home directory, remove the ``defaults``
-     channel to avoid a potential `Anaconda`_ terms of service violation.
+     installers for `Conda`_ and `Mamba`_ specific to `conda-forge`_. The
+     packages are automatically pulled from the ``conda-forge`` channel. In
+     case of a prior installation, remove the ``defaults`` channel to avoid a
+     potential `Anaconda`_ terms of service violation::
+
+       conda config --remove channels defaults
 
   #. Install `sfepy`::
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -23,28 +23,6 @@ Note: Depending on Python installation and OS used, replacing ``python`` by
 ``python3`` might be required in all the commands below
 (e.g. in :ref:`compilation`) in order to use Python 3.
 
-.. _Python_distribution:
-
-Notes on selecting Python Distribution
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-It is only matter of taste to use either native OS Python installation, `pip`,
-or any other suitable distribution. On all supported platforms we could
-recommend multi-platform scientific Python distributions `Anaconda`_ as
-easy-to-use, stable and up-to-date Python distribution with all the required
-dependencies (including pre-built `sfepy` package). See also `Notes on
-Multi-platform Python Distributions`_ for further details.
-
-On different platforms the following options can be recommended:
-
-- **Linux**: `Anaconda`_, OS native installation, if available, or `pip`_.
-
-- **macOS**: `Anaconda`_.
-
-- **Windows**: free versions of commercial scientific Python distributions
-  `Anaconda`_ or `Enthought Deployment Manager`_ . In addition a completely free
-  open-source portable distribution `WinPython`_ can be used.
-
 .. _installing_sfepy:
 
 Installing SfePy
@@ -56,11 +34,16 @@ The released versions of SfePy can be installed as follows.
 
     pip install sfepy
 
-- Using `Anaconda`_: install `sfepy` from `conda-forge`_ channel::
+- Using `conda`_:
 
-    conda install -c conda-forge sfepy
+  #. Install `miniforge`_. The miniforge distribution contains the minimal
+     installers for `Conda`_ and `Mamba`_ specific to `conda-forge`_. If you
+     have a ``.condarc`` file in your home directory, remove the ``defaults``
+     channel to avoid a potential `Anaconda`_ terms of service violation.
 
-  See `Notes on Multi-platform Python Distributions`_ for additional notes.
+  #. Install `sfepy`::
+
+       conda install sfepy
 
 If the installation succeeded, proceed with `Testing Installation`_.
 
@@ -224,7 +207,7 @@ or::
 
   conda install pytest
 
-when working in `Anaconda`_. If *SfePy* was installed, it can be tested using
+when working in `miniforge`_. If *SfePy* was installed, it can be tested using
 the command::
 
   sfepy-test
@@ -280,70 +263,3 @@ to turn on bound checks in the low level C functions, and recompile the code::
     python setup.py build_ext --inplace
 
 Then re-run your code and report the output to the `SfePy mailing list`_.
-
-.. _multi_platform_distributions_notes:
-
-Notes on Multi-platform Python Distributions
---------------------------------------------
-
-Anaconda
-^^^^^^^^
-
-We highly recommend this scientific-oriented Python distribution.
-
-(Currently regularly tested by developers on *SfePy* releases
-with Python 3.6 64-bit on Ubuntu 16.04 LTS, Windows 8.1+ and macOS 10.12+.)
-
-Download appropriate `Anaconda`_ Python 3.x installer package and follow
-install instructions. We recommend to choose *user-level* install option (no
-admin privileges required).
-
-Anaconda can be used for:
-
-#. installing the latest release of *SfePy*  directly from the `conda-forge`_
-   channel (see `sfepy-feedstock`_). In this case, follow the instructions
-   in `Installing SfePy`_.
-
-   Installing/upgrading *SfePy*  from the conda-forge channel can also be
-   achieved by adding `conda-forge`_ to your channels with::
-
-     conda config --add channels conda-forge
-
-   Once the `conda-forge`_ channel has been enabled, *SfePy* can be installed
-   with::
-
-     conda install sfepy
-
-   It is possible to list all of the versions of *SfePy*  available on your
-   platform with::
-
-     conda search sfepy --channel conda-forge
-
-#. installing the *SfePy* dependencies only - then proceed with the
-   :ref:`installing_from_sources` instructions.
-
-   In this case, install the missing/required packages using built-in `conda`
-   package manager::
-
-     conda install wxpython
-
-   See `conda help` for further information.
-
-Occasionally, you should check for distribution and/or installed packages
-updates (there is no built-in automatic update mechanism available)::
-
-  conda update conda
-  conda update anaconda
-  conda update <package>
-
-or try::
-
-  conda update --all
-
-
-Compilation of C Extension Modules on Windows
-"""""""""""""""""""""""""""""""""""""""""""""
-
-To build *SfePy* extension modules, included `mingw-w32/64`_ compiler tools
-should work fine. If you encounter any problems, we recommend to install and
-use Microsoft `Visual C++ Build Tools`_ instead (see `Anaconda FAQ`_).

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -52,6 +52,9 @@ If the installation succeeded, proceed with `Testing Installation`_.
 Using SfePy Docker Images
 ---------------------------
 
+**WARNING:** The image was not yet updated to use `miniforge`_ instead of
+`Anaconda`_, so read the Anaconda's terms of service carefully!
+
 Besides the classical installation we also provide official Docker images
 with ready-to-run Anaconda and *SfePy* installation.
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -55,11 +55,8 @@ If the installation succeeded, proceed with `Testing Installation`_.
 Using SfePy Docker Images
 ---------------------------
 
-**WARNING:** The image was not yet updated to use `miniforge`_ instead of
-`Anaconda`_, so read the Anaconda's terms of service carefully!
-
 Besides the classical installation we also provide official Docker images
-with ready-to-run Anaconda and *SfePy* installation.
+with a ready-to-run miniforge-based *SfePy* installation.
 
 Before you start using *SfePy* images, you need to first install and configure
 Docker on your computer. To do this follow official

--- a/doc/links.inc
+++ b/doc/links.inc
@@ -39,7 +39,10 @@
 
 .. _anaconda: https://store.continuum.io/cshop/anaconda/
 .. _continuum analytics: http://www.continuum.io/
+.. _conda: https://conda.io/
 .. _conda-forge: https://conda-forge.github.io/
+.. _miniforge: https://github.com/conda-forge/miniforge
+.. _mamba: https://github.com/mamba-org/mamba
 .. _Pre-built *SfePy* packages: https://anaconda.org/conda-forge/sfepy
 .. _sfepy-feedstock: https://github.com/conda-forge/sfepy-feedstock
 .. _pip: https://pip.pypa.io/en/stable/

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -47,8 +47,7 @@ All functions of *SfePy* package can be also used interactively (see
 :ref:`sec-interactive-example-linear-elasticity` for instance).
 
 We recommend to use the `IPython`_ interactive shell for the best fluent user
-experience. You can customize your `IPython` startup profile as described in
-:ref:`using-ipython`.
+experience.
 
 Basic Notions
 -------------


### PR DESCRIPTION
This PR was inspired by [this thread](https://discuss.scientific-python.org/t/response-to-anaconda-switch-to-paid-plans/1395/1). 

@BubuLK, could you eventually update the docker image to use the [miniforge](https://github.com/conda-forge/miniforge)? On a related note, I have not been able to release the `2024.2` version of the [sfepy-feedstock](https://github.com/conda-forge/sfepy-feedstock) yet.