### PR TITLE
remove usage of "six" shim

### DIFF
--- a/sfepy/base/base.py
+++ b/sfepy/base/base.py
@@ -6,7 +6,6 @@ from .getch import getch
 
 import numpy as nm
 import scipy.sparse as sp
-import six
 
 real_types = [nm.float64]
 complex_types = [nm.complex128]
@@ -387,7 +386,7 @@ class Struct(object):
         attribute and its counterpart in other are both Structs - these are
         merged then."""
         new = copy(self)
-        for key, val in six.iteritems(other.__dict__):
+        for key, val in other.__dict__.items():
             if hasattr(new, key):
                 sval = getattr(self, key)
                 if issubclass(sval.__class__, Struct) and \
@@ -405,7 +404,7 @@ class Struct(object):
         """Merge Structs in place. Attributes of self are left unchanged
         unless an attribute and its counterpart in other are both Structs -
         these are merged then."""
-        for key, val in six.iteritems(other.__dict__):
+        for key, val in other.__dict__.items():
             if hasattr(self, key):
                 sval = getattr(self, key)
                 if issubclass(sval.__class__, Struct) and \
@@ -424,7 +423,7 @@ class Struct(object):
     # 08.03.2005, c
     def str_all(self):
         ss = "%s\n" % self.__class__
-        for key, val in six.iteritems(self.__dict__):
+        for key, val in self.__dict__.items():
             if issubclass(self.__dict__[key].__class__, Struct):
                 ss += "  %s:\n" % key
                 aux = "\n" + self.__dict__[key].str_all()
@@ -947,7 +946,7 @@ def print_structs(objs):
     """Print Struct instances in a container, works recursively. Debugging
     utility function."""
     if isinstance(objs, dict):
-        for key, vals in six.iteritems(objs):
+        for key, vals in objs.items():
             print(key)
             print_structs(vals)
     elif isinstance(objs, list):
@@ -957,7 +956,7 @@ def print_structs(objs):
         print(objs)
 
 def iter_dict_of_lists(dol, return_keys=False):
-    for key, vals in six.iteritems(dol):
+    for key, vals in dol.items():
         for ii, val in enumerate(vals):
             if return_keys:
                 yield key, ii, val
@@ -994,7 +993,7 @@ def dict_to_struct(*args, **kwargs):
             else:
                 aux = {}
 
-            for key, val in six.iteritems(arg):
+            for key, val in arg.items():
                 if type(val) == dict:
                     try:
                         flag[level + 1]
@@ -1232,7 +1231,7 @@ def edit_dict_strings(str_dict, old, new, recur=False):
     """
     if isinstance(old, str):
         new_dict = {}
-        for key, val in six.iteritems(str_dict):
+        for key, val in str_dict.items():
             if isinstance(val, str):
                 new_dict[key] = val.replace(old, new)
 
@@ -1274,7 +1273,7 @@ def invert_dict(d, is_val_tuple=False, unique=True):
     """
     di = {}
 
-    for key, val in six.iteritems(d):
+    for key, val in d.items():
         if unique:
             if is_val_tuple:
                 for v in val:
@@ -1299,7 +1298,7 @@ def remap_dict(d, map):
     Utility function to remap state dict keys according to var_map.
     """
     out = {}
-    for new_key, key in six.iteritems(map):
+    for new_key, key in map.items():
         out[new_key] = d[key]
 
     return out
@@ -1320,7 +1319,7 @@ def dict_from_keys_init(keys, seq_class=None):
 ##
 # 16.10.2006, c
 def dict_extend(d1, d2):
-    for key, val in six.iteritems(d1):
+    for key, val in d1.items():
         val.extend(d2[key])
 
 def get_subdict(adict, keys):
@@ -1330,7 +1329,7 @@ def get_subdict(adict, keys):
     return dict((key, adict[key]) for key in keys if key in adict)
 
 def set_defaults(dict_, defaults):
-    for key, val in six.iteritems(defaults):
+    for key, val in defaults.items():
         dict_.setdefault(key, val)
 
 ##
@@ -1394,7 +1393,7 @@ def check_names(names1, names2, msg):
 # c: 27.02.2008, r: 27.02.2008
 def select_by_names(objs_all, names, replace=None, simple=True):
     objs = {}
-    for key, val in six.iteritems(objs_all):
+    for key, val in objs_all.items():
         if val.name in names:
             if replace is None:
                 objs[key] = val
@@ -1432,7 +1431,7 @@ def dict_to_array(adict):
     aux = nm.asarray(adict[ik[0]])
     out = nm.empty((ik.max() + 1,) + aux.shape, dtype=aux.dtype)
     out.fill(-1)
-    for key, val in six.iteritems(adict):
+    for key, val in adict.items():
         out[key] = val
 
     return out

--- a/sfepy/base/conf.py
+++ b/sfepy/base/conf.py
@@ -14,7 +14,6 @@ from sfepy.base.base import (Struct, IndexedStruct, dict_to_struct,
                              output, copy, update_dict_recursively,
                              import_file, assert_, get_default)
 from sfepy.base.parse_conf import create_bnf
