### PR TITLE
replace "basestr" with plain "str" everywhere

### DIFF
--- a/sfepy/base/base.py
+++ b/sfepy/base/base.py
@@ -19,10 +19,6 @@ sfepy_config_dir = os.path.expanduser('~/.sfepy')
 if not os.path.exists(sfepy_config_dir):
     os.makedirs(sfepy_config_dir)
 
-# is this part of some public API ?
-PY3 = True
-basestr = str
-
 
 def get_debug():
     """

--- a/sfepy/base/base.py
+++ b/sfepy/base/base.py
@@ -19,12 +19,10 @@ sfepy_config_dir = os.path.expanduser('~/.sfepy')
 if not os.path.exists(sfepy_config_dir):
     os.makedirs(sfepy_config_dir)
 
-if sys.version_info[0] < 3:
-    PY3 = False
-    basestr = basestring
-else:
-    PY3 = True
-    basestr = str
+# is this part of some public API ?
+PY3 = True
+basestr = str
+
 
 def get_debug():
     """
@@ -150,12 +148,8 @@ def import_file(filename, package_name=None, can_reload=True):
         mod = __import__(name)
 
     if (name in sys.modules) and can_reload:
-        if PY3:
-            import importlib
-            importlib.reload(mod)
-
-        else:
-            reload(mod)
+        import importlib
+        importlib.reload(mod)
 
     if remove_path:
         sys.path.remove(path)
@@ -536,7 +530,7 @@ class Container(Struct):
 
     def __setitem__(self, ii, obj):
         try:
-            if isinstance(ii, basestr):
+            if isinstance(ii, str):
                 if ii in self.names:
                     ii = self.names.index(ii)
                 else:
@@ -558,7 +552,7 @@ class Container(Struct):
 
     def __getitem__(self, ii):
         try:
-            if isinstance(ii, basestr):
+            if isinstance(ii, str):
                 ii = self.names.index(ii)
             elif not isinstance(ii, int):
                 raise ValueError('bad index type! (%s)' % type(ii))
@@ -665,7 +659,7 @@ class Container(Struct):
                 return True
             else:
                 return False
-        elif isinstance(ii, basestr):
+        elif isinstance(ii, str):
             try:
                 self.names.index(ii)
                 return True
@@ -720,7 +714,7 @@ class OneTypeList(list):
     def __getitem__(self, ii):
         if isinstance(ii, int):
             return list.__getitem__(self, ii)
-        elif isinstance(ii, basestr):
+        elif isinstance(ii, str):
             ir = self.find(ii, ret_indx=True)
             if ir:
                 return list.__getitem__(self, ir[0])
@@ -823,7 +817,7 @@ class Output(Struct):
             Append to an existing file instead of overwriting it. Use with
             `filename`.
         """
-        if not isinstance(filename, basestr):
+        if not isinstance(filename, str):
             # filename is a file descriptor.
             append = True
 
@@ -845,7 +839,7 @@ class Output(Struct):
                 self.level += 1
 
         def print_to_file(filename, msg):
-            if isinstance(filename, basestr):
+            if isinstance(filename, str):
                 fd = open(filename, 'a')
 
             else:
@@ -853,7 +847,7 @@ class Output(Struct):
 
             print(self._prefix + ('  ' * self.level) + msg, file=fd)
 
-            if isinstance(filename, basestr):
+            if isinstance(filename, str):
                 fd.close()
 
             else:
@@ -886,7 +880,7 @@ class Output(Struct):
                 self.level += 1
 
         def reset_file(filename):
-            if isinstance(filename, basestr):
+            if isinstance(filename, str):
                 output_dir = os.path.dirname(filename)
                 if output_dir and not os.path.exists(output_dir):
                     os.makedirs(output_dir)
@@ -925,7 +919,7 @@ class Output(Struct):
         return self.output_function
 
     def set_output_prefix(self, prefix):
-        assert_(isinstance(prefix, basestr))
+        assert_(isinstance(prefix, str))
         if len(prefix) > 0:
             prefix += ' '
         self._prefix = prefix
@@ -1040,14 +1034,10 @@ def structify(obj):
     return out
 
 def is_string(var):
-    return isinstance(var, basestr)
+    return isinstance(var, str)
 
 def is_integer(var):
-    if PY3:
-        return isinstance(var, int)
-
-    else:
-        return isinstance(var, (int, long))
+    return isinstance(var, int)
 
 ##
 # 23.01.2006, c
@@ -1056,7 +1046,7 @@ def is_sequence(var):
         from collections.abc import Sequence
     except ImportError:
         from collections import Sequence
-    if isinstance(var, basestr):
+    if isinstance(var, str):
         return False
     return isinstance(var, Sequence)
 
@@ -1073,10 +1063,7 @@ def insert_static_method(cls, function):
 ##
 # 23.10.2007, c
 def insert_method(instance, function):
-    if PY3:
-        meth = MethodType(function, instance)
-    else:
-        meth = MethodType(function, instance, type(instance))
+    meth = MethodType(function, instance)
     setattr(instance, function.__name__, meth)
 
 def use_method_with_name(instance, method, new_name):
@@ -1215,7 +1202,7 @@ def edit_tuple_strings(str_tuple, old, new, recur=False):
     """
     new_tuple = []
     for item in str_tuple:
