### PR TITLE
doc/primer.rst updated to gmsh 4.12.1

### DIFF
--- a/doc/primer.rst
+++ b/doc/primer.rst
@@ -75,7 +75,7 @@ symmetry. The meshing program `Gmsh`_ is used here to very quickly mesh the
 model. Follow these steps to model the ITS, creating the file
 `its2D.mesh <../meshes/2d/its2D.mesh>`:
 
-#. The ITS specimen has a diameter of 150 mm. Using *Gmsh* add (geometry/Elementary Entities/add) three new
+#. The ITS specimen has a diameter of 150 mm. Using *Gmsh* add (geometry/Elementary Entities/Add) three new
    points at the following coordinates:
    :math:`(75.0,0.0,0.0), (0.0,0.0,0.0) \,\textrm{and}\, (0.0,75.0,0.0)`.
 #. Next add two straight lines connecting the points.


### PR DESCRIPTION
updated to gmsh 4.12.1 linux64-sdk written by C. Geuzaine and J.-F. Remacle.

I did not find any button to change the file type in gmsh 4.12.1 at saving step, so I left this part in primer.rst.