-import six
 
 _required = ['filename_mesh|filename_domain', 'field_[0-9]+|fields',
             # TODO originaly EBC were required to be specified but in some examples
@@ -47,7 +46,7 @@ def tuple_to_conf(name, vals, order):
 
 def transform_variables(adict):
     d2 = {}
-    for ii, (key, conf) in enumerate(six.iteritems(adict)):
+    for ii, (key, conf) in enumerate(adict.items()):
         if isinstance(conf, tuple):
             c2 = tuple_to_conf(key, conf, ['kind', 'field'])
             if len(conf) >= 3:
@@ -72,7 +71,7 @@ def transform_variables(adict):
 
 def transform_conditions(adict, prefix):
     d2 = {}
-    for ii, (key, conf) in enumerate(six.iteritems(adict)):
+    for ii, (key, conf) in enumerate(adict.items()):
         if isinstance(conf, tuple):
             if len(conf) == 2:
                 c2 = tuple_to_conf(key, conf, ['region', 'dofs'])
@@ -99,7 +98,7 @@ def transform_ics(adict):
 
 def transform_lcbcs(adict):
     d2 = {}
-    for ii, (key, conf) in enumerate(six.iteritems(adict)):
+    for ii, (key, conf) in enumerate(adict.items()):
         if isinstance(conf, tuple):
             if len(conf) >= 4:
                 if isinstance(conf[1], dict):
@@ -129,7 +128,7 @@ def transform_lcbcs(adict):
 
 def transform_epbcs(adict, prefix="epbc"):
     d2 = {}
-    for ii, (key, conf) in enumerate(six.iteritems(adict)):
+    for ii, (key, conf) in enumerate(adict.items()):
         if isinstance(conf, tuple):
             if len(conf) == 3:
                 c2 = tuple_to_conf(key, conf, ['region', 'dofs', 'match'])
@@ -149,7 +148,7 @@ def transform_dgepbcs(adict):
 
 def transform_regions(adict):
     d2 = {}
-    for ii, (key, conf) in enumerate(six.iteritems(adict)):
+    for ii, (key, conf) in enumerate(adict.items()):
         if isinstance(conf, str):
             c2 = Struct(name=key, select=conf)
             d2['region_%s__%d' % (c2.name, ii)] = c2
@@ -168,7 +167,7 @@ def transform_regions(adict):
 
 def transform_integrals(adict):
     d2 = {}
-    for ii, (key, conf) in enumerate(six.iteritems(adict)):
+    for ii, (key, conf) in enumerate(adict.items()):
         if isinstance(conf, int):
             c2 = Struct(name=key, order=conf)
             d2['integral_%s__%d' % (c2.name, ii)] = c2
@@ -192,7 +191,7 @@ def transform_integrals(adict):
 def transform_fields(adict):
     dtypes = {'real' : nm.float64, 'complex' : nm.complex128}
     d2 = {}
-    for ii, (key, conf) in enumerate(six.iteritems(adict)):
+    for ii, (key, conf) in enumerate(adict.items()):
         if isinstance(conf, tuple):
             c2 = tuple_to_conf(key, conf,
                                ['dtype', 'shape', 'region', 'approx_order',
@@ -210,7 +209,7 @@ def transform_fields(adict):
 
 def transform_materials(adict):
     d2 = {}
-    for ii, (key, conf) in enumerate(six.iteritems(adict)):
+    for ii, (key, conf) in enumerate(adict.items()):
         if isinstance(conf, str):
             c2 = Struct(name=key, function=conf)
             d2['material_%s__%d' % (c2.name, ii)] = c2
@@ -230,10 +229,10 @@ def transform_materials(adict):
 
 def transform_solvers(adict):
     d2 = {}
-    for ii, (key, conf) in enumerate(six.iteritems(adict)):
+    for ii, (key, conf) in enumerate(adict.items()):
         if isinstance(conf, tuple):
             c2 = tuple_to_conf(key, conf, ['kind','params'])
-            for param, val in six.iteritems(c2.params):
+            for param, val in c2.params.items():
                 setattr(c2, param, val)
             delattr(c2, 'params')
             d2['solvers_%s__%d' % (c2.name, ii)] = c2
@@ -244,7 +243,7 @@ def transform_solvers(adict):
 
 def transform_functions(adict):
     d2 = {}
-    for ii, (key, conf) in enumerate(six.iteritems(adict)):
+    for ii, (key, conf) in enumerate(adict.items()):
         if isinstance(conf, tuple):
             c2 = tuple_to_conf(key, conf, ['function'])
             d2['function_%s__%d' % (c2.name, ii)] = c2
@@ -439,7 +438,7 @@ class ProblemConf(Struct):
 
         self.transform_input_trivial()
         self._raw = {}
-        for key, val in six.iteritems(define_dict):
+        for key, val in define_dict.items():
             if isinstance(val, dict):
                 self._raw[key] = copy(val)
 
@@ -514,7 +513,7 @@ class ProblemConf(Struct):
 
     def transform_input(self):
         keys = list(self.__dict__.keys())
-        for key, transform in six.iteritems(transforms):
+        for key, transform in transforms.items():
             if not key in keys: continue
             self.__dict__[key] = transform(self.__dict__[key])
 
@@ -530,7 +529,7 @@ class ProblemConf(Struct):
         by `key`.
         """
         val = getattr(self, key)
-        for item in six.itervalues(val):
+        for item in val.values():
             if item.name == item_name:
                 return item
 

--- a/sfepy/base/goptions.py
+++ b/sfepy/base/goptions.py
@@ -6,7 +6,6 @@ Notes
 Inspired by rcParams of matplotlib.
 """
 
-import six
 def validate_bool(val):
     """
     Convert b to a boolean or raise a ValueError.
@@ -33,7 +32,7 @@ class ValidatedDict(dict):
     A dictionary object including validation.
     """
     validate = dict([(key, validator) for key, (default, validator) in \
-                     six.iteritems(default_goptions)])
+                     default_goptions.items()])
 
     def __setitem__(self, key, val):
         try:
@@ -59,4 +58,4 @@ class ValidatedDict(dict):
         return [self[key] for key in self.keys()]
 
 goptions = ValidatedDict([(key, val[0])
-                          for key, val in six.iteritems(default_goptions)])
+                          for key, val in default_goptions.items()])

--- a/sfepy/base/ioutils.py
+++ b/sfepy/base/ioutils.py
@@ -6,7 +6,6 @@ import fnmatch
 import shutil
 import glob
 from .base import output, ordered_iteritems, Struct
-import six
 import pickle
 import warnings
 import scipy.sparse as sp
@@ -307,7 +306,7 @@ def write_dict_hdf5(filename, adict, level=0, group=None, fd=None):
         fd = pt.open_file(filename, mode='w', title='Recursive dict dump')
         group = '/'
 
-    for key, val in six.iteritems(adict):
+    for key, val in adict.items():
         if isinstance(val, dict):
             group2 = fd.create_group(group, '_' + str(key), '%s group' % key)
             write_dict_hdf5(filename, val, level + 1, group2, fd)
@@ -329,11 +328,11 @@ def read_dict_hdf5(filename, level=0, group=None, fd=None):
         fd = pt.open_file(filename, mode='r')
         group = fd.root
 
-    for name, gr in six.iteritems(group._v_groups):
+    for name, gr in group._v_groups.items():
         name = name.replace('_', '', 1)
         out[name] = read_dict_hdf5(filename, level + 1, gr, fd)
 
-    for name, data in six.iteritems(group._v_leaves):
+    for name, data in group._v_leaves.items():
         name = name.replace('_', '', 1)
         val = data.read()
         if isinstance(val, bytes):

--- a/sfepy/base/log.py
+++ b/sfepy/base/log.py
@@ -1,7 +1,6 @@
 import time
 import os
 import atexit
-import six
 
 try:
     import multiprocessing as mp
@@ -143,7 +142,7 @@ def read_log(filename):
 
     fd.close()
 
-    for key, (xs, ys, vlines) in six.iteritems(log):
+    for key, (xs, ys, vlines) in log.items():
         log[key] = (nm.array(xs), nm.array(ys), nm.array(vlines))
 
     return log, info

--- a/sfepy/base/mem_usage.py
+++ b/sfepy/base/mem_usage.py
@@ -8,7 +8,6 @@ import numpy as nm
 import scipy.sparse as sp
 
 from sfepy.base.base import Struct, Output
-import six
 
 def get_mem_usage(obj, usage=None, name=None, traversal_order=None, level=0):
     """
@@ -75,7 +74,7 @@ def get_mem_usage(obj, usage=None, name=None, traversal_order=None, level=0):
         record.usage = len(obj)
 
     elif isinstance(obj, Struct):
-        for subname, sub in six.iteritems(obj.__dict__):
+        for subname, sub in obj.__dict__.items():
             to[0] += 1
             record.usage += get_mem_usage(sub, usage,
                                           name='attribute %s of %s'
@@ -85,7 +84,7 @@ def get_mem_usage(obj, usage=None, name=None, traversal_order=None, level=0):
 
     elif isinstance(obj, collections.Mapping):
         try:
-            for subname, sub in six.iteritems(obj):
+            for subname, sub in obj.items():
                 to[0] += 1
                 record.usage += get_mem_usage(sub, usage,
                                               name='item %s of %s'
@@ -124,7 +123,7 @@ def print_mem_usage(usage, order_by='usage', direction='up', print_key=False):
     """
     keys = list(usage.keys())
     order_vals = nm.array([record.get(order_by)
-                           for record in six.itervalues(usage)])
+                           for record in usage.values()])
 
     order = nm.argsort(order_vals)
     if direction == 'down':

--- a/sfepy/base/multiproc_mpi.py
+++ b/sfepy/base/multiproc_mpi.py
@@ -3,7 +3,6 @@ Multiprocessing functions.
 """
 import logging
 import os
-import six
 
 try:
     from mpi4py import MPI
@@ -93,7 +92,7 @@ logger = get_logger()
 
 def enum(*sequential):
     enums = dict(zip(sequential, range(len(sequential))))
-    reverse = dict((value, key) for key, value in six.iteritems(enums))
+    reverse = dict((value, key) for key, value in enums.items())
     enums['name'] = reverse
     return type('Enum', (), enums)
 

--- a/sfepy/base/reader.py
+++ b/sfepy/base/reader.py
@@ -1,6 +1,5 @@
 from .base import Struct
 import os.path as op
-import six
 
 ##
 # 16.06.2005, c
@@ -42,7 +41,7 @@ class Reader( Struct ):
         execfile( filename, {}, aux )
 
         obj = obj_class()
-        for key, val in six.iteritems(aux):
+        for key, val in aux.items():
             obj.__dict__[key] = val
 
         return obj

--- a/sfepy/base/resolve_deps.py
+++ b/sfepy/base/resolve_deps.py
@@ -3,14 +3,13 @@ Functions for resolving dependencies.
 """
 import itertools as it
 
-import six
 
 def get_nums(deps):
     """
     Get number of prerequisite names for each name in dependencies.
     """
     nums = {}