-        if isinstance(item, basestr):
+        if isinstance(item, str):
             item = item.replace(old, new)
 
         elif recur and isinstance(item, tuple):
@@ -1247,10 +1234,10 @@ def edit_dict_strings(str_dict, old, new, recur=False):
     new_dict : dict
         The dictionary with edited strings.
     """
-    if isinstance(old, basestr):
+    if isinstance(old, str):
         new_dict = {}
         for key, val in six.iteritems(str_dict):
-            if isinstance(val, basestr):
+            if isinstance(val, str):
                 new_dict[key] = val.replace(old, new)
 
             elif isinstance(val, tuple):

--- a/sfepy/base/conf.py
+++ b/sfepy/base/conf.py
@@ -12,7 +12,7 @@ import numpy as nm
 
 from sfepy.base.base import (Struct, IndexedStruct, dict_to_struct,
                              output, copy, update_dict_recursively,
-                             import_file, assert_, get_default, basestr)
+                             import_file, assert_, get_default)
 from sfepy.base.parse_conf import create_bnf
 import six
 
@@ -57,7 +57,7 @@ def transform_variables(adict):
                 elif kind == 'test':
                     c2.dual = conf[2]
                 elif kind == 'parameter':
-                    if isinstance(conf[2], basestr) or (conf[2] is None):
+                    if isinstance(conf[2], str) or (conf[2] is None):
                         c2.like = conf[2]
                     else:
                         c2.like = None
@@ -150,7 +150,7 @@ def transform_dgepbcs(adict):
 def transform_regions(adict):
     d2 = {}
     for ii, (key, conf) in enumerate(six.iteritems(adict)):
-        if isinstance(conf, basestr):
+        if isinstance(conf, str):
             c2 = Struct(name=key, select=conf)
             d2['region_%s__%d' % (c2.name, ii)] = c2
         elif isinstance(conf, tuple):
@@ -211,7 +211,7 @@ def transform_fields(adict):
 def transform_materials(adict):
     d2 = {}
     for ii, (key, conf) in enumerate(six.iteritems(adict)):
-        if isinstance(conf, basestr):
+        if isinstance(conf, str):
             c2 = Struct(name=key, function=conf)
             d2['material_%s__%d' % (c2.name, ii)] = c2
 

--- a/sfepy/base/ioutils.py
+++ b/sfepy/base/ioutils.py
@@ -5,7 +5,7 @@ import os.path as op
 import fnmatch
 import shutil
 import glob
-from .base import output, ordered_iteritems, Struct, basestr
+from .base import output, ordered_iteritems, Struct
 import six
 import pickle
 import warnings
@@ -312,7 +312,7 @@ def write_dict_hdf5(filename, adict, level=0, group=None, fd=None):
             group2 = fd.create_group(group, '_' + str(key), '%s group' % key)
             write_dict_hdf5(filename, val, level + 1, group2, fd)
         else:
-            if not isinstance(val, basestr):
+            if not isinstance(val, str):
                 fd.create_array(group, '_' + str(key), val, '%s data' % key)
 
             else:

--- a/sfepy/base/mem_usage.py
+++ b/sfepy/base/mem_usage.py
@@ -7,7 +7,7 @@ import collections
 import numpy as nm
 import scipy.sparse as sp
 
-from sfepy.base.base import basestr, Struct, Output
+from sfepy.base.base import Struct, Output
 import six
 
 def get_mem_usage(obj, usage=None, name=None, traversal_order=None, level=0):
@@ -71,7 +71,7 @@ def get_mem_usage(obj, usage=None, name=None, traversal_order=None, level=0):
                         + get_mem_usage(obj.indptr, usage, name='indptr',
                                         traversal_order=to, level=level))
 
-    elif isinstance(obj, basestr):
+    elif isinstance(obj, str):
         record.usage = len(obj)
 
     elif isinstance(obj, Struct):

--- a/sfepy/base/resolve_deps.py
+++ b/sfepy/base/resolve_deps.py
@@ -3,7 +3,6 @@ Functions for resolving dependencies.
 """
 import itertools as it
 
