### PR TITLE
Fix the issue with python3.13 exec() and locals() behaviour

### DIFF
--- a/sfepy/base/base.py
+++ b/sfepy/base/base.py
@@ -182,9 +182,10 @@ def try_imports(imports, fail_msg=None):
         The dictionary of imported modules.
     """
     msgs = []
+    locals = {}
     for imp in imports:
         try:
-            exec(imp)
+            exec(imp, locals=locals)
             break
 
         except Exception as inst:
@@ -194,8 +195,7 @@ def try_imports(imports, fail_msg=None):
         if fail_msg is not None:
             msgs.append(fail_msg)
             raise ValueError('\n'.join(msgs))
-
-    return locals()
+    return locals
 
 def python_shell(frame=0):
     import code


### PR DESCRIPTION
In Python 3.13, the built-in exec() function, which executes dynamically generated Python code from a string or code object, has undergone a notable change in its default behavior concerning the locals namespace. In Python 3.13, the default locals namespace used by exec() is now an independent snapshot that does not affect future calls to locals() in the surrounding scope.

As a result, the `try_imports` function of the `base` module does not return the loaded libraries, and 'SuperLU not available' exception is raised. The workaround is to explicitely pass `locals` argument to the `exec()` function.