-    for key, val in six.iteritems(deps):
+    for key, val in deps.items():
         nums[key] = len(val)
 
     return nums
@@ -34,7 +33,7 @@ def remove_known(deps, known):
     """
     if isinstance(known, str):
         out = {}
-        for key, val in six.iteritems(deps):
+        for key, val in deps.items():
             if key == known: continue
             out[key] = [ii for ii in val if ii != known]
 

--- a/sfepy/discrete/common/fields.py
+++ b/sfepy/discrete/common/fields.py
@@ -3,7 +3,6 @@ import numpy as nm
 
 from sfepy.base.base import output, iter_dict_of_lists, Struct, assert_
 from sfepy.base.timing import Timer
-import six
 from sfepy.mechanics.tensors import get_cauchy_strain
 
 
@@ -54,7 +53,7 @@ def parse_shape(shape, dim):
         except KeyError:
             raise ValueError('unsupported field shape! (%s)', shape)
 
-    elif isinstance(shape, six.integer_types):
+    elif isinstance(shape, int):
         shape = (int(shape),)
 
     return shape
@@ -71,7 +70,7 @@ def setup_extra_data(conn_info):
 
 def fields_from_conf(conf, regions):
     fields = {}
-    for key, val in six.iteritems(conf):
+    for key, val in conf.items():
         field = Field.from_conf(val, regions)
         fields[field.name] = field
 
@@ -202,7 +201,7 @@ class Field(Struct):
         import sfepy.base.multiproc as multi
 
         if multi.is_remote_dict(self.mappings0):
-            for k, v in six.iteritems(self.mappings):
+            for k, v in self.mappings.items():
                 m, _ = self.mappings[k]
                 nv = (m.bf, m.bfg, m.det, m.volume, m.normal)
                 self.mappings0[k] = nv

--- a/sfepy/discrete/conditions.py
+++ b/sfepy/discrete/conditions.py
@@ -6,7 +6,6 @@ import numpy as nm
 
 from sfepy.base.base import Container, Struct, is_sequence
 from sfepy.discrete.functions import Function
-import six
 
 def get_condition_value(val, functions, kind, name):
     """
@@ -54,7 +53,7 @@ class Conditions(Container):
     @staticmethod
     def from_conf(conf, regions):
         conds = []
-        for key, cc in six.iteritems(conf):
+        for key, cc in conf.items():
             times = cc.get('times', None)
 
 
@@ -188,7 +187,7 @@ class Condition(Struct):
         Create a single condition instance for each item in self.dofs
         and yield it.
         """
-        for dofs, val in six.iteritems(self.dofs):
+        for dofs, val in self.dofs.items():
             single_cond = self.copy(name=self.name)
             single_cond.is_single = True
             if 'grad' in dofs:
@@ -241,7 +240,7 @@ class EssentialBC(Condition):
 
         else:
             new_dofs = {}
-            for key in six.iterkeys(self.dofs):
+            for key in self.dofs.keys():
                 new_dofs[key] = 0.0
 
             self.dofs = new_dofs

--- a/sfepy/discrete/dg/fields.py
+++ b/sfepy/discrete/dg/fields.py
@@ -3,7 +3,6 @@
 Fields for Discontinous Galerkin method
 """
 import numpy as nm
-import six
 from numpy.lib.stride_tricks import as_strided
 
 from sfepy.base.base import (output, assert_, Struct)
@@ -121,7 +120,7 @@ def get_gel(region):
         base geometry element of the region
     """
     cmesh = region.cmesh
-    for key, gel in six.iteritems(region.domain.geom_els):
+    for key, gel in region.domain.geom_els.items():
         ct = cmesh.cell_types
         if (ct[region.cells] == cmesh.key_to_index[gel.name]).all():
             return gel

--- a/sfepy/discrete/evaluate.py
+++ b/sfepy/discrete/evaluate.py
@@ -5,7 +5,6 @@ import numpy as nm
 from sfepy.base.base import output, get_default, OneTypeList, Struct
 from sfepy.discrete import Equations, Variables, Region, Integral, Integrals
 from sfepy.discrete.common.fields import setup_extra_data
-import six
 
 def apply_ebc_to_matrix(mtx, ebc_rows, epbc_rows=None):
     """