-from sfepy.base.base import basestr
 import six
 
 def get_nums(deps):
@@ -33,7 +32,7 @@ def remove_known(deps, known):
     """
     Remove known names from dependencies.
     """
-    if isinstance(known, basestr):
+    if isinstance(known, str):
         out = {}
         for key, val in six.iteritems(deps):
             if key == known: continue

--- a/sfepy/discrete/common/dof_info.py
+++ b/sfepy/discrete/common/dof_info.py
@@ -7,7 +7,7 @@ Helper functions for the equation mapping.
 import numpy as nm
 import scipy.sparse as sp
 
-from sfepy.base.base import assert_, Struct, basestr
+from sfepy.base.base import assert_, Struct
 from sfepy.discrete.functions import Function
 from sfepy.discrete.conditions import get_condition_value, EssentialBC, \
     PeriodicBC, DGPeriodicBC, DGEssentialBC
@@ -227,7 +227,7 @@ def is_active_bc(bc, ts=None, functions=None):
             active = False
 
     else:
-        if isinstance(bc.times, basestr):
+        if isinstance(bc.times, str):
             if functions is not None:
                 fun = functions[bc.times]
 

--- a/sfepy/discrete/common/fields.py
+++ b/sfepy/discrete/common/fields.py
@@ -1,8 +1,7 @@
 
 import numpy as nm
 
-from sfepy.base.base import output, iter_dict_of_lists, Struct, basestr,\
-    assert_
+from sfepy.base.base import output, iter_dict_of_lists, Struct, assert_
 from sfepy.base.timing import Timer
 import six
 from sfepy.mechanics.tensors import get_cauchy_strain
@@ -19,7 +18,7 @@ def parse_approx_order(approx_order):
     if approx_order is None:
         return 'iga', force_bubble, discontinuous
 
-    elif isinstance(approx_order, basestr):
+    elif isinstance(approx_order, str):
         if approx_order.startswith('iga'):
             return approx_order, force_bubble, discontinuous
 
@@ -48,7 +47,7 @@ def parse_approx_order(approx_order):
     return ao, force_bubble, discontinuous
 
 def parse_shape(shape, dim):
-    if isinstance(shape, basestr):
+    if isinstance(shape, str):
         try:
             shape = {'scalar' : (1,),
                      'vector' : (dim,)}[shape]