@@ -386,7 +385,7 @@ def eval_in_els_and_qp(expression, iels, coors,
     region.update_shape()
     domain.regions.append(region)
 
-    for field in six.itervalues(fields):
+    for field in fields.values():
         field.clear_mappings(clear_all=True)
         field.clear_qp_basis()
 
@@ -428,7 +427,7 @@ def assemble_by_blocks(conf_equations, problem, ebcs=None, epbcs=None,
         raise TypeError('bad BC!')
 
     matrices = {}
-    for key, mtx_term in six.iteritems(conf_equations):
+    for key, mtx_term in conf_equations.items():
         ks = key.split( ',' )
         mtx_name, var_names = ks[0], ks[1:]
         output( mtx_name, var_names )

--- a/sfepy/discrete/fem/history.py
+++ b/sfepy/discrete/fem/history.py
@@ -3,7 +3,6 @@ import numpy as nm
 from sfepy.base.base import get_default, OneTypeList, Container, Struct
 from sfepy.solvers.ts import TimeStepper
 from sfepy.discrete.fem.meshio import HDF5MeshIO
-import six
 
 ##
 # 14.06.2007, c
@@ -18,13 +17,13 @@ class Histories( Container ):
         ths = io.read_variables_time_history( var_names, ts )
 
         objs = OneTypeList( History )
-        for name, th in six.iteritems(ths):
+        for name, th in ths.items():
             hist = History( name,
                             steps = steps,
                             times = ts.times,
                             th = th )
             objs.append( hist )
-            
+
         obj = Histories( objs, dt = ts.dt,
                          name = ' '.join( var_names ) )
         return obj

--- a/sfepy/discrete/fem/meshio.py
+++ b/sfepy/discrete/fem/meshio.py
@@ -15,7 +15,6 @@ from sfepy.base.ioutils import (skip_read_line, look_ahead_line, read_token,
                                 HDF5ContextManager, get_or_create_hdf5_group)
 
 import os.path as op
-import six
 import meshio as meshiolib
 try:
     from meshio import CellBlock as meshio_Cells  # for meshio >= 4.0.3
@@ -136,7 +135,7 @@ def convert_complex_output(out_in):
     real and imaginary parts.
     """
     out = {}
-    for key, val in six.iteritems(out_in):
+    for key, val in out_in.items():
 
         if val.data.dtype in complex_types:
             rval = copy(val)
@@ -787,7 +786,7 @@ class ComsolMeshIO(MeshIO):
         fd.close()
 
         if out is not None:
-            for key, val in six.iteritems(out):
+            for key, val in out.items():
                 raise NotImplementedError
 
 
@@ -908,7 +907,7 @@ class HDF5MeshIO(MeshIO):
             node_sets_groups = fd.create_group(group, 'node_sets',
                                                'node sets groups')
             ii = 0
-            for key, nods in six.iteritems(mesh.nodal_bcs):
+            for key, nods in mesh.nodal_bcs.items():
                 group = fd.create_group(node_sets_groups, 'group%d' % ii,
                                         'node sets group')
                 fd.create_array(group, 'key', enc(key), 'key')
@@ -1153,7 +1152,7 @@ class HDF5MeshIO(MeshIO):
             fd.create_array(ts_group, 'nt', nt, 'normalized time')
 
             name_dict = {}
-            for key, val in six.iteritems(out):
+            for key, val in out.items():
                 if xdmf and mesh.coors.shape[1] == 2:
                     data = expand_data_3d(val.data)
                 else:
@@ -1334,7 +1333,7 @@ class HDF5MeshIO(MeshIO):
             return None
 
         groups = step_group._v_groups
-        for name, data_group in six.iteritems(groups):
+        for name, data_group in groups.items():
             try:
                 key = dec(data_group.dname.read())
 
@@ -1363,7 +1362,7 @@ class HDF5MeshIO(MeshIO):
 
         fd.close()
 
-        for key, val in six.iteritems(th):
+        for key, val in th.items():
             aux = nm.array(val)
             if aux.ndim == 4: # cell data.
                 aux = aux[:,0,:,0]
@@ -1947,7 +1946,7 @@ class ANSYSCDBMeshIO(MeshIO):
                                 hexas, mat_ids_hexas, remap=remap)
 
         mesh.nodal_bcs = {}
-        for key, nods in six.iteritems(nodal_bcs):
+        for key, nods in nodal_bcs.items():
             nods = nods[nods < len(remap)]
             mesh.nodal_bcs[key] = remap[nods]
 

--- a/sfepy/discrete/functions.py
+++ b/sfepy/discrete/functions.py
@@ -1,14 +1,13 @@
 import numpy as nm
 
 from sfepy.base.base import assert_, OneTypeList, Container, Struct
-import six
 
 class Functions(Container):
     """Container to hold all user-defined functions."""
 
     def from_conf(conf):
         objs = OneTypeList(Function)
-        for key, fc in six.iteritems(conf):
+        for key, fc in conf.items():
             fun = Function(name = fc.name,
                            function = fc.function,
                            is_constant = False,
@@ -105,13 +104,13 @@ class ConstantFunction(Function):
         def get_constants(ts=None, coors=None, mode=None, **kwargs):
             out = {}
             if mode == 'special':
-                for key, val in six.iteritems(values):
+                for key, val in values.items():
                     if '.' in key:
                         vkey = key.split('.')[1]
                         out[vkey] = val
 
             elif (mode == 'qp'):
-                for key, val in six.iteritems(values):
+                for key, val in values.items():
                     if '.' in key: continue
 
                     dtype = nm.float64 if nm.isrealobj(val) else nm.complex128
@@ -120,7 +119,7 @@ class ConstantFunction(Function):
                     out[key] = nm.tile(val, (nc, 1, 1))
 
             elif (mode == 'special_constant') or (mode is None):
-                for key, val in six.iteritems(values):
+                for key, val in values.items():
                     if '.' in key: continue
 
                     out[key] = val
@@ -153,14 +152,14 @@ class ConstantFunctionByRegion(Function):
                 qps = term.get_physical_qps()
                 assert_(qps.num == coors.shape[0])
 
-                for key, val in six.iteritems(values):
+                for key, val in values.items():
                     if '.' in key: continue
                     rval = nm.array(val[list(val.keys())[0]], ndmin=3)
                     s0 = rval.shape[1:]
                     dtype = nm.float64 if nm.isrealobj(rval) else nm.complex128
                     matdata = nm.zeros(qps.shape[:2] + s0, dtype=dtype)
 
-                    for rkey, rval in six.iteritems(val):
+                    for rkey, rval in val.items():
                         region = problem.domain.regions[rkey]
                         rval = nm.array(rval, dtype=dtype, ndmin=3)
 

--- a/sfepy/discrete/iga/domain.py
+++ b/sfepy/discrete/iga/domain.py
@@ -10,7 +10,6 @@ from sfepy.discrete.common.domain import Domain
 from sfepy.discrete.iga import iga
 from sfepy.discrete.iga import io
 from sfepy.discrete.iga.extmods.igac import eval_in_tp_coors
-import six
 
 class NurbsPatch(Struct):
     """
@@ -232,7 +231,7 @@ class IGDomain(Domain):
 
         if regions is not None:
             self.vertex_set_bcs = {}
-            for key, val in six.iteritems(self.regions):
+            for key, val in self.regions.items():
                 self.vertex_set_bcs[key] = remap[val]
 
         self.reset_regions()

--- a/sfepy/discrete/iga/io.py
+++ b/sfepy/discrete/iga/io.py
@@ -2,7 +2,6 @@
 IO for NURBS and Bezier extraction data.
 """
 import numpy as nm
-import six
 from sfepy.base.ioutils import HDF5ContextManager, enc, dec
 
 def write_iga_data(filename, group, knots, degrees, control_points, weights,
@@ -58,7 +57,7 @@ def write_iga_data(filename, group, knots, degrees, control_points, weights,
                         'bezier_connectivity')
 
         regs = fd.create_group(group, 'regions', 'regions')
-        for key, val in six.iteritems(regions):
+        for key, val in regions.items():
             fd.create_array(regs, key, val, key)
 
         if name is not None:

--- a/sfepy/discrete/iga/utils.py
+++ b/sfepy/discrete/iga/utils.py
@@ -6,7 +6,6 @@ import numpy as nm
 from sfepy.base.base import Struct
 from sfepy.discrete.fem import Mesh
 from sfepy.mesh.mesh_generators import get_tensor_product_conn
-import six
 
 def create_linear_fe_mesh(nurbs, pars=None):
     """
@@ -82,7 +81,7 @@ def create_mesh_and_output(nurbs, pars=None, **kwargs):
     mesh = Mesh.from_data('nurbs', coors, None, [conn], [mat_id], [desc])
 
     out = {}
-    for key, variable in six.iteritems(kwargs):
+    for key, variable in kwargs.items():
         if variable.ndim == 2:
             nc = variable.shape[1]
             field = variable.reshape(nurbs.weights.shape + (nc,))

--- a/sfepy/discrete/integrals.py
+++ b/sfepy/discrete/integrals.py
@@ -6,7 +6,6 @@ import numpy as nm
 
 from sfepy.base.base import OneTypeList, Container, Struct
 from .quadratures import QuadraturePoints
-import six
 
 class Integrals(Container):
     """
@@ -17,7 +16,7 @@ class Integrals(Container):
     def from_conf(conf):
         objs = OneTypeList(Integral)
 
-        for desc in six.itervalues(conf):
+        for desc in conf.values():
             if hasattr(desc, 'vals'):
                 aux = Integral(desc.name,
                                coors=desc.vals,

--- a/sfepy/discrete/materials.py
+++ b/sfepy/discrete/materials.py
@@ -3,7 +3,6 @@ from sfepy.base.base import (Struct, Container, OneTypeList, assert_,
                              output, get_default)
 from sfepy.base.timing import Timer
 from .functions import ConstantFunction, ConstantFunctionByRegion
-import six
 import numpy as nm
 
 class Materials(Container):
@@ -17,7 +16,7 @@ class Materials(Container):
             wanted = list(conf.keys())
 
         objs = OneTypeList(Material)
-        for key, mc in six.iteritems(conf):
+        for key, mc in conf.items():
             if key not in wanted: continue
 
             mat = Material.from_conf(mc, functions)
@@ -212,7 +211,7 @@ class Material(Struct):
         # point values only.
         new_data = {}
         if data is not None:
-            for dkey, val in six.iteritems(data):
+            for dkey, val in data.items():
                 if val.ndim != 3:
                     raise ValueError('material parameter array must have'
                                      " three dimensions! ('%s' has %d)"
@@ -391,7 +390,7 @@ class Material(Struct):
             return self._get_data(key, name)
         else:
             out = Struct()
-            for key, item in six.iteritems(name):
+            for key, item in name.items():
                 setattr(out, key, self._get_data(key, item))
             return out
 
@@ -429,8 +428,8 @@ class Material(Struct):
     def reduce_on_datas(self, reduce_fun, init=0.0):
         """For non-special values only!"""
         out = {}.fromkeys(list(self.datas[list(self.datas.keys())[0]].keys()), init)
-        for data in six.itervalues(self.datas):
-            for key, val in six.iteritems(data):
+        for data in self.datas.values():
+            for key, val in data.items():
                 out[key] = reduce_fun(out[key], val)
 
         return out

--- a/sfepy/discrete/probes.py
+++ b/sfepy/discrete/probes.py
@@ -8,7 +8,6 @@ import numpy.linalg as nla
 
 from sfepy.base.base import assert_, Struct
 from sfepy.linalg import make_axis_rotation_matrix, norm_l2_along_axis
-import six
 
 def write_results(filename, probe, results):
     """
@@ -27,7 +26,7 @@ def write_results(filename, probe, results):
     fd = open(filename, 'w') if isinstance(filename, str) else filename
 
     fd.write('\n'.join(probe.report()) + '\n')
-    for key, result in six.iteritems(results):
+    for key, result in results.items():
         pars, vals = result
         vals = vals.reshape(pars.shape[0], -1)
         fd.write('\n# %s %d\n' % (key, vals.shape[-1]))

--- a/sfepy/discrete/simplex_cubature.py
+++ b/sfepy/discrete/simplex_cubature.py
@@ -3,7 +3,6 @@ Generate simplex quadrature points. Code taken and adapted from pytools/hedge
 by Andreas Kloeckner.
 """
 import numpy as nm
-import six
 from functools import reduce
 
 def generate_decreasing_nonnegative_tuples_summing_to(n, length, min=0,
@@ -142,7 +141,7 @@ def get_simplex_cubature(order, dimension):
     neg_weights = []
 
     dim_factor = 2**n
-    for p, w in six.iteritems(points_to_weights):
+    for p, w in points_to_weights.items():
         real_p = reduce(add, (a/b*v for (a,b),v in zip(p, vertices)))
         if w > 0:
             pos_points.append(real_p)

--- a/sfepy/discrete/variables.py
+++ b/sfepy/discrete/variables.py
@@ -18,7 +18,6 @@ from sfepy.discrete.common.dof_info import (DofInfo, EquationMap,
 from sfepy.discrete.fem.lcbc_operators import LCBCOperators
 from sfepy.discrete.common.mappings import get_physical_qps
 from sfepy.discrete.evaluate_variable import eval_real, eval_complex
-import six
 
 is_state = 0
 is_virtual = 1
@@ -176,7 +175,7 @@ class Variables(Container):
     @staticmethod
     def from_conf(conf, fields):
         obj = Variables()
-        for key, val in six.iteritems(conf):
+        for key, val in conf.items():
             var = Variable.from_conf(key, val, fields)
 
             obj[var.name] = var
@@ -735,7 +734,7 @@ class Variables(Container):
 
         if isinstance(data, dict):
 
-            for key, val in six.iteritems(data):
+            for key, val in data.items():
                 try:
                     var = self[key]
 
@@ -933,7 +932,7 @@ class Variables(Container):
                 var_info[name] = (False, name)
 
         out = {}
-        for key, indx in six.iteritems(di.indx):
+        for key, indx in di.indx.items():
             var = self[key]
 
             if key not in list(var_info.keys()): continue
@@ -1231,13 +1230,13 @@ class Variable(Struct):
                 self.data[ii][self.indx] = self.data[ii - 1][self.indx]
 
             # Advance evaluate cache.
-            for step_cache in six.itervalues(self.evaluate_cache):
+            for step_cache in self.evaluate_cache.values():
                 steps = sorted(step_cache.keys())
                 for step in steps:
                     if step is None:
                         # Special caches with possible custom advance()
                         # function.
-                        for key, val in six.iteritems(step_cache[step]):
+                        for key, val in step_cache[step].items():
                             if hasattr(val, '__advance__'):
                                 val.__advance__(ts, val)
 
@@ -1665,7 +1664,7 @@ class FieldVariable(Variable):
         This should be done, for example, prior to every nonlinear
         solver iteration.
         """
-        for step_cache in six.itervalues(self.evaluate_cache):
+        for step_cache in self.evaluate_cache.values():
             for key in list(step_cache.keys()):
                 if key == step: # Given time step to clear.
                     step_cache.pop(key)

--- a/sfepy/examples/homogenization/nonlinear_hyperelastic_mM.py
+++ b/sfepy/examples/homogenization/nonlinear_hyperelastic_mM.py
@@ -7,7 +7,6 @@ Run in parallel using::
   mpiexec -n 4 sfepy-run --app=bvp-mM --debug-mpi sfepy/examples/homogenization/nonlinear_hyperelastic_mM.py
 """
 import numpy as nm
-import six
 
 from sfepy import data_dir, base_dir
 from sfepy.base.base import Struct, output
@@ -70,7 +69,7 @@ def post_process(out, pb, state, extend=False):
 def get_homog_mat(ts, coors, mode, term=None, problem=None, **kwargs):
     if problem.update_materials_flag == 2 and mode == 'qp':
         out = hyperelastic_data['homog_mat']
-        return {k: nm.array(v) for k, v in six.iteritems(out)}
+        return {k: nm.array(v) for k, v in out.items()}
     elif problem.update_materials_flag == 0 or not mode == 'qp':
         return
 
@@ -104,7 +103,7 @@ def get_homog_mat(ts, coors, mode, term=None, problem=None, **kwargs):
     hyperelastic_data['time'] = ts.step
     hyperelastic_data['homog_mat_shape'] = family_data.det_f.shape[:2]
     hyperelastic_data['homog_mat'] = \
-        {k: nm.array(v) for k, v in six.iteritems(out)}
+        {k: nm.array(v) for k, v in out.items()}
 
     return out
 

--- a/sfepy/examples/homogenization/perfusion_micro.py
+++ b/sfepy/examples/homogenization/perfusion_micro.py
@@ -16,7 +16,6 @@ from sfepy.discrete.fem.periodic import match_x_plane, match_y_plane
 import sfepy.homogenization.coefs_base as cb
 import numpy as nm
 from sfepy import data_dir
-import six
 
 def get_mats(pk, ph, pe, dim):
     m1 = nm.eye(dim, dtype=nm.float64) * pk
@@ -39,7 +38,7 @@ def recovery_perf(pb, corrs, macro):
     nodes_Y = {}
 
     channels = {}
-    for k in six.iterkeys(macro):
+    for k in macro.keys():
         if 'press' in k:
             channels[k[-1]] = 1
 
@@ -69,11 +68,11 @@ def recovery_perf(pb, corrs, macro):
 
         press_mic = nm.zeros((nnod, 1))
         for key, val in \
-          six.iteritems(corrs['corrs_%s_pi%s' % (pb_def['name'], ch)]):
+          corrs['corrs_%s_pi%s' % (pb_def['name'], ch)].items():
             kk = int(key[-1])
             press_mic += val * press_mac_grad[kk, 0]
 
-        for key in six.iterkeys(corrs):
+        for key in corrs.keys():
             if ('_gamma_' + ch in key):
                 kk = int(key[-1]) - 1
                 press_mic += corrs[key]['p' + ch] * macro['g' + ch][kk]
@@ -172,7 +171,7 @@ functions = {
 }
 
 aux = []
-for ch, val in six.iteritems(pb_def['channels']):
+for ch, val in pb_def['channels'].items():
     aux.append('r.bYM' + ch)
 
 # basic regions
@@ -232,7 +231,7 @@ ebcs_eta = {}
 ebcs_gamma = {}
 
 # generate regions, ebcs, epbcs
-for ch, val in six.iteritems(pb_def['channels']):
+for ch, val in pb_def['channels'].items():
 
     all_periodicY[ch] = ['periodic_%sY%s' % (ii, ch)
                          for ii in ['x', 'y'][:pb_def['dim']-1]]
@@ -252,7 +251,7 @@ for ch, val in six.iteritems(pb_def['channels']):
         })
 
     ebcs_eta[ch] = []
-    for ch2, val2 in six.iteritems(pb_def['channels']):
+    for ch2, val2 in pb_def['channels'].items():
         aux = 'eta%s_bYM%s' % (ch, ch2)
         if ch2 == ch:
             ebcs.update({aux: ('bYM' + ch2, {'pM.0': 1.0})})
@@ -352,7 +351,7 @@ variables = {
 }
 
 # generate regions for channel inputs/outputs
-for ch, val in six.iteritems(pb_def['channels']):
+for ch, val in pb_def['channels'].items():
 
     matk1, matk2 = get_mats(val['param_kappa_ch'],  param_h,
                             eps0, pb_def['dim'])
@@ -411,7 +410,7 @@ for ipm in ['p', 'm']:
         }
     })
 
-for ch in six.iterkeys(reg_io):
+for ch in reg_io.keys():
     for ireg in reg_io[ch]:
         options['volumes'].update({
             ireg: {
@@ -514,7 +513,7 @@ def set_corr_cc(variables, ir, *args, **kwargs):
     variables['corr1_' + ch].set_data(val)
 
 
-for ch, val in six.iteritems(pb_def['channels']):
+for ch, val in pb_def['channels'].items():
     coefs.update({
         'G' + ch: {  # test+
             'requires': ['corrs_one' + ch, 'corrs_eta' + ch],

--- a/sfepy/examples/homogenization/rs_correctors.py
+++ b/sfepy/examples/homogenization/rs_correctors.py
@@ -4,7 +4,6 @@ Compute homogenized elastic coefficients for a given microstructure.
 """
 from argparse import ArgumentParser
 import sys
-import six
 sys.path.append('.')
 
 import numpy as nm
@@ -53,7 +52,7 @@ def get_pars(ts, coor, mode=None, term=None, **kwargs):
         oot = nm.outer(o, o)
         out['D'] = lam * oot + mu * nm.diag(o + 1.0)
 
-        for key, val in six.iteritems(out):
+        for key, val in out.items():
             out[key] = nm.tile(val, (coor.shape[0], 1, 1))
 
         channels_cells = term.region.domain.regions['Yc'].cells

--- a/sfepy/examples/large_deformation/compare_elastic_materials.py
+++ b/sfepy/examples/large_deformation/compare_elastic_materials.py
@@ -6,7 +6,6 @@ Requires Matplotlib.
 """
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 import sys
-import six
 sys.path.append('.')
 
 import numpy as nm
@@ -139,7 +138,7 @@ def store_top_u(displacements):
 
 def solve_branch(problem, branch_function):
     displacements = {}
-    for key, eq in six.iteritems(problem.conf.equations):
+    for key, eq in problem.conf.equations.items():
         problem.set_equations({key : eq})
 
         load = problem.get_materials()['load']
@@ -203,7 +202,7 @@ def main():
         output(load)
     else:
         legend = []
-        for key, val in six.iteritems(displacements):
+        for key, val in displacements.items():
             plt.plot(load, val)
             legend.append(key)
 

--- a/sfepy/examples/linear_elasticity/modal_analysis.py
+++ b/sfepy/examples/linear_elasticity/modal_analysis.py
@@ -41,7 +41,6 @@ Examples
   See :mod:`sfepy.solvers.eigen` for available solvers.
 """
 import sys
-import six
 sys.path.append('.')
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
@@ -145,7 +144,7 @@ def main():
     output('requested %d eigenvalues' % options.n_eigs)
     output('using eigenvalue problem solver:', eig_conf.kind)
     output.level += 1
-    for key, val in six.iteritems(kwargs):
+    for key, val in kwargs.items():
         output('%s: %r' % (key, val))
     output.level -= 1
 

--- a/sfepy/examples/multi_physics/piezo_elasticity.py
+++ b/sfepy/examples/multi_physics/piezo_elasticity.py
@@ -29,7 +29,6 @@ import numpy as nm
 from sfepy import data_dir
 from sfepy.discrete.fem import MeshIO
 from sfepy.mechanics.matcoefs import stiffness_from_lame
-import six
 
 def post_process(out, pb, state, extend=False):
     """
@@ -131,7 +130,7 @@ def get_inclusion_pars(ts, coor, mode=None, **kwargs):
             'density' : nm.array([[0.1142]]), # in 1e4 kg/m3
         }
 
-        for key, val in six.iteritems(out):
+        for key, val in out.items():
             out[key] = val[None, ...]
 
         return out

--- a/sfepy/homogenization/band_gaps_app.py
+++ b/sfepy/homogenization/band_gaps_app.py
@@ -11,7 +11,6 @@ from sfepy.homogenization.coefficients import Coefficients
 from sfepy.homogenization.coefs_base import CoefDummy
 from sfepy.applications import PDESolverApp
 from sfepy.base.plotutils import plt
-import six
 
 def try_set_defaults(obj, attr, defaults, recur=False):
     try:
@@ -22,7 +21,7 @@ def try_set_defaults(obj, attr, defaults, recur=False):
 
     else:
         if recur and isinstance(values, dict):
-            for key, val in six.iteritems(values):
+            for key, val in values.items():
                 set_defaults(val, defaults)
 
         else:
@@ -338,7 +337,7 @@ class AcousticBandGapsApp(HomogenizationApp):
         if options.analyze_dispersion or options.phase_velocity:
 
             # Insert incident wave direction to coefficients that need it.
-            for key, val in six.iteritems(coef_info):
+            for key, val in coef_info.items():
                 coef_opts = val.get('options', None)
                 if coef_opts is None: continue
 

--- a/sfepy/homogenization/coefs_phononic.py
+++ b/sfepy/homogenization/coefs_phononic.py
@@ -10,7 +10,6 @@ from sfepy.linalg import norm_l2_along_axis
 from sfepy.discrete.evaluate import eval_equations
 from sfepy.homogenization.coefs_base import MiniAppBase, CorrMiniApp
 from sfepy.homogenization.utils import coor_to_sym
-import six
 
 def compute_eigenmomenta(em_equation, var_name, problem, eig_vectors,
                          transform=None):
@@ -612,7 +611,7 @@ class SimpleEVP(CorrMiniApp):
             if (ii >= save[0]) and (ii < (n_eigs - save[1])): continue
             variables.set_state(mtx_phi[:,ii], force=True)
             aux = variables.create_output()
-            for name, val in six.iteritems(aux):
+            for name, val in aux.items():
                 out[name+'%03d' % ii] = val
 
         if self.post_process_hook is not None:
@@ -693,7 +692,7 @@ class DensityVolumeInfo(MiniAppBase):
         total_volume = 0.0
         volumes = {}
         densities = {}
-        for region_name, aux in six.iteritems(self.region_to_material):
+        for region_name, aux in self.region_to_material.items():
             vol = vf['volume_' + region_name]
 
             mat_name, item_name = aux
@@ -731,7 +730,7 @@ class DensityVolumeInfo(MiniAppBase):
         fd.write('average density:\n')
         fd.write(ff % dv_info.average_density)
 
-        for key, val in six.iteritems(dv_info.volumes):
+        for key, val in dv_info.volumes.items():
             fd.write('%s volume:\n' % key)
             fd.write(ff % val)
             fd.write('%s density:\n' % key)

--- a/sfepy/homogenization/engine.py
+++ b/sfepy/homogenization/engine.py
@@ -8,7 +8,6 @@ from .utils import rm_multi
 from sfepy.discrete.evaluate import eval_equations
 import sfepy.base.multiproc as multi
 import numpy as nm
-import six
 
 
 def insert_sub_reqs(reqs, levels, req_info):
@@ -41,7 +40,7 @@ def insert_sub_reqs(reqs, levels, req_info):
 
 
 def get_dict_idxval(dict_array, idx):
-    return {k: v[idx] for k, v in six.iteritems(dict_array)}
+    return {k: v[idx] for k, v in dict_array.items()}
 
 
 class CoefVolume(MiniAppBase):
@@ -157,7 +156,7 @@ class HomogenizationWorker(object):
                 chunk_tag = '-%d' % (chunk_id + 1)
                 local_state = \
                     {k: v[chunk_tab[chunk_id]] if v is not None else None
-                    for k, v in six.iteritems(micro_states)}
+                    for k, v in micro_states.items()}
             else:
                 chunk_tag = ''
                 local_state = micro_states
@@ -422,7 +421,7 @@ class HomogenizationWorkerMulti(HomogenizationWorker):
     @staticmethod
     def process_reqs_coefs(old, num_workers, store_idxs=[]):
         new = {}
-        for k, v in six.iteritems(old):
+        for k, v in old.items():
             if k == 'filenames':
                 new[k] = v.copy()
                 continue
@@ -577,7 +576,7 @@ class HomogenizationWorkerMultiMPI(HomogenizationWorkerMulti):
                         inverse_deps[req] = [name]
 
         if multiproc.mpi_rank == multiproc.mpi_master:  # master node
-            for k, v in six.iteritems(loc_numdeps):
+            for k, v in loc_numdeps.items():
                 numdeps[k] = v
 
             remaining.value = len(sorted_names)
@@ -675,7 +674,7 @@ class HomogenizationEngine(PDESolverApp):
         """
         vcfkeys = []
         cf_vols = {}
-        for vk, vv in six.iteritems(volumes):
+        for vk, vv in volumes.items():
             cfkey = 'Volume_%s' % vk
             vcfkeys.append('c.' + cfkey)
             if 'value' in vv:
@@ -685,7 +684,7 @@ class HomogenizationEngine(PDESolverApp):
                 cf_vols[cfkey] = {'expression': vv['expression'],
                                   'class': CoefVolume}
 
-        for cf in six.itervalues(coef_info):
+        for cf in coef_info.values():
             if 'requires' in cf:
                 cf['requires'] += vcfkeys
             else:

--- a/sfepy/homogenization/homogen_app.py
+++ b/sfepy/homogenization/homogen_app.py
@@ -10,7 +10,6 @@ from sfepy.applications import PDESolverApp
 import sfepy.discrete.fem.periodic as per
 import sfepy.linalg as la
 import sfepy.base.multiproc as multi
-import six
 
 
 class HomogenizationApp(HomogenizationEngine):
@@ -133,7 +132,7 @@ class HomogenizationApp(HomogenizationEngine):
             return state
 
         micro_update = self.app_options.micro_update
-        for key, upd_obj in six.iteritems(micro_update):
+        for key, upd_obj in micro_update.items():
             if '_prev' in key:
                 continue
 
@@ -239,7 +238,7 @@ class HomogenizationApp(HomogenizationEngine):
             coefs, dependencies = aux
             # store correctors for coors update
             self.updating_corrs = {}
-            for upd_obj in six.itervalues(opts.micro_update):
+            for upd_obj in opts.micro_update.values():
                 if upd_obj is not None and not hasattr(upd_obj, '__call__'):
                     for v in upd_obj:
                         cr = v[0]

--- a/sfepy/homogenization/recovery.py
+++ b/sfepy/homogenization/recovery.py
@@ -13,7 +13,6 @@ from sfepy.base.conf import ProblemConf
 from sfepy.homogenization.coefficients import Coefficients
 from sfepy.homogenization.micmac import get_correctors_from_file_hdf5
 import os.path as op
-import six
 import atexit
 
 shared = Struct()

--- a/sfepy/mechanics/matcoefs.py
+++ b/sfepy/mechanics/matcoefs.py
@@ -7,7 +7,6 @@ import os
 import numpy as nm
 
 from sfepy.base.base import Struct
-import six
 
 def lame_from_youngpoisson(young, poisson, plane='strain'):
     r"""
@@ -262,7 +261,7 @@ class ElasticConstants(Struct):
         relations = {}
 
         def _expand_keys(sols):
-            for key, val in six.iteritems(sols):
+            for key, val in sols.items():
                 if len(val) == 2 and (key.name == 'poisson'):
                     val = val[0]
                 else:
@@ -335,7 +334,7 @@ relations = {
 %s
 }
         """ % ',\n'.join(['    %s : %s' % (key, val)
-                         for key, val in six.iteritems(relations)]))
+                         for key, val in relations.items()]))
         fd.close()
 
         return relations
@@ -350,7 +349,7 @@ relations = {
                         mu=mu, p_wave=p_wave)
 
         values = {}
-        for key, val in six.iteritems(self.__dict__):
+        for key, val in self.__dict__.items():
             if (key in self.names) and (val is not None):
                 sym = getattr(self.ec, key)
                 values[sym] = val

--- a/sfepy/mechanics/units.py
+++ b/sfepy/mechanics/units.py
@@ -1,7 +1,6 @@
 """
 Some utilities for work with units of physical quantities.
 """
-import six
 try:
     import sympy as sm
 except ImportError:
@@ -106,7 +105,7 @@ class Unit(Struct):
         if omit is None:
             omit = num_prefixes
 
-        values = [val for key, val in six.iteritems(prefixes) if key not in omit]
+        values = [val for key, val in prefixes.items() if key not in omit]
         coefs = nm.array(values, dtype=nm.float64)
         coefs.sort()
         ii = nm.searchsorted(coefs, bias*coef, side='left')
@@ -204,7 +203,7 @@ class Quantity(Struct):
         self.def_coef = float(self.symbolic_value.subs(self.def_names))
 
         coef_dict = {}
-        for key, val in six.iteritems(self.def_units):
+        for key, val in self.def_units.items():
             coef_dict[val.name] = self.units[key].coef
         self.coef_dict = coef_dict
 