--- a/sfepy/discrete/conditions.py
+++ b/sfepy/discrete/conditions.py
@@ -4,7 +4,7 @@ classes, as well as the initial condition class.
 """
 import numpy as nm
 
-from sfepy.base.base import basestr, Container, Struct, is_sequence
+from sfepy.base.base import Container, Struct, is_sequence
 from sfepy.discrete.functions import Function
 import six
 
@@ -70,7 +70,7 @@ class Conditions(Container):
                                    times=times)
 
             elif key.startswith('lcbc'):
-                if isinstance(cc.region, basestr):
+                if isinstance(cc.region, str):
                     rs = [_get_region(cc.region, regions, cc.name), None]
 
                 else:

--- a/sfepy/discrete/evaluate.py
+++ b/sfepy/discrete/evaluate.py
@@ -2,7 +2,7 @@ from copy import copy
 
 import numpy as nm
 
-from sfepy.base.base import output, get_default, OneTypeList, Struct, basestr
+from sfepy.base.base import output, get_default, OneTypeList, Struct
 from sfepy.discrete import Equations, Variables, Region, Integral, Integrals
 from sfepy.discrete.common.fields import setup_extra_data
 import six
@@ -102,7 +102,7 @@ class Evaluator(Struct):
 
     def eval_tangent_matrix(self, vec, mtx=None, is_full=False,
                             select_term=None):
-        if isinstance(vec, basestr) and vec == 'linear':
+        if isinstance(vec, str) and vec == 'linear':
             return get_default(mtx, self.problem.mtx_a)
 
         if not is_full and self.problem.active_only:

--- a/sfepy/discrete/fem/lcbc_operators.py
+++ b/sfepy/discrete/fem/lcbc_operators.py
@@ -5,7 +5,7 @@ setting.
 import numpy as nm
 import scipy.sparse as sp
 
-from sfepy.base.base import (basestr, output, assert_, find_subclasses,
+from sfepy.base.base import (output, assert_, find_subclasses,
                              Container, Struct)
 from sfepy.discrete.common.dof_info import DofInfo, expand_nodes_to_equations
 from sfepy.discrete.fem.utils import (compute_nodal_normals,
@@ -537,7 +537,7 @@ class NodalLCOperator(MRLCBCOperator):
 
         assert_(dpn <= n_c)
 
-        if (isinstance(constraints, basestr)
+        if (isinstance(constraints, str)
             or isinstance(constraints, Function)):
             fun = get_condition_value(constraints, functions,
                                       'nodal', 'constraints')

--- a/sfepy/discrete/fem/meshio.py
+++ b/sfepy/discrete/fem/meshio.py
@@ -7,7 +7,7 @@ import numpy as nm
 from sfepy.base.base import (complex_types, dict_from_keys_init,
                              assert_, is_derived_class, ordered_iteritems,
                              insert_static_method, output, get_default,
-                             get_default_attr, Struct, basestr)
+                             get_default_attr, Struct)
 from sfepy.base.ioutils import (skip_read_line, look_ahead_line, read_token,
                                 read_array, pt, enc, dec,
                                 edit_filename,
@@ -215,7 +215,7 @@ class MeshIO(Struct):
         self.set_float_format()
 
     def get_filename_trunk(self):
-        if isinstance(self.filename, basestr):
+        if isinstance(self.filename, str):
             trunk = op.splitext(self.filename)[0]
         else:
             trunk = 'from_descriptor'
@@ -2418,7 +2418,7 @@ def any_from_filename(filename, prefix_dir=None, file_format=None, mode='r'):
     io : MeshIO subclass instance
         The MeshIO subclass instance corresponding to the kind of `filename`.
     """
-    if not isinstance(filename, basestr):
+    if not isinstance(filename, str):
         if isinstance(filename, MeshIO):
             return filename
 

--- a/sfepy/discrete/iga/fields.py
+++ b/sfepy/discrete/iga/fields.py
@@ -3,7 +3,7 @@ Fields for isogeometric analysis.
 """
 import numpy as nm
 
-from sfepy.base.base import basestr, Struct
+from sfepy.base.base import Struct
 from sfepy.discrete.common.fields import parse_shape, Field
 from sfepy.discrete.iga.mappings import IGMapping
 from sfepy.discrete.iga.iga import get_bezier_element_entities
@@ -62,7 +62,7 @@ class IGField(Field):
             elevate_times = 0
 
         else:
-            if isinstance(approx_order, basestr): approx_order = (approx_order,)
+            if isinstance(approx_order, str): approx_order = (approx_order,)
             elevate_times = parse_approx_order(approx_order[0])
 
         Struct.__init__(self, name=name, dtype=dtype, shape=shape,

--- a/sfepy/discrete/integrals.py
+++ b/sfepy/discrete/integrals.py
@@ -4,7 +4,7 @@ element geometries.
 """
 import numpy as nm
 
-from sfepy.base.base import OneTypeList, Container, Struct, basestr
+from sfepy.base.base import OneTypeList, Container, Struct
 from .quadratures import QuadraturePoints
 import six
 