--- a/sfepy/mesh/geom_tools.py
+++ b/sfepy/mesh/geom_tools.py
@@ -1,5 +1,4 @@
 import numpy as nm
-import six
 
 class geometry(object):
     """The geometry is given by a sets of points (d0), lines (d1), surfaces
@@ -80,15 +79,15 @@ class geometry(object):
         print("  dimension:", self.dim)
         print("  points:", len(self.d0))
         if verbose:
-            for k, v in six.iteritems(self.d0):
+            for k, v in self.d0.items():
                 print("    %d - %s" % (k, v.getstr()))
         print("  lines:", len(self.d1))
         if verbose:
-            for k, v in six.iteritems(self.d1):
+            for k, v in self.d1.items():
                 print("    %d - " % k, v.points)
         print("  surfaces:", len(self.d2))
         if verbose:
-            for k, v in six.iteritems(self.d2):
+            for k, v in self.d2.items():
                 if v.is_hole:
                     aux = '(hole)'
                 else:
@@ -96,7 +95,7 @@ class geometry(object):
                 print("    %d%s - " % (k, aux), v.lines)
         print("  volumes:", len(self.d3))
         if verbose:
-            for k, v in six.iteritems(self.d3):
+            for k, v in self.d3.items():
                 print("    %d - " % k, v.surfaces)
         print("Physical entities:")
         if self.dim == 2:
@@ -166,7 +165,7 @@ class geometry(object):
                 self.addline(lid, [points[ii], points[ii + 1]])
                 lines.append(lid)
 
-            for s in six.itervalues(self.d2):
+            for s in self.d2.values():
                 try:
                     idx = s.lines.index(l.n)
                 except ValueError:

--- a/sfepy/postprocess/plot_facets.py
+++ b/sfepy/postprocess/plot_facets.py
@@ -12,7 +12,6 @@ import matplotlib.pyplot as plt
 from sfepy.linalg import (get_perpendiculars, normalize_vectors,
                           make_axis_rotation_matrix)
 from sfepy.postprocess.plot_dofs import _get_axes, plot_mesh, plot_global_dofs
-import six
 
 def plot_geometry(ax, gel):
     """
@@ -144,7 +143,7 @@ if __name__ == '__main__':
     from sfepy.discrete.fem.geometry_element import (GeometryElement,
                                                      geometry_data)
 
-    for key, gd in six.iteritems(geometry_data):
+    for key, gd in geometry_data.items():
         if key == '1_2' : continue
 
         gel = GeometryElement(key)

--- a/sfepy/postprocess/time_history.py
+++ b/sfepy/postprocess/time_history.py
@@ -5,11 +5,10 @@ from sfepy.discrete.fem.mesh import Mesh
 from sfepy.discrete.fem.meshio import MeshIO
 from sfepy.solvers.ts import TimeStepper
 from sfepy.base.ioutils import get_trunk, write_dict_hdf5
-import six
 
 def _linearize(out, fields, linearization):
     new = {}
-    for key, val in six.iteritems(out):
+    for key, val in out.items():
         field = fields[val.field_name]
         new.update(field.create_output(val.data, var_name=key,
                                        dof_names=val.dofs, key=key,
@@ -26,7 +25,7 @@ def dump_to_vtk(filename, output_filename_trunk=None, step0=0, steps=None,
             output('linearizing...')
             out = _linearize(out, fields, linearization)
             output('...done')
-            for key, val in six.iteritems(out):
+            for key, val in out.items():
                 lmesh = val.get('mesh', mesh)
                 lmesh.write(output_filename_trunk + '_' + key + suffix,
                             io='auto', out={key : val})
@@ -196,11 +195,11 @@ def average_vertex_var_in_cells(ths_in):
     """Average histories in the element nodes for each nodal variable
         originally requested in elements."""
     ths = dict.fromkeys(list(ths_in.keys()))
-    for var, th in six.iteritems(ths_in):
+    for var, th in ths_in.items():
         aux = dict.fromkeys(list(th.keys()))
-        for ir, data in six.iteritems(th):
+        for ir, data in th.items():
             if isinstance(data, dict):
-                for ic, ndata in six.iteritems(data):
+                for ic, ndata in data.items():
                     if aux[ir] is None:
                         aux[ir] = ndata
                     else:

--- a/sfepy/scripts/probe.py
+++ b/sfepy/scripts/probe.py
@@ -51,7 +51,6 @@ from sfepy.base.conf import ProblemConf, get_standard_keywords
 from sfepy.discrete import Problem
 from sfepy.discrete.fem import MeshIO
 from sfepy.discrete.probes import write_results, read_results
-import six
 
 helps = {
     'debug':
@@ -107,7 +106,7 @@ def generate_probes(filename_input, filename_results, options,
         data = all_data
     else:
         data = {}
-        for key, val in six.iteritems(all_data):
+        for key, val in all_data.items():
             if key in options.only_names:
                 data[key] = val
 
@@ -138,7 +137,7 @@ def generate_probes(filename_input, filename_results, options,
 
         probe.set_options(close_limit=options.close_limit)
 
-        for key, probe_hook in six.iteritems(probe_hooks):
+        for key, probe_hook in probe_hooks.items():
 
             out = probe_hook(data, probe, labels[ip], problem)
             if out is None: continue
@@ -155,7 +154,7 @@ def generate_probes(filename_input, filename_results, options,
 
             if fig is not None:
                 if isinstance(fig, dict):
-                    for fig_name, fig_fig in six.iteritems(fig):
+                    for fig_name, fig_fig in fig.items():
                         fig_filename = edit_filename(filename,
                                                      suffix='_' + fig_name)
                         fig_fig.savefig(fig_filename)
@@ -201,7 +200,7 @@ def postprocess(filename_input, filename_results, options):
     output(header)
 
     fig = plt.figure()
-    for name, result in six.iteritems(results):
+    for name, result in results.items():
         pars, vals = result[:, 0], result[:, 1]
 
         ii = nm.where(nm.isfinite(vals))[0]

--- a/sfepy/solvers/eigen.py
+++ b/sfepy/solvers/eigen.py
@@ -5,7 +5,6 @@ import scipy.sparse as sps
 from sfepy.base.base import get_default, try_imports, Struct
 from sfepy.base.timing import Timer
 from sfepy.solvers.solvers import Solver, EigenvalueSolver
-import six
 
 def eig(mtx_a, mtx_b=None, n_eigs=None, eigenvectors=True,
         return_time=None, solver_kind='eig.scipy', **ckwargs):
@@ -332,7 +331,7 @@ class SLEPcEigenvalueSolver(EigenvalueSolver):
         optDB = self.petsc.Options()
 
         if options is not None:
-            for key, val in six.iteritems(options):
+            for key, val in options.items():
                 optDB[key] = val
 
         es = self.slepc.EPS()

--- a/sfepy/solvers/optimize.py
+++ b/sfepy/solvers/optimize.py
@@ -9,7 +9,6 @@ from sfepy.solvers.solvers import OptimizationSolver
 
 import scipy.optimize as sopt
 import scipy.optimize.linesearch as linesearch
-import six
 
 def conv_test(conf, it, of, of0, ofg_norm=None):
     """
@@ -267,7 +266,7 @@ class FMinSteepestDescent(OptimizationSolver):
             else:
                 ofg = ofg1.copy()
 
-            for key, val in six.iteritems(time_stats):
+            for key, val in time_stats.items():
                 if len(val):
                     output('%10s: %7.2f [s]' % (key, val[-1]))
 

--- a/sfepy/solvers/oseen.py
+++ b/sfepy/solvers/oseen.py
@@ -7,7 +7,6 @@ from sfepy.base.log import Log, get_logging_conf
 from sfepy.base.timing import Timer
 from sfepy.solvers.solvers import NonlinearSolver
 from .nls import conv_test
-import six
 
 class StabilizationFunction(Struct):
     """
@@ -318,7 +317,7 @@ class Oseen(NonlinearSolver):
             dx_norm = nla.norm(vec_dx)
             output('||dx||: %.2e' % dx_norm)
 
-            for kv in six.iteritems(time_stats):
+            for kv in time_stats.items():
                 output('%10s: %7.2f [s]' % kv)
 
             vec_x_prev = vec_x.copy()

--- a/sfepy/solvers/semismooth_newton.py
+++ b/sfepy/solvers/semismooth_newton.py
@@ -7,7 +7,6 @@ from sfepy.base.base import output, get_default, debug
 from sfepy.base.timing import Timer
 from sfepy.solvers.nls import Newton, conv_test
 from sfepy.linalg import compose_sparse
-import six
 
 class SemismoothNewton(Newton):
     r"""
@@ -241,7 +240,7 @@ class SemismoothNewton(Newton):
 
             time_stats['solve'] = timer.stop()
 
-            for kv in six.iteritems(time_stats):
+            for kv in time_stats.items():
                 output('%10s: %7.2f [s]' % kv)
 
             vec_x -= vec_dx

--- a/sfepy/terms/terms_hyperelastic_base.py
+++ b/sfepy/terms/terms_hyperelastic_base.py
@@ -3,7 +3,6 @@ from sfepy.terms.terms import Term, terms
 from sfepy.base.base import Struct
 from sfepy import site_config
 
-import six
 
 _msg_missing_data = 'missing family data!'
 
@@ -37,7 +36,7 @@ class HyperElasticFamilyData(Struct):
         n_el, n_qp, dim, n_en, n_c = state_shape
         sym = dim2sym(dim); sym
 
-        shdict = dict(( (k, v) for k, v in six.iteritems(locals())\
+        shdict = dict(( (k, v) for k, v in locals().items()\
             if k in ['n_el', 'n_qp', 'dim', 'n_en', 'n_c', 'sym']))
 
         data = Struct(name=name)

--- a/tools/gen_term_table.py
+++ b/tools/gen_term_table.py
@@ -13,7 +13,6 @@ from argparse import ArgumentParser
 import pyparsing as pp
 
 import numpy as nm
-import six
 
 sys.path.append('.')
 import sfepy.discrete.fem # Hack: fix circular dependency, as terms.pyx imports
@@ -185,7 +184,7 @@ def get_examples(table):
 
         use = conf.options.get('use_equations', 'equations')
         eqs_conf = getattr(conf, use)
-        for key, eq_conf in six.iteritems(eqs_conf):
+        for key, eq_conf in eqs_conf.items():
             term_descs = parse_definition(eq_conf)
             for td in term_descs:
                 term_use[td.name].add(label)
@@ -249,7 +248,7 @@ def typeset_term_tables(fd, table):
         ('de_', 3)]
 
     new_tabs = [[],[],[],[]]
-    for term_name in six.iterkeys(table):
+    for term_name in table.keys():
         for term_tag, tab_id in scattab:
             if term_tag in term_name:
                 new_tabs[tab_id].append(term_name)

--- a/tools/show_terms_use.py
+++ b/tools/show_terms_use.py
@@ -3,7 +3,6 @@
 Show terms use in problem description files in the given directory.
 """
 import sys
-import six
 sys.path.append('.')
 import os
 from argparse import ArgumentParser
@@ -51,7 +50,7 @@ def main():
 
         use = conf.options.get('use_equations', 'equations')
         eqs_conf = getattr(conf, use)
-        for key, eq_conf in six.iteritems(eqs_conf):
+        for key, eq_conf in eqs_conf.items():
             term_descs = parse_definition(eq_conf)
             for td in term_descs:
                 terms_use[td.name].add(base)


### PR DESCRIPTION
"six" was never added to `pyproject.toml`, so there is nothing to remove.

On Debian we had to add an explicit `python3-six` dependency because none of the dependencies of `sfepy` pull in anymore (it had been patched-out of our `dateutil` module) ... that's why nobody noticed here.

https://salsa.debian.org/science-team/sfepy/-/commit/e1a5f1253b573f30883bec8e01778d14daca89e3