@@ -48,7 +48,7 @@ class Integrals(Container):
         if name == 'a':
             raise NotImplementedError
 
-        elif isinstance(name, basestr) and (name[0] == 'i'):
+        elif isinstance(name, str) and (name[0] == 'i'):
             try:
                 obj = self[name]
 

--- a/sfepy/discrete/materials.py
+++ b/sfepy/discrete/materials.py
@@ -1,6 +1,6 @@
 
 from sfepy.base.base import (Struct, Container, OneTypeList, assert_,
-                             output, get_default, basestr)
+                             output, get_default)
 from sfepy.base.timing import Timer
 from .functions import ConstantFunction, ConstantFunctionByRegion
 import six
@@ -82,7 +82,7 @@ class Material(Struct):
         function = conf.get('function', None)
         values = conf.get('values', None)
 
-        if isinstance(function, basestr):
+        if isinstance(function, str):
             function = functions[function]
 
         obj = Material(conf.name, kind, function, values, flags)
@@ -387,7 +387,7 @@ class Material(Struct):
         """`name` can be a dict - then a Struct instance with data as
         attributes named as the dict keys is returned."""
 
-        if isinstance(name, basestr):
+        if isinstance(name, str):
             return self._get_data(key, name)
         else:
             out = Struct()

--- a/sfepy/discrete/probes.py
+++ b/sfepy/discrete/probes.py
@@ -6,7 +6,7 @@ from ast import literal_eval
 import numpy as nm
 import numpy.linalg as nla
 
-from sfepy.base.base import assert_, basestr, Struct
+from sfepy.base.base import assert_, Struct
 from sfepy.linalg import make_axis_rotation_matrix, norm_l2_along_axis
 import six
 
@@ -24,7 +24,7 @@ def write_results(filename, probe, results):
         The dictionary of probing results. Keys are data names, values are
         the probed values.
     """
-    fd = open(filename, 'w') if isinstance(filename, basestr) else filename
+    fd = open(filename, 'w') if isinstance(filename, str) else filename
 
     fd.write('\n'.join(probe.report()) + '\n')
     for key, result in six.iteritems(results):
@@ -36,7 +36,7 @@ def write_results(filename, probe, results):
 
         nm.savetxt(fd, aux)
 
-    if isinstance(filename, basestr):
+    if isinstance(filename, str):
         fd.close()
 
 def read_results(filename, only_names=None):
@@ -60,7 +60,7 @@ def read_results(filename, only_names=None):
 
     is_only_names = only_names is not None
 
-    fd = open(filename, 'r') if isinstance(filename, basestr) else filename
+    fd = open(filename, 'r') if isinstance(filename, str) else filename
 
     header = read_header(fd)
     results = {}

--- a/sfepy/homogenization/coefficients.py
+++ b/sfepy/homogenization/coefficients.py
@@ -1,6 +1,6 @@
 import numpy as nm
 
-from sfepy.base.base import ordered_iteritems, Struct, basestr
+from sfepy.base.base import ordered_iteritems, Struct
 from sfepy.base.ioutils import read_dict_hdf5, write_dict_hdf5
 from sfepy.homogenization.utils import iter_sym
 
@@ -102,7 +102,7 @@ class Coefficients(Struct):
             if isinstance(val, dict):
                 self._save_dict_latex(val, fd, names)
 
-            elif isinstance(val, basestr):
+            elif isinstance(val, str):
                 fd.write(self._escape_latex(val) + '\n')
 
             elif isinstance(val, float):
@@ -188,10 +188,10 @@ class Coefficients(Struct):
                 fd.write('\n')
 
             elif isinstance(val, list):
-                if isinstance(val[0], basestr):
+                if isinstance(val[0], str):
                     fd.write('\n'.join(val) + '\n')
 
-            elif isinstance(val, basestr):
+            elif isinstance(val, str):
                 fd.write(val + '\n')
 
             elif isinstance(val, float):

--- a/sfepy/terms/terms.py
+++ b/sfepy/terms/terms.py
@@ -4,7 +4,7 @@ from copy import copy
 import numpy as nm
 
 from sfepy.base.base import (as_float_or_complex, get_default, assert_,
-                             Container, Struct, basestr, goptions)
+                             Container, Struct, goptions)
 from sfepy.base.compat import in1d
 
 # Used for imports in term files.
@@ -515,7 +515,7 @@ class Term(Struct):
 
         self.args = []
         for ia, arg_name in enumerate(self.arg_names):
-            if isinstance(arg_name, basestr):
+            if isinstance(arg_name, str):
                 name, append = arg_name, None
 
             else:
@@ -556,7 +556,7 @@ class Term(Struct):
 
         kwargs = {}
         for arg_name in self.arg_names:
-            if isinstance(arg_name, basestr):
+            if isinstance(arg_name, str):
                 if arg_name in variables.names:
                     kwargs[arg_name] = variables[arg_name]
 
@@ -877,7 +877,7 @@ class Term(Struct):
         for at in arg_types:
             ii = ats.index(at)
             arg_name = self.arg_names[ii]
-            if isinstance(arg_name, basestr):
+            if isinstance(arg_name, str):
                 if arg_name in kwargs:
                     args.append(kwargs[arg_name])
 
@@ -1170,7 +1170,7 @@ class Term(Struct):
         sym = dim2sym(dim)
 
         def _parse_scalar_shape(sh):
-            if isinstance(sh, basestr):
+            if isinstance(sh, str):
                 if sh == 'D':
                     return dim
 
@@ -1199,7 +1199,7 @@ class Term(Struct):
                 return sh
 
         def _parse_tuple_shape(sh):
-            if isinstance(sh, basestr):
+            if isinstance(sh, str):
                 return tuple((_parse_scalar_shape(ii.strip())
                               for ii in sh.split(',')))
 
@@ -1271,13 +1271,13 @@ class Term(Struct):
                         continue
 
                     prefix = ''
-                    if isinstance(sh, basestr):
+                    if isinstance(sh, str):
                         aux = tuple(ii.strip() for ii in sh.split(':'))
                         if len(aux) == 2:
                             prefix, sh = aux
 
                     if sh == 'str':
-                        n_ok += isinstance(arg, basestr)
+                        n_ok += isinstance(arg, str)
                         continue
 
                     shape = _parse_tuple_shape(sh)

--- a/sfepy/tests/test_term_call_modes.py
+++ b/sfepy/tests/test_term_call_modes.py
@@ -18,7 +18,6 @@ not_tested_terms = ['dw_ns_dot_grad_s',
 
 def make_term_args(arg_shapes, arg_kinds, arg_types, ats_mode, domain,
                    material_value=None, poly_space_basis=None):
-    from sfepy.base.base import basestr
     from sfepy.discrete import FieldVariable, Material, Variables, Materials
     from sfepy.discrete.fem import Field
     from sfepy.solvers.ts import TimeStepper
@@ -29,7 +28,7 @@ def make_term_args(arg_shapes, arg_kinds, arg_types, ats_mode, domain,
     sym = dim2sym(dim)
 
     def _parse_scalar_shape(sh):
-        if isinstance(sh, basestr):
+        if isinstance(sh, str):
             if sh == 'D':
                 return dim
 
@@ -58,7 +57,7 @@ def make_term_args(arg_shapes, arg_kinds, arg_types, ats_mode, domain,
             return sh
 
     def _parse_tuple_shape(sh):
-        if isinstance(sh, basestr):
+        if isinstance(sh, str):
             return [_parse_scalar_shape(ii.strip()) for ii in sh.split(',')]
 
         else:
@@ -121,7 +120,7 @@ def make_term_args(arg_shapes, arg_kinds, arg_types, ats_mode, domain,
                 continue
 
             prefix = ''
-            if isinstance(sh, basestr):
+            if isinstance(sh, str):
                 aux = sh.split(':')
                 if len(aux) == 2:
                     prefix, sh = aux


### PR DESCRIPTION
Hi,

Should these two declaration go too ? or maybe some third party rely on these ?

```
sfepy/base/base.py-# is this part of some public API ?
sfepy/base/base.py-PY3 = True
sfepy/base/base.py:basestr = str
```

We are in 2025, I guess no ...